### PR TITLE
treewide: fully rename project to 'circus'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,15 +241,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -409,9 +409,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -443,6 +443,132 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "circus-common"
+version = "0.3.0-dev"
+dependencies = [
+ "anyhow",
+ "argon2",
+ "chrono",
+ "clap",
+ "config",
+ "git2",
+ "hex",
+ "humantime-serde",
+ "lettre",
+ "libc",
+ "regex",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "circus-evaluator"
+version = "0.3.0-dev"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "circus-common",
+ "clap",
+ "config",
+ "futures",
+ "git2",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "circus-migrate-cli"
+version = "0.3.0-dev"
+dependencies = [
+ "anyhow",
+ "circus-common",
+ "clap",
+ "tokio",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "circus-queue-runner"
+version = "0.3.0-dev"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "circus-common",
+ "clap",
+ "config",
+ "dashmap",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "circus-server"
+version = "0.3.0-dev"
+dependencies = [
+ "anyhow",
+ "askama",
+ "async-stream",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "circus-common",
+ "clap",
+ "config",
+ "dashmap",
+ "futures",
+ "hex",
+ "hmac",
+ "ldap3",
+ "oauth2",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx",
+ "subtle",
+ "tar",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "xz2",
 ]
 
 [[package]]
@@ -521,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -647,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -745,9 +871,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -833,140 +959,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "fc-common"
-version = "0.3.0-dev"
-dependencies = [
- "anyhow",
- "argon2",
- "chrono",
- "clap",
- "config",
- "git2",
- "hex",
- "humantime-serde",
- "lettre",
- "libc",
- "regex",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "sha2",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
- "urlencoding",
- "uuid",
-]
-
-[[package]]
-name = "fc-evaluator"
-version = "0.3.0-dev"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "config",
- "fc-common",
- "futures",
- "git2",
- "hex",
- "serde",
- "serde_json",
- "sha2",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
-name = "fc-migrate-cli"
-version = "0.3.0-dev"
-dependencies = [
- "anyhow",
- "clap",
- "fc-common",
- "tokio",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "fc-queue-runner"
-version = "0.3.0-dev"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "config",
- "dashmap",
- "fc-common",
- "serde",
- "serde_json",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "urlencoding",
- "uuid",
-]
-
-[[package]]
-name = "fc-server"
-version = "0.3.0-dev"
-dependencies = [
- "anyhow",
- "askama",
- "async-stream",
- "axum",
- "axum-extra",
- "chrono",
- "clap",
- "config",
- "dashmap",
- "fc-common",
- "futures",
- "hex",
- "hmac",
- "ldap3",
- "oauth2",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "sha2",
- "sqlx",
- "subtle",
- "tar",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tower",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "xz2",
-]
-
-[[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -991,6 +990,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1185,14 +1190,23 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1201,6 +1215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1533,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1543,16 +1566,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1627,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1700,9 +1713,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",
@@ -1733,9 +1746,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -1760,7 +1773,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -1822,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1963,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2052,9 +2065,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2411,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2803,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2994,7 +3007,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -3223,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3361,9 +3374,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3478,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3491,7 +3504,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -3502,6 +3514,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3778,9 +3791,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3791,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3801,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3811,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3824,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3867,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4214,9 +4227,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4359,13 +4372,13 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.0",
 ]
 
 [[package]]
@@ -4413,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,18 @@ members = [
 resolver = "3"
 
 [workspace.package]
-authors      = [ "NotAShelf <raf@notashelf.dev" ]
 edition      = "2024"
 license      = "MPL-2.0"
-repository   = "https://gitub.com/feel-co/fc"
+repository   = "https://github.com/notashelf/circus"
 rust-version = "1.95.0"
 version      = "0.3.0-dev"
 
 [workspace.dependencies]
 # Components
-fc-common       = { path = "./crates/common" }
-fc-evaluator    = { path = "./crates/evaluator" }
-fc-queue-runner = { path = "./crates/queue-runner" }
-fc-server       = { path = "./crates/server" }
+circus-common       = { path = "./crates/common", version = "0.3.0-dev" }
+circus-evaluator    = { path = "./crates/evaluator", version = "0.3.0-dev" }
+circus-queue-runner = { path = "./crates/queue-runner", version = "0.3.0-dev" }
+circus-server       = { path = "./crates/server", version = "0.3.0-dev" }
 
 anyhow = "1.0.101"
 argon2 = "0.5.3"

--- a/circus.toml
+++ b/circus.toml
@@ -1,12 +1,12 @@
-# FC CI Configuration File
-# This file contains default configuration for all FC CI components
+# Configuration File for Circus CI system
+# This file contains default configuration for all circus components
 [database]
 connect_timeout = 30
 idle_timeout    = 600
 max_connections = 20
 max_lifetime    = 1800
 min_connections = 5
-url             = "postgresql://fc_ci:password@localhost/fc_ci"
+url             = "postgresql://circus:password@localhost/circus"
 
 [server]
 allowed_origins = [  ]
@@ -26,10 +26,10 @@ git_timeout   = 600
 nix_timeout   = 1800
 poll_interval = 60
 restrict_eval = true
-work_dir      = "/tmp/fc-evaluator"
+work_dir      = "/tmp/circus-evaluator"
 
 [queue_runner]
 build_timeout = 3600
 poll_interval = 5
-work_dir      = "/tmp/fc-queue-runner"
+work_dir      = "/tmp/circus-queue-runner"
 workers       = 4

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name                 = "fc-common"
+name                 = "circus-common"
 version.workspace    = true
 edition.workspace    = true
-authors.workspace    = true
 license.workspace    = true
 repository.workspace = true
 

--- a/crates/common/migrations/0001_schema.sql
+++ b/crates/common/migrations/0001_schema.sql
@@ -1,5 +1,5 @@
--- FC database schema.
--- Full schema definition for the FC CI system.
+-- circus database schema.
+-- Full schema definition for the circus system.
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- projects: stores repository configurations
@@ -473,7 +473,7 @@ EXECUTE FUNCTION update_updated_at_column ();
 -- Trigger functions: LISTEN/NOTIFY for event-driven daemon wakeup
 CREATE OR REPLACE FUNCTION notify_builds_changed () RETURNS trigger AS $$
 BEGIN
-    PERFORM pg_notify('fc_builds_changed', json_build_object(
+    PERFORM pg_notify('circus_builds_changed', json_build_object(
         'op', TG_OP,
         'table', TG_TABLE_NAME
     )::text);
@@ -483,7 +483,7 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION notify_jobsets_changed () RETURNS trigger AS $$
 BEGIN
-    PERFORM pg_notify('fc_jobsets_changed', json_build_object(
+    PERFORM pg_notify('circus_jobsets_changed', json_build_object(
         'op', TG_OP,
         'table', TG_TABLE_NAME
     )::text);

--- a/crates/common/migrations/0002_example.sql
+++ b/crates/common/migrations/0002_example.sql
@@ -1,5 +1,5 @@
 -- Example migration stub.
 -- Replace this with real schema changes when needed.
--- Run: cargo run --bin fc-migrate -- create <name>
+-- Run: cargo run --bin circus-migrate -- create <name>
 SELECT
   1;

--- a/crates/common/migrations/README.md
+++ b/crates/common/migrations/README.md
@@ -1,6 +1,6 @@
 # Database Migrations
 
-This directory contains SQL migrations for the FC database.
+This directory contains SQL migrations for the circus database.
 
 ## Migration Files
 
@@ -10,16 +10,16 @@ This directory contains SQL migrations for the FC database.
 
 ## Running Migrations
 
-The easiest way to run migrations is to use the vendored CLI, `fc-migrate`.
+The easiest way to run migrations is to use the vendored CLI, `circus-migrate`.
 Packagers should vendor this crate if possible.
 
 ```bash
 # Run all pending migrations
-fc-migrate up postgresql://user:password@localhost/fc_ci
+circus-migrate up postgresql://user:password@localhost/circus
 
 # Validate current schema
-fc-migrate validate postgresql://user:password@localhost/fc_ci
+circus-migrate validate postgresql://user:password@localhost/circus
 
 # Create a new migration
-fc-migrate create migration_name
+circus-migrate create migration_name
 ```

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,4 +1,4 @@
-//! Configuration management for FC CI
+//! Configuration management for circus
 
 use std::{path::PathBuf, time::Duration};
 
@@ -577,7 +577,7 @@ impl Default for TracingConfig {
 impl Default for DatabaseConfig {
   fn default() -> Self {
     Self {
-      url:             "postgresql://fc_ci:password@localhost/fc_ci"
+      url:             "postgresql://circus:password@localhost/circus"
         .to_string(),
       max_connections: 20,
       min_connections: 5,
@@ -654,7 +654,7 @@ impl Default for EvaluatorConfig {
       git_timeout:          600,
       nix_timeout:          1800,
       max_concurrent_evals: 4,
-      work_dir:             PathBuf::from("/tmp/fc-evaluator"),
+      work_dir:             PathBuf::from("/tmp/circus-evaluator"),
       restrict_eval:        true,
       allow_ifd:            false,
       strict_errors:        false,
@@ -668,7 +668,7 @@ impl Default for QueueRunnerConfig {
       workers:             4,
       poll_interval:       5,
       build_timeout:       3600,
-      work_dir:            PathBuf::from("/tmp/fc-queue-runner"),
+      work_dir:            PathBuf::from("/tmp/circus-queue-runner"),
       strict_errors:       false,
       failed_paths_cache:  true,
       failed_paths_ttl:    86400,
@@ -684,7 +684,7 @@ impl Default for GcConfig {
   fn default() -> Self {
     Self {
       gc_roots_dir:     PathBuf::from(
-        "/nix/var/nix/gcroots/per-user/fc/fc-roots",
+        "/nix/var/nix/gcroots/per-user/circus/circus-roots",
       ),
       enabled:          true,
       max_age_days:     30,
@@ -696,7 +696,7 @@ impl Default for GcConfig {
 impl Default for LogConfig {
   fn default() -> Self {
     Self {
-      log_dir:  PathBuf::from("/var/lib/fc/logs"),
+      log_dir:  PathBuf::from("/var/lib/circus/logs"),
       compress: false,
     }
   }
@@ -775,19 +775,19 @@ impl Config {
       settings.add_source(config_crate::Config::try_from(&Self::default())?);
 
     // Load from config file if it exists
-    if let Ok(config_path) = std::env::var("FC_CONFIG_FILE") {
+    if let Ok(config_path) = std::env::var("CIRCUS_CONFIG_FILE") {
       if std::path::Path::new(&config_path).exists() {
         settings =
           settings.add_source(config_crate::File::with_name(&config_path));
       }
-    } else if std::path::Path::new("fc.toml").exists() {
+    } else if std::path::Path::new("circus.toml").exists() {
       settings = settings
         .add_source(config_crate::File::with_name("fc").required(false));
     }
 
-    // Load from environment variables with FC_ prefix (highest priority)
+    // Load from environment variables with CIRCUS_ prefix (highest priority)
     settings = settings.add_source(
-      config_crate::Environment::with_prefix("FC")
+      config_crate::Environment::with_prefix("circus")
         .separator("__")
         .try_parsing(true),
     );
@@ -961,7 +961,7 @@ mod tests {
 
             [[api_keys]]
             name = "admin-key"
-            key = "fc_secret_key_123"
+            key = "circus_secret_key_123"
             role = "admin"
         "#;
     let config: DeclarativeConfig = toml::from_str(toml_str).unwrap();
@@ -1001,7 +1001,7 @@ mod tests {
       }],
       api_keys:        vec![DeclarativeApiKey {
         name: "test-key".to_string(),
-        key:  "fc_test".to_string(),
+        key:  "circus_test".to_string(),
         role: "admin".to_string(),
       }],
       users:           vec![],
@@ -1033,7 +1033,7 @@ mod tests {
     let toml_str = r#"
             [[api_keys]]
             name = "default-key"
-            key = "fc_test_123"
+            key = "circus_test_123"
         "#;
     let config: DeclarativeConfig = toml::from_str(toml_str).unwrap();
     assert_eq!(config.api_keys[0].role, "read-only");
@@ -1043,20 +1043,23 @@ mod tests {
   fn test_environment_override() {
     // Test environment variable parsing directly
     unsafe {
-      env::set_var("FC_DATABASE__URL", "postgresql://test:test@localhost/test");
-      env::set_var("FC_SERVER__PORT", "8080");
+      env::set_var(
+        "CIRCUS_DATABASE__URL",
+        "postgresql://test:test@localhost/test",
+      );
+      env::set_var("CIRCUS_SERVER__PORT", "8080");
     }
 
     // Test that environment variables are being read correctly
-    let db_url = std::env::var("FC_DATABASE__URL").unwrap();
-    let server_port = std::env::var("FC_SERVER__PORT").unwrap();
+    let db_url = std::env::var("CIRCUS_DATABASE__URL").unwrap();
+    let server_port = std::env::var("CIRCUS_SERVER__PORT").unwrap();
 
     assert_eq!(db_url, "postgresql://test:test@localhost/test");
     assert_eq!(server_port, "8080");
 
     unsafe {
-      env::remove_var("FC_DATABASE__URL");
-      env::remove_var("FC_SERVER__PORT");
+      env::remove_var("CIRCUS_DATABASE__URL");
+      env::remove_var("CIRCUS_SERVER__PORT");
     }
   }
 

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types for FC CI
+//! Error types for circus
 
 use thiserror::Error;
 

--- a/crates/common/src/migrate_cli.rs
+++ b/crates/common/src/migrate_cli.rs
@@ -5,8 +5,8 @@ use tracing::info;
 use tracing_subscriber::fmt::init;
 
 #[derive(Parser)]
-#[command(name = "fc-migrate")]
-#[command(about = "Database migration utility for FC CI")]
+#[command(name = "circus-migrate")]
+#[command(about = "Database migration utility for circus")]
 pub struct Cli {
   #[command(subcommand)]
   pub command: Commands,

--- a/crates/common/src/notifications.rs
+++ b/crates/common/src/notifications.rs
@@ -514,7 +514,7 @@ async fn set_github_status(
   match http_client()
     .post(&url)
     .header("Authorization", format!("token {token}"))
-    .header("User-Agent", "fc-ci")
+    .header("User-Agent", "circus")
     .header("Accept", "application/vnd.github+json")
     .json(&body)
     .send()
@@ -770,12 +770,12 @@ async fn send_email_notification(
   };
 
   let subject = format!(
-    "[FC] {} - {} ({})",
+    "[circus] {} - {} ({})",
     status_str, build.job_name, project.name
   );
 
   let body = format!(
-    "Build notification from FC CI\n\nProject: {}\nJob: {}\nStatus: \
+    "Build notification from circus\n\nProject: {}\nJob: {}\nStatus: \
      {}\nDerivation: {}\nOutput: {}\nBuild ID: {}\n",
     project.name,
     build.job_name,
@@ -929,7 +929,7 @@ pub async fn process_notification_task(
       let resp = http_client()
         .post(&url)
         .header("Authorization", format!("token {token}"))
-        .header("User-Agent", "fc-ci")
+        .header("User-Agent", "circus")
         .header("Accept", "application/vnd.github+json")
         .json(&body)
         .send()
@@ -1141,9 +1141,9 @@ pub async fn process_notification_task(
       };
 
       let subject =
-        format!("[FC] {status_display} - {job_name} ({project_name})");
+        format!("[circus] {status_display} - {job_name} ({project_name})");
       let body = format!(
-        "Build notification from FC CI\n\nProject: {}\nJob: {}\nStatus: \
+        "Build notification from circus\n\nProject: {}\nJob: {}\nStatus: \
          {}\nDerivation: {}\nOutput: {}\nBuild ID: {}\n",
         project_name,
         job_name,

--- a/crates/common/src/pg_notify.rs
+++ b/crates/common/src/pg_notify.rs
@@ -7,10 +7,10 @@ use sqlx::PgPool;
 use tokio::{sync::Notify, task::JoinHandle};
 
 /// Channel emitted on `builds` INSERT or status UPDATE.
-pub const CHANNEL_BUILDS_CHANGED: &str = "fc_builds_changed";
+pub const CHANNEL_BUILDS_CHANGED: &str = "circus_builds_changed";
 
 /// Channel emitted on `jobsets` INSERT, UPDATE (relevant fields), or DELETE.
-pub const CHANNEL_JOBSETS_CHANGED: &str = "fc_jobsets_changed";
+pub const CHANNEL_JOBSETS_CHANGED: &str = "circus_jobsets_changed";
 
 /// Spawns a background task that listens on the given PG channels and calls
 /// `wakeup.notify_waiters()` on each notification. Reconnects with 5s backoff
@@ -72,7 +72,7 @@ mod tests {
   #[test]
   fn channel_names_match_migration_triggers() {
     // These must match the pg_notify() calls in migration 015
-    assert_eq!(CHANNEL_BUILDS_CHANGED, "fc_builds_changed");
-    assert_eq!(CHANNEL_JOBSETS_CHANGED, "fc_jobsets_changed");
+    assert_eq!(CHANNEL_BUILDS_CHANGED, "circus_builds_changed");
+    assert_eq!(CHANNEL_JOBSETS_CHANGED, "circus_jobsets_changed");
   }
 }

--- a/crates/common/src/repo/search.rs
+++ b/crates/common/src/repo/search.rs
@@ -1,4 +1,4 @@
-//! Advanced search functionality for FC
+//! Advanced search functionality for circus
 
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use uuid::Uuid;

--- a/crates/common/src/roles.rs
+++ b/crates/common/src/roles.rs
@@ -1,4 +1,4 @@
-//! Role constants and validation for FC
+//! Role constants and validation for circus
 
 /// Global role - full system access
 pub const ROLE_ADMIN: &str = "admin";

--- a/crates/common/src/tracing_init.rs
+++ b/crates/common/src/tracing_init.rs
@@ -1,4 +1,4 @@
-//! Tracing initialization helper for all FC daemons.
+//! Tracing initialization helper for all circus daemons.
 
 use tracing_subscriber::{EnvFilter, fmt};
 

--- a/crates/common/src/validation.rs
+++ b/crates/common/src/validation.rs
@@ -1,4 +1,4 @@
-//! Input validation utilities for FC
+//! Input validation utilities for circus
 
 use std::sync::LazyLock;
 

--- a/crates/common/tests/database_tests.rs
+++ b/crates/common/tests/database_tests.rs
@@ -1,6 +1,6 @@
 //! Database integration tests
 
-use fc_common::{config::DatabaseConfig, *};
+use circus_common::{config::DatabaseConfig, *};
 use sqlx::PgPool;
 
 #[tokio::test]

--- a/crates/common/tests/mod.rs
+++ b/crates/common/tests/mod.rs
@@ -2,7 +2,7 @@
 
 mod notifications_tests;
 
-use fc_common::{
+use circus_common::{
   Database,
   config::{Config, DatabaseConfig},
 };
@@ -12,7 +12,7 @@ async fn test_database_connection_full() -> anyhow::Result<()> {
   // This test requires a running PostgreSQL instance
   // Skip if no database is available
   let config = DatabaseConfig {
-    url:             "postgresql://postgres:password@localhost/fc_ci_test"
+    url:             "postgresql://postgres:password@localhost/circus_test"
       .to_string(),
     max_connections: 5,
     min_connections: 1,

--- a/crates/common/tests/notifications_tests.rs
+++ b/crates/common/tests/notifications_tests.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use fc_common::notifications::*;
+use circus_common::notifications::*;
 
 #[test]
 fn test_rate_limit_extraction() {

--- a/crates/common/tests/repo_tests.rs
+++ b/crates/common/tests/repo_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for repository CRUD operations.
 //! Requires `TEST_DATABASE_URL` to be set to a `PostgreSQL` connection string.
 
-use fc_common::{models::*, repo};
+use circus_common::{models::*, repo};
 
 async fn get_pool() -> Option<sqlx::PgPool> {
   let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
@@ -166,7 +166,7 @@ async fn test_project_unique_constraint() {
   })
   .await;
 
-  assert!(matches!(result, Err(fc_common::CiError::Conflict(_))));
+  assert!(matches!(result, Err(circus_common::CiError::Conflict(_))));
 }
 
 #[tokio::test]
@@ -392,22 +392,22 @@ async fn test_not_found_errors() {
 
   assert!(matches!(
     repo::projects::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 
   assert!(matches!(
     repo::jobsets::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 
   assert!(matches!(
     repo::evaluations::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 
   assert!(matches!(
     repo::builds::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 }
 

--- a/crates/common/tests/search_tests.rs
+++ b/crates/common/tests/search_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for advanced search functionality
 //! Requires `TEST_DATABASE_URL` to be set to a `PostgreSQL` connection string.
 
-use fc_common::{BuildStatus, models::*, repo, repo::search::*};
+use circus_common::{BuildStatus, models::*, repo, repo::search::*};
 use uuid::Uuid;
 
 async fn get_pool() -> Option<sqlx::PgPool> {

--- a/crates/common/tests/user_management_tests.rs
+++ b/crates/common/tests/user_management_tests.rs
@@ -2,7 +2,7 @@
 //! relationships. Requires `TEST_DATABASE_URL` to be set to a `PostgreSQL`
 //! connection string.
 
-use fc_common::{models::*, repo};
+use circus_common::{models::*, repo};
 use uuid::Uuid;
 
 async fn get_pool() -> Option<sqlx::PgPool> {
@@ -126,7 +126,7 @@ async fn test_user_crud() {
 
   // Verify deleted
   let result = repo::users::get(&pool, user.id).await;
-  assert!(matches!(result, Err(fc_common::CiError::NotFound(_))));
+  assert!(matches!(result, Err(circus_common::CiError::NotFound(_))));
 }
 
 #[tokio::test]
@@ -168,7 +168,7 @@ async fn test_user_authentication() {
   .await;
   assert!(matches!(
     wrong_auth,
-    Err(fc_common::CiError::Unauthorized(_))
+    Err(circus_common::CiError::Unauthorized(_))
   ));
 
   // Authenticate with wrong username
@@ -179,7 +179,7 @@ async fn test_user_authentication() {
   .await;
   assert!(matches!(
     wrong_user,
-    Err(fc_common::CiError::Unauthorized(_))
+    Err(circus_common::CiError::Unauthorized(_))
   ));
 
   // Authenticate disabled user
@@ -193,7 +193,7 @@ async fn test_user_authentication() {
   .await;
   assert!(matches!(
     disabled_auth,
-    Err(fc_common::CiError::Unauthorized(_))
+    Err(circus_common::CiError::Unauthorized(_))
   ));
 
   // Cleanup
@@ -202,7 +202,7 @@ async fn test_user_authentication() {
 
 #[tokio::test]
 async fn test_password_hashing() {
-  use fc_common::repo::users::{hash_password, verify_password};
+  use circus_common::repo::users::{hash_password, verify_password};
 
   let password = "test_password_123";
 
@@ -256,7 +256,7 @@ async fn test_user_unique_constraints() {
     role:      None,
   })
   .await;
-  assert!(matches!(result, Err(fc_common::CiError::Conflict(_))));
+  assert!(matches!(result, Err(circus_common::CiError::Conflict(_))));
 
   // Try to create with same email
   let result = repo::users::create(&pool, &CreateUser {
@@ -267,7 +267,7 @@ async fn test_user_unique_constraints() {
     role:      None,
   })
   .await;
-  assert!(matches!(result, Err(fc_common::CiError::Conflict(_))));
+  assert!(matches!(result, Err(circus_common::CiError::Conflict(_))));
 
   // Cleanup
   let user = repo::users::get_by_username(&pool, &username)
@@ -408,7 +408,10 @@ async fn test_starred_jobs_crud() {
       job_name:   "hello-world".to_string(),
     })
     .await;
-  assert!(matches!(duplicate, Err(fc_common::CiError::Conflict(_))));
+  assert!(matches!(
+    duplicate,
+    Err(circus_common::CiError::Conflict(_))
+  ));
 
   // Delete starred job
   repo::starred_jobs::delete(&pool, starred.id)
@@ -587,7 +590,10 @@ async fn test_project_members_crud() {
       role:    "member".to_string(),
     })
     .await;
-  assert!(matches!(duplicate, Err(fc_common::CiError::Conflict(_))));
+  assert!(matches!(
+    duplicate,
+    Err(circus_common::CiError::Conflict(_))
+  ));
 
   // Delete member
   repo::project_members::delete(&pool, member.id)
@@ -596,7 +602,7 @@ async fn test_project_members_crud() {
 
   // Verify deleted
   let result = repo::project_members::get(&pool, member.id).await;
-  assert!(matches!(result, Err(fc_common::CiError::NotFound(_))));
+  assert!(matches!(result, Err(circus_common::CiError::NotFound(_))));
 
   // Cleanup
   repo::projects::delete(&pool, project.id).await.ok();
@@ -806,16 +812,16 @@ async fn test_user_not_found_errors() {
 
   assert!(matches!(
     repo::users::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 
   assert!(matches!(
     repo::starred_jobs::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 
   assert!(matches!(
     repo::project_members::get(&pool, fake_id).await,
-    Err(fc_common::CiError::NotFound(_))
+    Err(circus_common::CiError::NotFound(_))
   ));
 }

--- a/crates/evaluator/Cargo.toml
+++ b/crates/evaluator/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name                 = "fc-evaluator"
+name                 = "circus-evaluator"
 version.workspace    = true
 edition.workspace    = true
-authors.workspace    = true
 license.workspace    = true
 repository.workspace = true
 
@@ -26,7 +25,7 @@ tracing-subscriber.workspace = true
 uuid.workspace               = true
 
 # Our crates
-fc-common.workspace = true
+circus-common.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use chrono::Utc;
-use fc_common::{
+use circus_common::{
   config::EvaluatorConfig,
   error::{CiError, check_disk_space},
   models::{
@@ -28,7 +28,7 @@ use uuid::Uuid;
 pub async fn run(
   pool: PgPool,
   config: EvaluatorConfig,
-  notifications_config: fc_common::config::NotificationsConfig,
+  notifications_config: circus_common::config::NotificationsConfig,
   wakeup: Arc<Notify>,
 ) -> anyhow::Result<()> {
   let poll_interval = Duration::from_secs(config.poll_interval);
@@ -60,7 +60,7 @@ pub async fn run(
 async fn run_cycle(
   pool: &PgPool,
   config: &EvaluatorConfig,
-  notifications_config: &fc_common::config::NotificationsConfig,
+  notifications_config: &circus_common::config::NotificationsConfig,
   nix_timeout: Duration,
   git_timeout: Duration,
 ) -> anyhow::Result<()> {
@@ -112,8 +112,8 @@ async fn run_cycle(
             tracing::error!(
               "Evaluation failed due to disk space problems. Please free up \
                space on the server:\n- Run `nix-collect-garbage -d` to clean \
-               the Nix store\n- Clear /tmp/fc-evaluator directory\n- Check \
-               build logs directory if configured"
+               the Nix store\n- Clear /tmp/circus-evaluator directory\n- \
+               Check build logs directory if configured"
             );
           }
         }
@@ -126,9 +126,9 @@ async fn run_cycle(
 
 async fn evaluate_jobset(
   pool: &PgPool,
-  jobset: &fc_common::models::ActiveJobset,
+  jobset: &circus_common::models::ActiveJobset,
   config: &EvaluatorConfig,
-  notifications_config: &fc_common::config::NotificationsConfig,
+  notifications_config: &circus_common::config::NotificationsConfig,
   nix_timeout: Duration,
   git_timeout: Duration,
 ) -> anyhow::Result<()> {
@@ -355,7 +355,7 @@ async fn evaluate_jobset(
               // Skip aggregate builds (they complete later when constituents
               // finish)
               if !build.is_aggregate {
-                fc_common::notifications::dispatch_build_created(
+                circus_common::notifications::dispatch_build_created(
                   pool,
                   &build,
                   &project,
@@ -522,8 +522,8 @@ fn compute_inputs_hash(commit_hash: &str, inputs: &[JobsetInput]) -> String {
   hex::encode(hasher.finalize())
 }
 
-/// Check for declarative project config (.fc.toml or .fc/config.toml) in the
-/// repo.
+/// Check for declarative project config (.circus.toml or .circus/config.toml)
+/// in the repo.
 async fn check_declarative_config(
   pool: &PgPool,
   repo_path: &std::path::Path,
@@ -543,8 +543,8 @@ async fn check_declarative_config(
     enabled:        Option<bool>,
   }
 
-  let config_path = repo_path.join(".fc.toml");
-  let alt_config_path = repo_path.join(".fc/config.toml");
+  let config_path = repo_path.join(".circus.toml");
+  let alt_config_path = repo_path.join(".circus/config.toml");
 
   let path = if config_path.exists() {
     config_path
@@ -575,7 +575,7 @@ async fn check_declarative_config(
 
   if let Some(jobsets) = config.jobsets {
     for js in jobsets {
-      let input = fc_common::models::CreateJobset {
+      let input = circus_common::models::CreateJobset {
         project_id,
         name: js.name,
         nix_expression: js.nix_expression,

--- a/crates/evaluator/src/git.rs
+++ b/crates/evaluator/src/git.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use fc_common::error::Result;
+use circus_common::error::Result;
 use git2::Repository;
 
 /// Clone or fetch a repository. Returns (`repo_path`, `commit_hash`).
@@ -47,7 +47,7 @@ pub fn clone_or_fetch(
 
   let remote_ref = format!("refs/remotes/origin/{branch_name}");
   let reference = repo.find_reference(&remote_ref).map_err(|e| {
-    fc_common::error::CiError::NotFound(format!(
+    circus_common::error::CiError::NotFound(format!(
       "Branch '{branch_name}' not found ({remote_ref}): {e}"
     ))
   })?;

--- a/crates/evaluator/src/main.rs
+++ b/crates/evaluator/src/main.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use circus_common::{Config, Database};
 use clap::Parser;
-use fc_common::{Config, Database};
 
 #[derive(Parser)]
-#[command(name = "fc-evaluator")]
+#[command(name = "circus-evaluator")]
 #[command(about = "CI Evaluator - Git polling and Nix evaluation")]
 struct Cli {
   #[arg(short, long)]
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
   let _cli = Cli::parse();
 
   let config = Config::load()?;
-  fc_common::init_tracing(&config.tracing);
+  circus_common::init_tracing(&config.tracing);
 
   tracing::info!("Starting CI Evaluator");
   tracing::info!("Configuration loaded");
@@ -33,14 +33,14 @@ async fn main() -> anyhow::Result<()> {
   let notifications_config = config.notifications;
 
   let wakeup = Arc::new(tokio::sync::Notify::new());
-  let listener_handle = fc_common::pg_notify::spawn_listener(
+  let listener_handle = circus_common::pg_notify::spawn_listener(
     db.pool(),
-    &[fc_common::pg_notify::CHANNEL_JOBSETS_CHANGED],
+    &[circus_common::pg_notify::CHANNEL_JOBSETS_CHANGED],
     wakeup.clone(),
   );
 
   tokio::select! {
-      result = fc_evaluator::eval_loop::run(pool, eval_config, notifications_config, wakeup) => {
+      result = circus_evaluator::eval_loop::run(pool, eval_config, notifications_config, wakeup) => {
           if let Err(e) = result {
               tracing::error!("Evaluator loop failed: {e}");
           }

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::Path, time::Duration};
 
-use fc_common::{
+use circus_common::{
   CiError,
   config::EvaluatorConfig,
   error::Result,
@@ -119,7 +119,7 @@ pub async fn evaluate(
   inputs: &[JobsetInput],
 ) -> Result<EvalResult> {
   // Validate nix expression before constructing any commands
-  fc_common::validate::validate_nix_expression(nix_expression)
+  circus_common::validate::validate_nix_expression(nix_expression)
     .map_err(|e| CiError::NixEval(format!("Invalid nix expression: {e}")))?;
 
   if flake_mode {

--- a/crates/evaluator/tests/eval_tests.rs
+++ b/crates/evaluator/tests/eval_tests.rs
@@ -4,7 +4,7 @@
 #[test]
 fn test_parse_valid_job() {
   let line = r#"{"name":"hello","drvPath":"/nix/store/abc123-hello.drv","system":"x86_64-linux","outputs":{"out":"/nix/store/abc123-hello"}}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 1);
   assert_eq!(result.error_count, 0);
   assert_eq!(result.jobs[0].name, "hello");
@@ -17,7 +17,7 @@ fn test_parse_multiple_jobs() {
   let output = r#"{"name":"hello","drvPath":"/nix/store/abc-hello.drv","system":"x86_64-linux"}
 {"name":"world","drvPath":"/nix/store/def-world.drv","system":"aarch64-linux"}"#;
 
-  let result = fc_evaluator::nix::parse_eval_output(output);
+  let result = circus_evaluator::nix::parse_eval_output(output);
   assert_eq!(result.jobs.len(), 2);
   assert_eq!(result.error_count, 0);
   assert_eq!(result.jobs[0].name, "hello");
@@ -30,14 +30,14 @@ fn test_parse_error_lines() {
 {"attr":"broken","error":"attribute 'broken' missing"}
 {"name":"world","drvPath":"/nix/store/def-world.drv"}"#;
 
-  let result = fc_evaluator::nix::parse_eval_output(output);
+  let result = circus_evaluator::nix::parse_eval_output(output);
   assert_eq!(result.jobs.len(), 2);
   assert_eq!(result.error_count, 1);
 }
 
 #[test]
 fn test_parse_empty_output() {
-  let result = fc_evaluator::nix::parse_eval_output("");
+  let result = circus_evaluator::nix::parse_eval_output("");
   assert_eq!(result.jobs.len(), 0);
   assert_eq!(result.error_count, 0);
 }
@@ -45,7 +45,7 @@ fn test_parse_empty_output() {
 #[test]
 fn test_parse_blank_lines_ignored() {
   let output = "\n  \n\n";
-  let result = fc_evaluator::nix::parse_eval_output(output);
+  let result = circus_evaluator::nix::parse_eval_output(output);
   assert_eq!(result.jobs.len(), 0);
   assert_eq!(result.error_count, 0);
 }
@@ -54,7 +54,7 @@ fn test_parse_blank_lines_ignored() {
 fn test_parse_malformed_json_skipped() {
   let output = "not json at all\n{invalid \
                 json}\n{\"name\":\"ok\",\"drvPath\":\"/nix/store/x-ok.drv\"}";
-  let result = fc_evaluator::nix::parse_eval_output(output);
+  let result = circus_evaluator::nix::parse_eval_output(output);
   assert_eq!(result.jobs.len(), 1);
   assert_eq!(result.jobs[0].name, "ok");
 }
@@ -62,7 +62,7 @@ fn test_parse_malformed_json_skipped() {
 #[test]
 fn test_parse_job_with_input_drvs() {
   let line = r#"{"name":"hello","drvPath":"/nix/store/abc-hello.drv","inputDrvs":{"/nix/store/dep1.drv":["out"],"/nix/store/dep2.drv":["out"]}}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 1);
   let input_drvs = result.jobs[0].input_drvs.as_ref().unwrap();
   assert_eq!(input_drvs.len(), 2);
@@ -71,7 +71,7 @@ fn test_parse_job_with_input_drvs() {
 #[test]
 fn test_parse_job_with_constituents() {
   let line = r#"{"name":"aggregate","drvPath":"/nix/store/abc-aggregate.drv","constituents":["hello","world"]}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 1);
   let constituents = result.jobs[0].constituents.as_ref().unwrap();
   assert_eq!(constituents.len(), 2);
@@ -82,7 +82,7 @@ fn test_parse_job_with_constituents() {
 #[test]
 fn test_parse_error_without_name() {
   let line = r#"{"error":"some eval error"}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 0);
   assert_eq!(result.error_count, 1);
 }
@@ -91,7 +91,7 @@ fn test_parse_error_without_name() {
 fn test_parse_nix_eval_jobs_attr_field() {
   // nix-eval-jobs uses "attr" instead of "name" for the job identifier
   let line = r#"{"attr":"x86_64-linux.hello","drvPath":"/nix/store/abc123-hello.drv","system":"x86_64-linux"}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 1);
   assert_eq!(result.jobs[0].name, "x86_64-linux.hello");
   assert_eq!(result.jobs[0].drv_path, "/nix/store/abc123-hello.drv");
@@ -102,8 +102,8 @@ fn test_parse_nix_eval_jobs_both_attr_and_name() {
   // nix-eval-jobs with --force-recurse outputs both "attr" and "name" fields.
   // "attr" is the attribute path, "name" is the derivation name. We prefer
   // "attr" as the job identifier.
-  let line = r#"{"attr":"x86_64-linux.hello","attrPath":["x86_64-linux","hello"],"drvPath":"/nix/store/abc123-hello.drv","name":"fc-test-hello","outputs":{"out":"/nix/store/abc123-hello"},"system":"x86_64-linux"}"#;
-  let result = fc_evaluator::nix::parse_eval_output(line);
+  let line = r#"{"attr":"x86_64-linux.hello","attrPath":["x86_64-linux","hello"],"drvPath":"/nix/store/abc123-hello.drv","name":"circus-test-hello","outputs":{"out":"/nix/store/abc123-hello"},"system":"x86_64-linux"}"#;
+  let result = circus_evaluator::nix::parse_eval_output(line);
   assert_eq!(result.jobs.len(), 1);
   assert_eq!(result.jobs[0].name, "x86_64-linux.hello");
   assert_eq!(result.jobs[0].drv_path, "/nix/store/abc123-hello.drv");

--- a/crates/evaluator/tests/git_tests.rs
+++ b/crates/evaluator/tests/git_tests.rs
@@ -22,7 +22,7 @@ fn test_clone_or_fetch_clones_new_repo() {
   }
 
   let url = format!("file://{}", upstream_dir.path().display());
-  let result = fc_evaluator::git::clone_or_fetch(
+  let result = circus_evaluator::git::clone_or_fetch(
     &url,
     work_dir.path(),
     "test-project",
@@ -59,7 +59,7 @@ fn test_clone_or_fetch_fetches_existing() {
 
   // First clone
   let (_, hash1): (std::path::PathBuf, String) =
-    fc_evaluator::git::clone_or_fetch(
+    circus_evaluator::git::clone_or_fetch(
       &url,
       work_dir.path(),
       "test-project",
@@ -80,7 +80,7 @@ fn test_clone_or_fetch_fetches_existing() {
 
   // Second fetch
   let (_, hash2): (std::path::PathBuf, String) =
-    fc_evaluator::git::clone_or_fetch(
+    circus_evaluator::git::clone_or_fetch(
       &url,
       work_dir.path(),
       "test-project",
@@ -95,7 +95,7 @@ fn test_clone_or_fetch_fetches_existing() {
 #[test]
 fn test_clone_invalid_url_returns_error() {
   let work_dir = TempDir::new().unwrap();
-  let result = fc_evaluator::git::clone_or_fetch(
+  let result = circus_evaluator::git::clone_or_fetch(
     "file:///nonexistent/repo",
     work_dir.path(),
     "bad-proj",

--- a/crates/migrate-cli/Cargo.toml
+++ b/crates/migrate-cli/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name                 = "fc-migrate-cli"
+name                 = "circus-migrate-cli"
 version.workspace    = true
 edition.workspace    = true
-authors.workspace    = true
 license.workspace    = true
 repository.workspace = true
 
 [[bin]]
-name = "fc-migrate"
+name = "circus-migrate"
 path = "src/main.rs"
 
 [dependencies]
-fc-common.workspace = true
+circus-common.workspace = true
 
 anyhow.workspace             = true
 clap.workspace               = true

--- a/crates/migrate-cli/src/main.rs
+++ b/crates/migrate-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! Database migration CLI utility
 
-use fc_common::migrate_cli::run;
+use circus_common::migrate_cli::run;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/queue-runner/Cargo.toml
+++ b/crates/queue-runner/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name                 = "fc-queue-runner"
+name                 = "circus-queue-runner"
 version.workspace    = true
 edition.workspace    = true
-authors.workspace    = true
 license.workspace    = true
 repository.workspace = true
 
@@ -24,7 +23,7 @@ urlencoding.workspace        = true
 uuid.workspace               = true
 
 # Our crates
-fc-common.workspace = true
+circus-common.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/queue-runner/src/builder.rs
+++ b/crates/queue-runner/src/builder.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, time::Duration};
 
-use fc_common::{CiError, error::Result};
+use circus_common::{CiError, error::Result};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 const MAX_LOG_SIZE: usize = 100 * 1024 * 1024; // 100MB

--- a/crates/queue-runner/src/main.rs
+++ b/crates/queue-runner/src/main.rs
@@ -1,17 +1,17 @@
 use std::{sync::Arc, time::Duration};
 
-use clap::Parser;
-use fc_common::{
+use circus_common::{
   config::{Config, GcConfig, HotConfig},
   database::Database,
   gc_roots,
   repo,
 };
-use fc_queue_runner::worker::{ActiveBuilds, WorkerPool};
+use circus_queue_runner::worker::{ActiveBuilds, WorkerPool};
+use clap::Parser;
 use tokio::sync::RwLock;
 
 #[derive(Parser)]
-#[command(name = "fc-queue-runner")]
+#[command(name = "circus-queue-runner")]
 #[command(about = "CI Queue Runner - Build dispatch and execution")]
 struct Cli {
   #[arg(short, long)]
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
   let cli = Cli::parse();
 
   let config = Config::load()?;
-  fc_common::init_tracing(&config.tracing);
+  circus_common::init_tracing(&config.tracing);
 
   tracing::info!("Starting CI Queue Runner");
 
@@ -77,16 +77,16 @@ async fn main() -> anyhow::Result<()> {
   let worker_pool_for_drain = worker_pool.clone();
 
   let wakeup = Arc::new(tokio::sync::Notify::new());
-  let listener_handle = fc_common::pg_notify::spawn_listener(
+  let listener_handle = circus_common::pg_notify::spawn_listener(
     db.pool(),
-    &[fc_common::pg_notify::CHANNEL_BUILDS_CHANGED],
+    &[circus_common::pg_notify::CHANNEL_BUILDS_CHANGED],
     wakeup.clone(),
   );
 
   let active_builds = worker_pool.active_builds().clone();
 
   tokio::select! {
-      result = fc_queue_runner::runner_loop::run(db.pool().clone(), worker_pool, hot_config.clone(), wakeup, strict_errors, failed_paths_cache, unsupported_timeout) => {
+      result = circus_queue_runner::runner_loop::run(db.pool().clone(), worker_pool, hot_config.clone(), wakeup, strict_errors, failed_paths_cache, unsupported_timeout) => {
           if let Err(e) = result {
               tracing::error!("Runner loop failed: {e}");
           }
@@ -184,7 +184,8 @@ async fn failed_paths_cleanup_loop(
   loop {
     tokio::time::sleep(interval).await;
     let ttl = hot_config.read().await.failed_paths_ttl;
-    match fc_common::repo::failed_paths_cache::cleanup_expired(&pool, ttl).await
+    match circus_common::repo::failed_paths_cache::cleanup_expired(&pool, ttl)
+      .await
     {
       Ok(count) if count > 0 => {
         tracing::info!(count, "Cleaned up expired failed paths cache entries");
@@ -319,7 +320,8 @@ async fn notification_retry_loop(
         continue;
       }
 
-      match fc_common::notifications::process_notification_task(&task).await {
+      match circus_common::notifications::process_notification_task(&task).await
+      {
         Ok(()) => {
           if let Err(e) =
             repo::notification_tasks::mark_completed(&pool, task.id).await

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use fc_common::{
+use circus_common::{
   config::HotConfig,
   models::{Build, BuildStatus, JobsetState},
   repo,
@@ -16,7 +16,7 @@ use crate::worker::WorkerPool;
 async fn get_project_for_build(
   pool: &PgPool,
   build: &Build,
-) -> Option<(fc_common::models::Project, String)> {
+) -> Option<(circus_common::models::Project, String)> {
   let eval = repo::evaluations::get(pool, build.evaluation_id)
     .await
     .ok()?;
@@ -111,7 +111,7 @@ pub async fn run(
                   && let Some((project, commit_hash)) =
                     get_project_for_build(&pool, &updated_build).await
                 {
-                  fc_common::notifications::dispatch_build_finished(
+                  circus_common::notifications::dispatch_build_finished(
                     Some(&pool),
                     &updated_build,
                     &project,

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use dashmap::DashMap;
-use fc_common::{
+use circus_common::{
   alerts::AlertManager,
   config::{
     AlertConfig,
@@ -24,6 +23,7 @@ use fc_common::{
   },
   repo,
 };
+use dashmap::DashMap;
 use sqlx::PgPool;
 use tokio::sync::{RwLock, Semaphore};
 use tokio_util::sync::CancellationToken;
@@ -225,7 +225,7 @@ async fn get_path_info(output_path: &str) -> Option<(String, i64)> {
 async fn get_project_for_build(
   pool: &PgPool,
   build: &Build,
-) -> Option<(fc_common::models::Project, String)> {
+) -> Option<(circus_common::models::Project, String)> {
   let eval = repo::evaluations::get(pool, build.evaluation_id)
     .await
     .ok()?;
@@ -241,7 +241,7 @@ async fn dispatch_build_finished_notification(
 ) {
   if let Some((project, commit_hash)) = get_project_for_build(pool, build).await
   {
-    fc_common::notifications::dispatch_build_finished(
+    circus_common::notifications::dispatch_build_finished(
       Some(pool),
       build,
       &project,
@@ -299,7 +299,7 @@ async fn sign_outputs(
 async fn push_to_cache(
   output_paths: &[String],
   store_uri: &str,
-  s3_config: Option<&fc_common::config::S3CacheConfig>,
+  s3_config: Option<&circus_common::config::S3CacheConfig>,
   semaphore: Arc<Semaphore>,
   max_retries: u32,
 ) -> Vec<String> {
@@ -372,7 +372,7 @@ async fn push_to_cache(
 /// <s3://bucket?region=us-east-1&endpoint=https://minio.example.com>
 fn build_s3_store_uri(
   base_uri: &str,
-  config: Option<&fc_common::config::S3CacheConfig>,
+  config: Option<&circus_common::config::S3CacheConfig>,
 ) -> String {
   let Some(cfg) = config else {
     return base_uri.to_string();
@@ -416,7 +416,7 @@ async fn try_remote_build(
   work_dir: &std::path::Path,
   timeout: Duration,
   live_log_path: Option<&std::path::Path>,
-  strategy: &fc_common::config::BuilderSchedulingStrategy,
+  strategy: &circus_common::config::BuilderSchedulingStrategy,
   psi_threshold: Option<f64>,
   psi_check_timeout: Duration,
   psi_cache: &crate::psi::PsiCache,
@@ -570,7 +570,7 @@ async fn run_build(
   cache_upload_config: &CacheUploadConfig,
   alert_manager: &Option<AlertManager>,
   upload_semaphore: Arc<Semaphore>,
-  scheduling_strategy: fc_common::config::BuilderSchedulingStrategy,
+  scheduling_strategy: circus_common::config::BuilderSchedulingStrategy,
   psi_threshold: Option<f64>,
   psi_check_timeout: Duration,
   psi_cache: Arc<crate::psi::PsiCache>,
@@ -588,7 +588,7 @@ async fn run_build(
   if let Some((project, commit_hash)) =
     get_project_for_build(pool, &claimed_build).await
   {
-    fc_common::notifications::dispatch_build_started(
+    circus_common::notifications::dispatch_build_started(
       pool,
       &claimed_build,
       &project,
@@ -993,7 +993,7 @@ async fn run_build(
 
 #[cfg(test)]
 mod tests {
-  use fc_common::config::S3CacheConfig;
+  use circus_common::config::S3CacheConfig;
 
   use super::*;
 

--- a/crates/queue-runner/tests/runner_tests.rs
+++ b/crates/queue-runner/tests/runner_tests.rs
@@ -8,7 +8,7 @@
 fn test_parse_nix_log_start() {
   let line =
     r#"@nix {"action":"start","derivation":"/nix/store/abc-hello.drv"}"#;
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_some());
   let (action, drv) = result.unwrap();
   assert_eq!(action, "start");
@@ -19,7 +19,7 @@ fn test_parse_nix_log_start() {
 fn test_parse_nix_log_stop() {
   let line =
     r#"@nix {"action":"stop","derivation":"/nix/store/abc-hello.drv"}"#;
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_some());
   let (action, drv) = result.unwrap();
   assert_eq!(action, "stop");
@@ -29,34 +29,34 @@ fn test_parse_nix_log_stop() {
 #[test]
 fn test_parse_nix_log_unknown_action() {
   let line = r#"@nix {"action":"msg","msg":"building..."}"#;
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_none());
 }
 
 #[test]
 fn test_parse_nix_log_not_nix_prefix() {
   let line = "building '/nix/store/abc-hello.drv'...";
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_none());
 }
 
 #[test]
 fn test_parse_nix_log_invalid_json() {
   let line = "@nix {invalid json}";
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_none());
 }
 
 #[test]
 fn test_parse_nix_log_no_derivation_field() {
   let line = r#"@nix {"action":"start","type":"build"}"#;
-  let result = fc_queue_runner::builder::parse_nix_log_line(line);
+  let result = circus_queue_runner::builder::parse_nix_log_line(line);
   assert!(result.is_none());
 }
 
 #[test]
 fn test_parse_nix_log_empty_line() {
-  let result = fc_queue_runner::builder::parse_nix_log_line("");
+  let result = circus_queue_runner::builder::parse_nix_log_line("");
   assert!(result.is_none());
 }
 
@@ -77,26 +77,27 @@ async fn test_worker_pool_drain_stops_dispatch() {
     .expect("failed to connect");
 
   let hot_config = std::sync::Arc::new(tokio::sync::RwLock::new(
-    fc_common::config::HotConfig {
+    circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
-      notifications_config: fc_common::config::NotificationsConfig::default(),
+      notifications_config: circus_common::config::NotificationsConfig::default(
+      ),
       failed_paths_ttl:     0,
       scheduling_strategy:
-        fc_common::config::BuilderSchedulingStrategy::default(),
+        circus_common::config::BuilderSchedulingStrategy::default(),
       psi_threshold:        None,
       psi_check_timeout:    std::time::Duration::from_secs(5),
     },
   ));
-  let worker_pool = fc_queue_runner::worker::WorkerPool::new(
+  let worker_pool = circus_queue_runner::worker::WorkerPool::new(
     pool,
     2,
     std::env::temp_dir(),
     hot_config,
-    fc_common::config::LogConfig::default(),
-    fc_common::config::GcConfig::default(),
-    fc_common::config::SigningConfig::default(),
-    fc_common::config::CacheUploadConfig::default(),
+    circus_common::config::LogConfig::default(),
+    circus_common::config::GcConfig::default(),
+    circus_common::config::SigningConfig::default(),
+    circus_common::config::CacheUploadConfig::default(),
     None,
   );
 
@@ -117,7 +118,7 @@ async fn test_active_builds_registry_cancellation() {
   use dashmap::DashMap;
   use tokio_util::sync::CancellationToken;
 
-  let active_builds: fc_queue_runner::worker::ActiveBuilds =
+  let active_builds: circus_queue_runner::worker::ActiveBuilds =
     Arc::new(DashMap::new());
 
   let id1 = uuid::Uuid::new_v4();
@@ -196,26 +197,27 @@ async fn test_worker_pool_active_builds_cancel() {
     .expect("failed to connect");
 
   let hot_config = std::sync::Arc::new(tokio::sync::RwLock::new(
-    fc_common::config::HotConfig {
+    circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
-      notifications_config: fc_common::config::NotificationsConfig::default(),
+      notifications_config: circus_common::config::NotificationsConfig::default(
+      ),
       failed_paths_ttl:     0,
       scheduling_strategy:
-        fc_common::config::BuilderSchedulingStrategy::default(),
+        circus_common::config::BuilderSchedulingStrategy::default(),
       psi_threshold:        None,
       psi_check_timeout:    std::time::Duration::from_secs(5),
     },
   ));
-  let worker_pool = fc_queue_runner::worker::WorkerPool::new(
+  let worker_pool = circus_queue_runner::worker::WorkerPool::new(
     pool,
     2,
     std::env::temp_dir(),
     hot_config,
-    fc_common::config::LogConfig::default(),
-    fc_common::config::GcConfig::default(),
-    fc_common::config::SigningConfig::default(),
-    fc_common::config::CacheUploadConfig::default(),
+    circus_common::config::LogConfig::default(),
+    circus_common::config::GcConfig::default(),
+    circus_common::config::SigningConfig::default(),
+    circus_common::config::CacheUploadConfig::default(),
     None,
   );
 
@@ -261,9 +263,9 @@ async fn test_fair_share_scheduling() {
     .expect("migration failed");
 
   // Create two projects with different scheduling shares
-  let project_hi = fc_common::repo::projects::create(
+  let project_hi = circus_common::repo::projects::create(
     &pool,
-    fc_common::models::CreateProject {
+    circus_common::models::CreateProject {
       name:           format!("fair-hi-{}", uuid::Uuid::new_v4()),
       description:    None,
       repository_url: "https://github.com/test/repo".to_string(),
@@ -272,9 +274,9 @@ async fn test_fair_share_scheduling() {
   .await
   .expect("create project hi");
 
-  let project_lo = fc_common::repo::projects::create(
+  let project_lo = circus_common::repo::projects::create(
     &pool,
-    fc_common::models::CreateProject {
+    circus_common::models::CreateProject {
       name:           format!("fair-lo-{}", uuid::Uuid::new_v4()),
       description:    None,
       repository_url: "https://github.com/test/repo".to_string(),
@@ -284,8 +286,9 @@ async fn test_fair_share_scheduling() {
   .expect("create project lo");
 
   // High-share jobset (200 shares) and low-share jobset (100 shares)
-  let jobset_hi =
-    fc_common::repo::jobsets::create(&pool, fc_common::models::CreateJobset {
+  let jobset_hi = circus_common::repo::jobsets::create(
+    &pool,
+    circus_common::models::CreateJobset {
       project_id:        project_hi.id,
       name:              "main".to_string(),
       nix_expression:    "packages".to_string(),
@@ -296,12 +299,14 @@ async fn test_fair_share_scheduling() {
       scheduling_shares: Some(200),
       state:             None,
       keep_nr:           None,
-    })
-    .await
-    .expect("create jobset hi");
+    },
+  )
+  .await
+  .expect("create jobset hi");
 
-  let jobset_lo =
-    fc_common::repo::jobsets::create(&pool, fc_common::models::CreateJobset {
+  let jobset_lo = circus_common::repo::jobsets::create(
+    &pool,
+    circus_common::models::CreateJobset {
       project_id:        project_lo.id,
       name:              "main".to_string(),
       nix_expression:    "packages".to_string(),
@@ -312,13 +317,14 @@ async fn test_fair_share_scheduling() {
       scheduling_shares: Some(100),
       state:             None,
       keep_nr:           None,
-    })
-    .await
-    .expect("create jobset lo");
+    },
+  )
+  .await
+  .expect("create jobset lo");
 
-  let eval_hi = fc_common::repo::evaluations::create(
+  let eval_hi = circus_common::repo::evaluations::create(
     &pool,
-    fc_common::models::CreateEvaluation {
+    circus_common::models::CreateEvaluation {
       jobset_id:      jobset_hi.id,
       commit_hash:    format!("hi{}", uuid::Uuid::new_v4().simple()),
       pr_number:      None,
@@ -330,9 +336,9 @@ async fn test_fair_share_scheduling() {
   .await
   .expect("create eval hi");
 
-  let eval_lo = fc_common::repo::evaluations::create(
+  let eval_lo = circus_common::repo::evaluations::create(
     &pool,
-    fc_common::models::CreateEvaluation {
+    circus_common::models::CreateEvaluation {
       jobset_id:      jobset_lo.id,
       commit_hash:    format!("lo{}", uuid::Uuid::new_v4().simple()),
       pr_number:      None,
@@ -354,57 +360,69 @@ async fn test_fair_share_scheduling() {
   let drv_lo_2 =
     format!("/nix/store/{}-lo2.drv", uuid::Uuid::new_v4().simple());
 
-  fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
-    evaluation_id: eval_hi.id,
-    job_name:      "hi-build-1".to_string(),
-    drv_path:      drv_hi_1,
-    system:        Some("x86_64-linux".to_string()),
-    outputs:       None,
-    is_aggregate:  None,
-    constituents:  None,
-  })
+  circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
+      evaluation_id: eval_hi.id,
+      job_name:      "hi-build-1".to_string(),
+      drv_path:      drv_hi_1,
+      system:        Some("x86_64-linux".to_string()),
+      outputs:       None,
+      is_aggregate:  None,
+      constituents:  None,
+    },
+  )
   .await
   .expect("create hi build 1");
 
-  fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
-    evaluation_id: eval_hi.id,
-    job_name:      "hi-build-2".to_string(),
-    drv_path:      drv_hi_2,
-    system:        Some("x86_64-linux".to_string()),
-    outputs:       None,
-    is_aggregate:  None,
-    constituents:  None,
-  })
+  circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
+      evaluation_id: eval_hi.id,
+      job_name:      "hi-build-2".to_string(),
+      drv_path:      drv_hi_2,
+      system:        Some("x86_64-linux".to_string()),
+      outputs:       None,
+      is_aggregate:  None,
+      constituents:  None,
+    },
+  )
   .await
   .expect("create hi build 2");
 
-  fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
-    evaluation_id: eval_lo.id,
-    job_name:      "lo-build-1".to_string(),
-    drv_path:      drv_lo_1,
-    system:        Some("x86_64-linux".to_string()),
-    outputs:       None,
-    is_aggregate:  None,
-    constituents:  None,
-  })
+  circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
+      evaluation_id: eval_lo.id,
+      job_name:      "lo-build-1".to_string(),
+      drv_path:      drv_lo_1,
+      system:        Some("x86_64-linux".to_string()),
+      outputs:       None,
+      is_aggregate:  None,
+      constituents:  None,
+    },
+  )
   .await
   .expect("create lo build 1");
 
-  fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
-    evaluation_id: eval_lo.id,
-    job_name:      "lo-build-2".to_string(),
-    drv_path:      drv_lo_2,
-    system:        Some("x86_64-linux".to_string()),
-    outputs:       None,
-    is_aggregate:  None,
-    constituents:  None,
-  })
+  circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
+      evaluation_id: eval_lo.id,
+      job_name:      "lo-build-2".to_string(),
+      drv_path:      drv_lo_2,
+      system:        Some("x86_64-linux".to_string()),
+      outputs:       None,
+      is_aggregate:  None,
+      constituents:  None,
+    },
+  )
   .await
   .expect("create lo build 2");
 
   // With no running builds, hi-share jobset (200) should come first due to
   // higher share fraction (200/300 > 100/300)
-  let pending = fc_common::repo::builds::list_pending(&pool, 10, 4)
+  let pending = circus_common::repo::builds::list_pending(&pool, 10, 4)
     .await
     .expect("list pending cold start");
   assert!(
@@ -430,14 +448,14 @@ async fn test_fair_share_scheduling() {
     .collect();
 
   for &id in &hi_build_ids {
-    fc_common::repo::builds::start(&pool, id)
+    circus_common::repo::builds::start(&pool, id)
       .await
       .expect("start hi build");
   }
 
   // Re-query: lo-share jobset should now be prioritized because it is
   // underserved (0 running vs its fair share)
-  let pending2 = fc_common::repo::builds::list_pending(&pool, 10, 4)
+  let pending2 = circus_common::repo::builds::list_pending(&pool, 10, 4)
     .await
     .expect("list pending after running");
 
@@ -452,8 +470,8 @@ async fn test_fair_share_scheduling() {
   );
 
   // Clean up
-  let _ = fc_common::repo::projects::delete(&pool, project_hi.id).await;
-  let _ = fc_common::repo::projects::delete(&pool, project_lo.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project_hi.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project_lo.id).await;
 }
 
 // Database-dependent tests
@@ -477,9 +495,9 @@ async fn test_atomic_build_claiming() {
     .expect("migration failed");
 
   // Create a project -> jobset -> evaluation -> build chain
-  let project = fc_common::repo::projects::create(
+  let project = circus_common::repo::projects::create(
     &pool,
-    fc_common::models::CreateProject {
+    circus_common::models::CreateProject {
       name:           format!("runner-test-{}", uuid::Uuid::new_v4()),
       description:    None,
       repository_url: "https://github.com/test/repo".to_string(),
@@ -488,8 +506,9 @@ async fn test_atomic_build_claiming() {
   .await
   .expect("create project");
 
-  let jobset =
-    fc_common::repo::jobsets::create(&pool, fc_common::models::CreateJobset {
+  let jobset = circus_common::repo::jobsets::create(
+    &pool,
+    circus_common::models::CreateJobset {
       project_id:        project.id,
       name:              "main".to_string(),
       nix_expression:    "packages".to_string(),
@@ -500,13 +519,14 @@ async fn test_atomic_build_claiming() {
       scheduling_shares: None,
       state:             None,
       keep_nr:           None,
-    })
-    .await
-    .expect("create jobset");
+    },
+  )
+  .await
+  .expect("create jobset");
 
-  let eval = fc_common::repo::evaluations::create(
+  let eval = circus_common::repo::evaluations::create(
     &pool,
-    fc_common::models::CreateEvaluation {
+    circus_common::models::CreateEvaluation {
       jobset_id:      jobset.id,
       commit_hash:    "abcdef1234567890abcdef1234567890abcdef12".to_string(),
       pr_number:      None,
@@ -518,8 +538,9 @@ async fn test_atomic_build_claiming() {
   .await
   .expect("create eval");
 
-  let build =
-    fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
+  let build = circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
       evaluation_id: eval.id,
       job_name:      "test-build".to_string(),
       drv_path:      "/nix/store/test-runner-test.drv".to_string(),
@@ -527,26 +548,27 @@ async fn test_atomic_build_claiming() {
       outputs:       None,
       is_aggregate:  None,
       constituents:  None,
-    })
-    .await
-    .expect("create build");
+    },
+  )
+  .await
+  .expect("create build");
 
-  assert_eq!(build.status, fc_common::models::BuildStatus::Pending);
+  assert_eq!(build.status, circus_common::models::BuildStatus::Pending);
 
   // First claim should succeed
-  let claimed = fc_common::repo::builds::start(&pool, build.id)
+  let claimed = circus_common::repo::builds::start(&pool, build.id)
     .await
     .expect("start build");
   assert!(claimed.is_some());
 
   // Second claim should return None (already claimed)
-  let claimed2 = fc_common::repo::builds::start(&pool, build.id)
+  let claimed2 = circus_common::repo::builds::start(&pool, build.id)
     .await
     .expect("start build again");
   assert!(claimed2.is_none());
 
   // Clean up
-  let _ = fc_common::repo::projects::delete(&pool, project.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project.id).await;
 }
 
 #[tokio::test]
@@ -567,9 +589,9 @@ async fn test_orphan_build_reset() {
     .await
     .expect("migration failed");
 
-  let project = fc_common::repo::projects::create(
+  let project = circus_common::repo::projects::create(
     &pool,
-    fc_common::models::CreateProject {
+    circus_common::models::CreateProject {
       name:           format!("orphan-test-{}", uuid::Uuid::new_v4()),
       description:    None,
       repository_url: "https://github.com/test/repo".to_string(),
@@ -578,8 +600,9 @@ async fn test_orphan_build_reset() {
   .await
   .expect("create project");
 
-  let jobset =
-    fc_common::repo::jobsets::create(&pool, fc_common::models::CreateJobset {
+  let jobset = circus_common::repo::jobsets::create(
+    &pool,
+    circus_common::models::CreateJobset {
       project_id:        project.id,
       name:              "main".to_string(),
       nix_expression:    "packages".to_string(),
@@ -590,13 +613,14 @@ async fn test_orphan_build_reset() {
       scheduling_shares: None,
       state:             None,
       keep_nr:           None,
-    })
-    .await
-    .expect("create jobset");
+    },
+  )
+  .await
+  .expect("create jobset");
 
-  let eval = fc_common::repo::evaluations::create(
+  let eval = circus_common::repo::evaluations::create(
     &pool,
-    fc_common::models::CreateEvaluation {
+    circus_common::models::CreateEvaluation {
       jobset_id:      jobset.id,
       commit_hash:    "1234567890abcdef1234567890abcdef12345678".to_string(),
       pr_number:      None,
@@ -609,8 +633,9 @@ async fn test_orphan_build_reset() {
   .expect("create eval");
 
   // Create a build and mark it running
-  let build =
-    fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
+  let build = circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
       evaluation_id: eval.id,
       job_name:      "orphan-build".to_string(),
       drv_path:      "/nix/store/test-orphan.drv".to_string(),
@@ -618,11 +643,12 @@ async fn test_orphan_build_reset() {
       outputs:       None,
       is_aggregate:  None,
       constituents:  None,
-    })
-    .await
-    .expect("create build");
+    },
+  )
+  .await
+  .expect("create build");
 
-  let _ = fc_common::repo::builds::start(&pool, build.id).await;
+  let _ = circus_common::repo::builds::start(&pool, build.id).await;
 
   // Simulate the build being stuck for a while by manually backdating
   // started_at
@@ -637,19 +663,22 @@ async fn test_orphan_build_reset() {
   .expect("backdate build");
 
   // Reset orphaned builds (older than 5 minutes)
-  let count = fc_common::repo::builds::reset_orphaned(&pool, 300)
+  let count = circus_common::repo::builds::reset_orphaned(&pool, 300)
     .await
     .expect("reset orphaned");
   assert!(count >= 1, "should have reset at least 1 orphaned build");
 
   // Verify build is pending again
-  let reset_build = fc_common::repo::builds::get(&pool, build.id)
+  let reset_build = circus_common::repo::builds::get(&pool, build.id)
     .await
     .expect("get build");
-  assert_eq!(reset_build.status, fc_common::models::BuildStatus::Pending);
+  assert_eq!(
+    reset_build.status,
+    circus_common::models::BuildStatus::Pending
+  );
 
   // Clean up
-  let _ = fc_common::repo::projects::delete(&pool, project.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project.id).await;
 }
 
 #[tokio::test]
@@ -670,9 +699,9 @@ async fn test_get_cancelled_among() {
     .await
     .expect("migration failed");
 
-  let project = fc_common::repo::projects::create(
+  let project = circus_common::repo::projects::create(
     &pool,
-    fc_common::models::CreateProject {
+    circus_common::models::CreateProject {
       name:           format!("cancel-among-{}", uuid::Uuid::new_v4()),
       description:    None,
       repository_url: "https://github.com/test/repo".to_string(),
@@ -681,8 +710,9 @@ async fn test_get_cancelled_among() {
   .await
   .expect("create project");
 
-  let jobset =
-    fc_common::repo::jobsets::create(&pool, fc_common::models::CreateJobset {
+  let jobset = circus_common::repo::jobsets::create(
+    &pool,
+    circus_common::models::CreateJobset {
       project_id:        project.id,
       name:              "main".to_string(),
       nix_expression:    "packages".to_string(),
@@ -693,13 +723,14 @@ async fn test_get_cancelled_among() {
       scheduling_shares: None,
       state:             None,
       keep_nr:           None,
-    })
-    .await
-    .expect("create jobset");
+    },
+  )
+  .await
+  .expect("create jobset");
 
-  let eval = fc_common::repo::evaluations::create(
+  let eval = circus_common::repo::evaluations::create(
     &pool,
-    fc_common::models::CreateEvaluation {
+    circus_common::models::CreateEvaluation {
       jobset_id:      jobset.id,
       commit_hash:    "aabbccdd1234567890aabbccdd1234567890aabb".to_string(),
       pr_number:      None,
@@ -712,8 +743,9 @@ async fn test_get_cancelled_among() {
   .expect("create eval");
 
   // Create a pending build
-  let build_pending =
-    fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
+  let build_pending = circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
       evaluation_id: eval.id,
       job_name:      "pending-job".to_string(),
       drv_path:      format!("/nix/store/{}-pending.drv", uuid::Uuid::new_v4()),
@@ -721,13 +753,15 @@ async fn test_get_cancelled_among() {
       outputs:       None,
       is_aggregate:  None,
       constituents:  None,
-    })
-    .await
-    .expect("create pending build");
+    },
+  )
+  .await
+  .expect("create pending build");
 
   // Create a running build
-  let build_running =
-    fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
+  let build_running = circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
       evaluation_id: eval.id,
       job_name:      "running-job".to_string(),
       drv_path:      format!("/nix/store/{}-running.drv", uuid::Uuid::new_v4()),
@@ -735,16 +769,18 @@ async fn test_get_cancelled_among() {
       outputs:       None,
       is_aggregate:  None,
       constituents:  None,
-    })
-    .await
-    .expect("create running build");
-  fc_common::repo::builds::start(&pool, build_running.id)
+    },
+  )
+  .await
+  .expect("create running build");
+  circus_common::repo::builds::start(&pool, build_running.id)
     .await
     .expect("start running build");
 
   // Create a cancelled build (start then cancel)
-  let build_cancelled =
-    fc_common::repo::builds::create(&pool, fc_common::models::CreateBuild {
+  let build_cancelled = circus_common::repo::builds::create(
+    &pool,
+    circus_common::models::CreateBuild {
       evaluation_id: eval.id,
       job_name:      "cancelled-job".to_string(),
       drv_path:      format!(
@@ -755,39 +791,42 @@ async fn test_get_cancelled_among() {
       outputs:       None,
       is_aggregate:  None,
       constituents:  None,
-    })
-    .await
-    .expect("create cancelled build");
-  fc_common::repo::builds::start(&pool, build_cancelled.id)
+    },
+  )
+  .await
+  .expect("create cancelled build");
+  circus_common::repo::builds::start(&pool, build_cancelled.id)
     .await
     .expect("start cancelled build");
-  fc_common::repo::builds::cancel(&pool, build_cancelled.id)
+  circus_common::repo::builds::cancel(&pool, build_cancelled.id)
     .await
     .expect("cancel build");
 
   // Query for cancelled among all three
   let all_ids = vec![build_pending.id, build_running.id, build_cancelled.id];
-  let cancelled = fc_common::repo::builds::get_cancelled_among(&pool, &all_ids)
-    .await
-    .expect("get cancelled among");
+  let cancelled =
+    circus_common::repo::builds::get_cancelled_among(&pool, &all_ids)
+      .await
+      .expect("get cancelled among");
   assert_eq!(cancelled.len(), 1);
   assert_eq!(cancelled[0], build_cancelled.id);
 
   // Empty input returns empty
-  let empty = fc_common::repo::builds::get_cancelled_among(&pool, &[])
+  let empty = circus_common::repo::builds::get_cancelled_among(&pool, &[])
     .await
     .expect("empty query");
   assert!(empty.is_empty());
 
   // Query with only non-cancelled builds returns empty
-  let none_cancelled = fc_common::repo::builds::get_cancelled_among(&pool, &[
-    build_pending.id,
-    build_running.id,
-  ])
-  .await
-  .expect("no cancelled");
+  let none_cancelled =
+    circus_common::repo::builds::get_cancelled_among(&pool, &[
+      build_pending.id,
+      build_running.id,
+    ])
+    .await
+    .expect("no cancelled");
   assert!(none_cancelled.is_empty());
 
   // Clean up
-  let _ = fc_common::repo::projects::delete(&pool, project.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project.id).await;
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name                 = "fc-server"
+name                 = "circus-server"
 version.workspace    = true
 edition.workspace    = true
-authors.workspace    = true
 license.workspace    = true
 repository.workspace = true
 
@@ -39,7 +38,7 @@ uuid.workspace               = true
 xz2.workspace                = true
 
 # Our crates
-fc-common.workspace = true
+circus-common.workspace = true
 
 [dev-dependencies]
 tower.workspace = true

--- a/crates/server/src/auth_middleware.rs
+++ b/crates/server/src/auth_middleware.rs
@@ -4,14 +4,14 @@ use axum::{
   middleware::Next,
   response::Response,
 };
-use fc_common::models::{ApiKey, User};
+use circus_common::models::{ApiKey, User};
 use sha2::{Digest, Sha256};
 
 use crate::state::AppState;
 
 /// Extract and validate an API key from the Authorization header or session
-/// cookie. Keys use the format: `Bearer fc_xxxx`. Session cookies use
-/// `fc_session=<id>` for API keys or `fc_user_session=<id>` for users.
+/// cookie. Keys use the format: `Bearer circus_xxxx`. Session cookies use
+/// `circus_session=<id>` for API keys or `circus_user_session=<id>` for users.
 /// Write endpoints (POST/PUT/DELETE/PATCH) require a valid key.
 /// Read endpoints (GET/HEAD/OPTIONS) try to extract optionally (for
 /// dashboard admin UI).
@@ -47,14 +47,14 @@ pub async fn require_api_key(
     let key_hash = hex::encode(hasher.finalize());
 
     if let Ok(Some(api_key)) =
-      fc_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
+      circus_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
     {
       // Update last used timestamp asynchronously
       let pool = state.pool.clone();
       let key_id = api_key.id;
       tokio::spawn(async move {
         if let Err(e) =
-          fc_common::repo::api_keys::touch_last_used(&pool, key_id).await
+          circus_common::repo::api_keys::touch_last_used(&pool, key_id).await
         {
           tracing::warn!(error = %e, "Failed to update API key last_used timestamp");
         }
@@ -76,8 +76,8 @@ pub async fn require_api_key(
     .get("cookie")
     .and_then(|v| v.to_str().ok())
   {
-    // Try user session first (new fc_user_session cookie)
-    if let Some(session_id) = parse_cookie(cookie_header, "fc_user_session")
+    // Try user session first (new circus_user_session cookie)
+    if let Some(session_id) = parse_cookie(cookie_header, "circus_user_session")
       && let Some(session) = state.sessions.get(&session_id)
     {
       // Check session expiry (24 hours)
@@ -96,8 +96,8 @@ pub async fn require_api_key(
       state.sessions.remove(&session_id);
     }
 
-    // Try legacy API key session (fc_session cookie)
-    if let Some(session_id) = parse_cookie(cookie_header, "fc_session")
+    // Try legacy API key session (circus_session cookie)
+    if let Some(session_id) = parse_cookie(cookie_header, "circus_session")
       && let Some(session) = state.sessions.get(&session_id)
     {
       // Check session expiry (24 hours)
@@ -209,8 +209,8 @@ impl RequireRoles {
 }
 
 /// Session extraction middleware for dashboard routes.
-/// Reads `fc_user_session` or `fc_session` cookie, or Bearer token (API key),
-/// and inserts User/ApiKey into extensions if valid.
+/// Reads `circus_user_session` or `circus_session` cookie, or Bearer token (API
+/// key), and inserts User/ApiKey into extensions if valid.
 pub async fn extract_session(
   State(state): State<AppState>,
   mut request: Request,
@@ -232,14 +232,14 @@ pub async fn extract_session(
     let key_hash = hex::encode(hasher.finalize());
 
     if let Ok(Some(api_key)) =
-      fc_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
+      circus_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
     {
       // Update last used timestamp asynchronously
       let pool = state.pool.clone();
       let key_id = api_key.id;
       tokio::spawn(async move {
         if let Err(e) =
-          fc_common::repo::api_keys::touch_last_used(&pool, key_id).await
+          circus_common::repo::api_keys::touch_last_used(&pool, key_id).await
         {
           tracing::warn!(error = %e, "Failed to update API key last_used timestamp");
         }
@@ -258,7 +258,8 @@ pub async fn extract_session(
 
   if let Some(cookie_header) = cookie_header {
     // Try user session first
-    if let Some(session_id) = parse_cookie(&cookie_header, "fc_user_session")
+    if let Some(session_id) =
+      parse_cookie(&cookie_header, "circus_user_session")
       && let Some(session) = state.sessions.get(&session_id)
     {
       // Check session expiry
@@ -280,7 +281,7 @@ pub async fn extract_session(
     }
 
     // Try legacy API key session
-    if let Some(session_id) = parse_cookie(&cookie_header, "fc_session")
+    if let Some(session_id) = parse_cookie(&cookie_header, "circus_session")
       && let Some(session) = state.sessions.get(&session_id)
     {
       // Check session expiry

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -2,7 +2,7 @@ use axum::{
   http::StatusCode,
   response::{IntoResponse, Response},
 };
-use fc_common::CiError;
+use circus_common::CiError;
 use serde_json::json;
 
 pub struct ApiError(pub CiError);
@@ -48,8 +48,8 @@ impl IntoResponse for ApiError {
               "{msg}\n\nDISK SPACE ISSUE DETECTED:\nThe server has run out of \
                disk space. Please free up space:\n- Run `nix-collect-garbage \
                -d` to clean the Nix store\n- Clear the evaluator work \
-               directory: `rm -rf /tmp/fc-evaluator/*`\n- Clear build logs if \
-               configured"
+               directory: `rm -rf /tmp/circus-evaluator/*`\n- Clear build \
+               logs if configured"
             ),
           )
         } else {
@@ -133,7 +133,7 @@ impl IntoResponse for ApiError {
               "IO error: {msg}\n\nDISK SPACE ISSUE DETECTED:\nThe server has \
                run out of disk space. Please free up space:\n- Run \
                `nix-collect-garbage -d` to clean the Nix store\n- Clear the \
-               evaluator work directory: `rm -rf /tmp/fc-evaluator/*`\n- \
+               evaluator work directory: `rm -rf /tmp/circus-evaluator/*`\n- \
                Clear build logs if configured"
             ),
           )

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,11 +1,11 @@
+use circus_common::{Config, Database};
+use circus_server::{routes, state};
 use clap::Parser;
-use fc_common::{Config, Database};
-use fc_server::{routes, state};
 use state::AppState;
 use tokio::net::TcpListener;
 
 #[derive(Parser)]
-#[command(name = "fc-server")]
+#[command(name = "circus-server")]
 #[command(about = "CI Server - Web API and UI")]
 struct Cli {
   #[arg(short = 'H', long)]
@@ -44,21 +44,21 @@ async fn shutdown_signal() {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
   let config = Config::load()?;
-  fc_common::init_tracing(&config.tracing);
+  circus_common::init_tracing(&config.tracing);
 
   let cli = Cli::parse();
 
   let host = cli.host.unwrap_or(config.server.host.clone());
   let port = cli.port.unwrap_or(config.server.port);
 
-  fc_common::validate::warn_insecure_schemes(
+  circus_common::validate::warn_insecure_schemes(
     &config.server.allowed_url_schemes,
   );
 
   let db = Database::new(config.database.clone()).await?;
 
   // Bootstrap declarative projects, jobsets, and API keys from config
-  fc_common::bootstrap::run(db.pool(), &config.declarative).await?;
+  circus_common::bootstrap::run(db.pool(), &config.declarative).await?;
 
   // Per-process CSRF secret. Concatenating two v4 UUIDs gives 32 bytes of
   // entropy from the system CSPRNG with no extra dependency.

--- a/crates/server/src/routes/admin.rs
+++ b/crates/server/src/routes/admin.rs
@@ -4,7 +4,7 @@ use axum::{
   extract::{Path, State},
   routing::get,
 };
-use fc_common::{
+use circus_common::{
   Validate,
   models::{
     CreateRemoteBuilder,
@@ -20,7 +20,7 @@ use crate::{auth_middleware::RequireAdmin, error::ApiError, state::AppState};
 async fn list_builders(
   State(state): State<AppState>,
 ) -> Result<Json<Vec<RemoteBuilder>>, ApiError> {
-  let builders = fc_common::repo::remote_builders::list(&state.pool)
+  let builders = circus_common::repo::remote_builders::list(&state.pool)
     .await
     .map_err(ApiError)?;
   Ok(Json(builders))
@@ -30,7 +30,7 @@ async fn get_builder(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<RemoteBuilder>, ApiError> {
-  let builder = fc_common::repo::remote_builders::get(&state.pool, id)
+  let builder = circus_common::repo::remote_builders::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(builder))
@@ -43,10 +43,11 @@ async fn create_builder(
 ) -> Result<Json<RemoteBuilder>, ApiError> {
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  let builder = fc_common::repo::remote_builders::create(&state.pool, input)
-    .await
-    .map_err(ApiError)?;
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  let builder =
+    circus_common::repo::remote_builders::create(&state.pool, input)
+      .await
+      .map_err(ApiError)?;
   Ok(Json(builder))
 }
 
@@ -58,9 +59,9 @@ async fn update_builder(
 ) -> Result<Json<RemoteBuilder>, ApiError> {
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
   let builder =
-    fc_common::repo::remote_builders::update(&state.pool, id, input)
+    circus_common::repo::remote_builders::update(&state.pool, id, input)
       .await
       .map_err(ApiError)?;
   Ok(Json(builder))
@@ -71,7 +72,7 @@ async fn delete_builder(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-  fc_common::repo::remote_builders::delete(&state.pool, id)
+  circus_common::repo::remote_builders::delete(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(serde_json::json!({"deleted": true})))
@@ -86,27 +87,27 @@ async fn system_status(
   let projects: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM projects")
     .fetch_one(pool)
     .await
-    .map_err(|e| ApiError(fc_common::CiError::Database(e)))?;
+    .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
   let jobsets: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM jobsets")
     .fetch_one(pool)
     .await
-    .map_err(|e| ApiError(fc_common::CiError::Database(e)))?;
+    .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
   let evaluations: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM evaluations")
     .fetch_one(pool)
     .await
-    .map_err(|e| ApiError(fc_common::CiError::Database(e)))?;
+    .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
 
-  let build_stats = fc_common::repo::builds::get_stats(pool)
+  let build_stats = circus_common::repo::builds::get_stats(pool)
     .await
     .map_err(ApiError)?;
-  let builders = fc_common::repo::remote_builders::count(pool)
+  let builders = circus_common::repo::remote_builders::count(pool)
     .await
     .map_err(ApiError)?;
 
   let channels: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM channels")
     .fetch_one(pool)
     .await
-    .map_err(|e| ApiError(fc_common::CiError::Database(e)))?;
+    .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
 
   Ok(Json(SystemStatus {
     projects_count:    projects.0,

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -1,5 +1,5 @@
 use axum::{Json, Router, extract::State, routing::get};
-use fc_common::repo;
+use circus_common::repo;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -44,7 +44,7 @@ async fn create_api_key(
   let role = input.role.unwrap_or_else(|| "read-only".to_string());
 
   // Generate a random API key
-  let key = format!("fc_{}", Uuid::new_v4().to_string().replace('-', ""));
+  let key = format!("circus_{}", Uuid::new_v4().to_string().replace('-', ""));
   let key_hash = hash_api_key(&key);
 
   let api_key =

--- a/crates/server/src/routes/badges.rs
+++ b/crates/server/src/routes/badges.rs
@@ -14,12 +14,12 @@ async fn build_badge(
 ) -> Result<Response, ApiError> {
   // Find the project
   let project =
-    fc_common::repo::projects::get_by_name(&state.pool, &project_name)
+    circus_common::repo::projects::get_by_name(&state.pool, &project_name)
       .await
       .map_err(ApiError)?;
 
   // Find the jobset
-  let jobsets = fc_common::repo::jobsets::list_for_project(
+  let jobsets = circus_common::repo::jobsets::list_for_project(
     &state.pool,
     project.id,
     1000,
@@ -34,9 +34,10 @@ async fn build_badge(
   };
 
   // Get latest evaluation
-  let eval = fc_common::repo::evaluations::get_latest(&state.pool, jobset.id)
-    .await
-    .map_err(ApiError)?;
+  let eval =
+    circus_common::repo::evaluations::get_latest(&state.pool, jobset.id)
+      .await
+      .map_err(ApiError)?;
 
   let Some(eval) = eval else {
     return Ok(
@@ -46,7 +47,7 @@ async fn build_badge(
 
   // Find the build for this job
   let builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, eval.id)
+    circus_common::repo::builds::list_for_evaluation(&state.pool, eval.id)
       .await
       .map_err(ApiError)?;
 
@@ -54,20 +55,26 @@ async fn build_badge(
 
   let (label, color) = build.map_or(("not found", "#9f9f9f"), |b| {
     match b.status {
-      fc_common::BuildStatus::Succeeded => ("passing", "#4c1"),
-      fc_common::BuildStatus::Failed => ("failing", "#e05d44"),
-      fc_common::BuildStatus::Running => ("building", "#dfb317"),
-      fc_common::BuildStatus::Pending => ("queued", "#dfb317"),
-      fc_common::BuildStatus::Cancelled => ("cancelled", "#9f9f9f"),
-      fc_common::BuildStatus::DependencyFailed => ("dep failed", "#e05d44"),
-      fc_common::BuildStatus::Aborted => ("aborted", "#9f9f9f"),
-      fc_common::BuildStatus::FailedWithOutput => ("failed output", "#e05d44"),
-      fc_common::BuildStatus::Timeout => ("timeout", "#e05d44"),
-      fc_common::BuildStatus::CachedFailure => ("cached fail", "#e05d44"),
-      fc_common::BuildStatus::UnsupportedSystem => ("unsupported", "#9f9f9f"),
-      fc_common::BuildStatus::LogLimitExceeded => ("log limit", "#e05d44"),
-      fc_common::BuildStatus::NarSizeLimitExceeded => ("nar limit", "#e05d44"),
-      fc_common::BuildStatus::NonDeterministic => ("non-det", "#e05d44"),
+      circus_common::BuildStatus::Succeeded => ("passing", "#4c1"),
+      circus_common::BuildStatus::Failed => ("failing", "#e05d44"),
+      circus_common::BuildStatus::Running => ("building", "#dfb317"),
+      circus_common::BuildStatus::Pending => ("queued", "#dfb317"),
+      circus_common::BuildStatus::Cancelled => ("cancelled", "#9f9f9f"),
+      circus_common::BuildStatus::DependencyFailed => ("dep failed", "#e05d44"),
+      circus_common::BuildStatus::Aborted => ("aborted", "#9f9f9f"),
+      circus_common::BuildStatus::FailedWithOutput => {
+        ("failed output", "#e05d44")
+      },
+      circus_common::BuildStatus::Timeout => ("timeout", "#e05d44"),
+      circus_common::BuildStatus::CachedFailure => ("cached fail", "#e05d44"),
+      circus_common::BuildStatus::UnsupportedSystem => {
+        ("unsupported", "#9f9f9f")
+      },
+      circus_common::BuildStatus::LogLimitExceeded => ("log limit", "#e05d44"),
+      circus_common::BuildStatus::NarSizeLimitExceeded => {
+        ("nar limit", "#e05d44")
+      },
+      circus_common::BuildStatus::NonDeterministic => ("non-det", "#e05d44"),
     }
   });
 
@@ -90,11 +97,11 @@ async fn latest_build(
   Path((project_name, jobset_name, job_name)): Path<(String, String, String)>,
 ) -> Result<Response, ApiError> {
   let project =
-    fc_common::repo::projects::get_by_name(&state.pool, &project_name)
+    circus_common::repo::projects::get_by_name(&state.pool, &project_name)
       .await
       .map_err(ApiError)?;
 
-  let jobsets = fc_common::repo::jobsets::list_for_project(
+  let jobsets = circus_common::repo::jobsets::list_for_project(
     &state.pool,
     project.id,
     1000,
@@ -108,16 +115,17 @@ async fn latest_build(
     return Ok((StatusCode::NOT_FOUND, "Jobset not found").into_response());
   };
 
-  let eval = fc_common::repo::evaluations::get_latest(&state.pool, jobset.id)
-    .await
-    .map_err(ApiError)?;
+  let eval =
+    circus_common::repo::evaluations::get_latest(&state.pool, jobset.id)
+      .await
+      .map_err(ApiError)?;
 
   let Some(eval) = eval else {
     return Ok((StatusCode::NOT_FOUND, "No evaluations found").into_response());
   };
 
   let builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, eval.id)
+    circus_common::repo::builds::list_for_evaluation(&state.pool, eval.id)
       .await
       .map_err(ApiError)?;
 

--- a/crates/server/src/routes/builds.rs
+++ b/crates/server/src/routes/builds.rs
@@ -7,7 +7,7 @@ use axum::{
   response::{IntoResponse, Response},
   routing::{get, post, put},
 };
-use fc_common::{
+use circus_common::{
   Build,
   BuildProduct,
   BuildStep,
@@ -27,9 +27,13 @@ fn check_role(
     .map(|_| ())
     .map_err(|s| {
       ApiError(if s == StatusCode::FORBIDDEN {
-        fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+        circus_common::CiError::Forbidden(
+          "Insufficient permissions".to_string(),
+        )
       } else {
-        fc_common::CiError::Unauthorized("Authentication required".to_string())
+        circus_common::CiError::Unauthorized(
+          "Authentication required".to_string(),
+        )
       })
     })
 }
@@ -54,7 +58,7 @@ async fn list_builds(
   };
   let limit = pagination.limit();
   let offset = pagination.offset();
-  let items = fc_common::repo::builds::list_filtered(
+  let items = circus_common::repo::builds::list_filtered(
     &state.pool,
     params.evaluation_id,
     params.status.as_deref(),
@@ -65,7 +69,7 @@ async fn list_builds(
   )
   .await
   .map_err(ApiError)?;
-  let total = fc_common::repo::builds::count_filtered(
+  let total = circus_common::repo::builds::count_filtered(
     &state.pool,
     params.evaluation_id,
     params.status.as_deref(),
@@ -86,7 +90,7 @@ async fn get_build(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Build>, ApiError> {
-  let build = fc_common::repo::builds::get(&state.pool, id)
+  let build = circus_common::repo::builds::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(build))
@@ -98,11 +102,11 @@ async fn cancel_build(
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Build>>, ApiError> {
   check_role(&extensions, &["cancel-build"])?;
-  let cancelled = fc_common::repo::builds::cancel_cascade(&state.pool, id)
+  let cancelled = circus_common::repo::builds::cancel_cascade(&state.pool, id)
     .await
     .map_err(ApiError)?;
   if cancelled.is_empty() {
-    return Err(ApiError(fc_common::CiError::NotFound(
+    return Err(ApiError(circus_common::CiError::NotFound(
       "Build not found or not in a cancellable state".to_string(),
     )));
   }
@@ -113,7 +117,7 @@ async fn list_build_steps(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<BuildStep>>, ApiError> {
-  let steps = fc_common::repo::build_steps::list_for_build(&state.pool, id)
+  let steps = circus_common::repo::build_steps::list_for_build(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(steps))
@@ -124,7 +128,7 @@ async fn list_build_products(
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<BuildProduct>>, ApiError> {
   let products =
-    fc_common::repo::build_products::list_for_build(&state.pool, id)
+    circus_common::repo::build_products::list_for_build(&state.pool, id)
       .await
       .map_err(ApiError)?;
   Ok(Json(products))
@@ -132,8 +136,8 @@ async fn list_build_products(
 
 async fn build_stats(
   State(state): State<AppState>,
-) -> Result<Json<fc_common::BuildStats>, ApiError> {
-  let build_stats = fc_common::repo::builds::get_stats(&state.pool)
+) -> Result<Json<circus_common::BuildStats>, ApiError> {
+  let build_stats = circus_common::repo::builds::get_stats(&state.pool)
     .await
     .map_err(ApiError)?;
   Ok(Json(build_stats))
@@ -142,7 +146,7 @@ async fn build_stats(
 async fn recent_builds(
   State(state): State<AppState>,
 ) -> Result<Json<Vec<Build>>, ApiError> {
-  let builds = fc_common::repo::builds::list_recent(&state.pool, 20)
+  let builds = circus_common::repo::builds::list_recent(&state.pool, 20)
     .await
     .map_err(ApiError)?;
   Ok(Json(builds))
@@ -152,7 +156,7 @@ async fn list_project_builds(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Build>>, ApiError> {
-  let builds = fc_common::repo::builds::list_for_project(&state.pool, id)
+  let builds = circus_common::repo::builds::list_for_project(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(builds))
@@ -164,7 +168,7 @@ async fn restart_build(
   Path(id): Path<Uuid>,
 ) -> Result<Json<Build>, ApiError> {
   check_role(&extensions, &["restart-jobs"])?;
-  let build = fc_common::repo::builds::restart(&state.pool, id)
+  let build = circus_common::repo::builds::restart(&state.pool, id)
     .await
     .map_err(ApiError)?;
 
@@ -190,9 +194,9 @@ async fn bump_build(
   .bind(id)
   .fetch_optional(&state.pool)
   .await
-  .map_err(|e| ApiError(fc_common::CiError::Database(e)))?
+  .map_err(|e| ApiError(circus_common::CiError::Database(e)))?
   .ok_or_else(|| {
-    ApiError(fc_common::CiError::Validation(
+    ApiError(circus_common::CiError::Validation(
       "Build not found or not in pending state".to_string(),
     ))
   })?;
@@ -205,22 +209,23 @@ async fn download_build_product(
   Path((build_id, product_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Response, ApiError> {
   // Verify build exists
-  let _build = fc_common::repo::builds::get(&state.pool, build_id)
+  let _build = circus_common::repo::builds::get(&state.pool, build_id)
     .await
     .map_err(ApiError)?;
 
-  let product = fc_common::repo::build_products::get(&state.pool, product_id)
-    .await
-    .map_err(ApiError)?;
+  let product =
+    circus_common::repo::build_products::get(&state.pool, product_id)
+      .await
+      .map_err(ApiError)?;
 
   if product.build_id != build_id {
-    return Err(ApiError(fc_common::CiError::NotFound(
+    return Err(ApiError(circus_common::CiError::NotFound(
       "Product does not belong to this build".to_string(),
     )));
   }
 
-  if !fc_common::validate::is_valid_store_path(&product.path) {
-    return Err(ApiError(fc_common::CiError::Validation(
+  if !circus_common::validate::is_valid_store_path(&product.path) {
+    return Err(ApiError(circus_common::CiError::Validation(
       "Invalid store path".to_string(),
     )));
   }
@@ -236,14 +241,14 @@ async fn download_build_product(
     let mut child = match child {
       Ok(c) => c,
       Err(e) => {
-        return Err(ApiError(fc_common::CiError::Build(format!(
+        return Err(ApiError(circus_common::CiError::Build(format!(
           "Failed to dump path: {e}"
         ))));
       },
     };
 
     let Some(stdout) = child.stdout.take() else {
-      return Err(ApiError(fc_common::CiError::Build(
+      return Err(ApiError(circus_common::CiError::Build(
         "Failed to capture output".to_string(),
       )));
     };
@@ -271,7 +276,7 @@ async fn download_build_product(
     // Serve file directly
     let file = tokio::fs::File::open(&product.path)
       .await
-      .map_err(|e| ApiError(fc_common::CiError::Io(e)))?;
+      .map_err(|e| ApiError(circus_common::CiError::Io(e)))?;
 
     let stream = tokio_util::io::ReaderStream::new(file);
     let body = Body::from_stream(stream);
@@ -303,16 +308,16 @@ async fn list_build_constituents(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Build>>, ApiError> {
-  let build = fc_common::repo::builds::get(&state.pool, id)
+  let build = circus_common::repo::builds::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   if !build.is_aggregate {
-    return Err(ApiError(fc_common::CiError::Validation(
+    return Err(ApiError(circus_common::CiError::Validation(
       "Build is not an aggregate build".into(),
     )));
   }
   let constituents =
-    fc_common::repo::builds::list_constituents(&state.pool, id)
+    circus_common::repo::builds::list_constituents(&state.pool, id)
       .await
       .map_err(ApiError)?;
   Ok(Json(constituents))
@@ -323,7 +328,7 @@ async fn set_keep_flag(
   State(state): State<AppState>,
   Path((id, value)): Path<(Uuid, bool)>,
 ) -> Result<Json<Build>, ApiError> {
-  let build = fc_common::repo::builds::set_keep(&state.pool, id, value)
+  let build = circus_common::repo::builds::set_keep(&state.pool, id, value)
     .await
     .map_err(ApiError)?;
 

--- a/crates/server/src/routes/cache.rs
+++ b/crates/server/src/routes/cache.rs
@@ -42,7 +42,7 @@ async fn find_store_path(
   .bind(&like_pattern)
   .fetch_optional(pool)
   .await
-  .map_err(|e| ApiError(fc_common::CiError::Database(e)))?;
+  .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
 
   if path.is_some() {
     return Ok(path);
@@ -55,7 +55,7 @@ async fn find_store_path(
   .bind(&like_pattern)
   .fetch_optional(pool)
   .await
-  .map_err(|e| ApiError(fc_common::CiError::Database(e)))
+  .map_err(|e| ApiError(circus_common::CiError::Database(e)))
 }
 
 /// Serve `NARInfo` for a store path hash.
@@ -73,12 +73,12 @@ async fn narinfo(
   // Strip .narinfo suffix if present
   let hash = hash.strip_suffix(".narinfo").unwrap_or(&hash);
 
-  if !fc_common::validate::is_valid_nix_hash(hash) {
+  if !circus_common::validate::is_valid_nix_hash(hash) {
     return Ok(StatusCode::NOT_FOUND.into_response());
   }
 
   let store_path = match find_store_path(&state.pool, hash).await? {
-    Some(p) if fc_common::validate::is_valid_store_path(&p) => p,
+    Some(p) if circus_common::validate::is_valid_store_path(&p) => p,
     _ => return Ok(StatusCode::NOT_FOUND.into_response()),
   };
 
@@ -237,13 +237,13 @@ fn pipe_through_compressor(
     .stderr(std::process::Stdio::null())
     .spawn()
     .map_err(|_| {
-      ApiError(fc_common::CiError::Build(
+      ApiError(circus_common::CiError::Build(
         "Failed to start nix store dump-path".to_string(),
       ))
     })?;
 
   let nix_stdout = nix_child.stdout.take().ok_or_else(|| {
-    ApiError(fc_common::CiError::Build(
+    ApiError(circus_common::CiError::Build(
       "nix store dump-path produced no stdout".to_string(),
     ))
   })?;
@@ -256,13 +256,13 @@ fn pipe_through_compressor(
     .kill_on_drop(true)
     .spawn()
     .map_err(|_| {
-      ApiError(fc_common::CiError::Build(format!(
+      ApiError(circus_common::CiError::Build(format!(
         "Failed to start {compressor}"
       )))
     })?;
 
   comp_child.stdout.take().ok_or_else(|| {
-    ApiError(fc_common::CiError::Build(format!(
+    ApiError(circus_common::CiError::Build(format!(
       "{compressor} produced no stdout"
     )))
   })
@@ -295,12 +295,12 @@ async fn serve_nar_combined(
     return Ok(StatusCode::NOT_FOUND.into_response());
   };
 
-  if !fc_common::validate::is_valid_nix_hash(stripped) {
+  if !circus_common::validate::is_valid_nix_hash(stripped) {
     return Ok(StatusCode::NOT_FOUND.into_response());
   }
 
   let store_path = match find_store_path(&state.pool, stripped).await? {
-    Some(p) if fc_common::validate::is_valid_store_path(&p) => p,
+    Some(p) if circus_common::validate::is_valid_store_path(&p) => p,
     _ => return Ok(StatusCode::NOT_FOUND.into_response()),
   };
 
@@ -315,12 +315,12 @@ async fn serve_nar_combined(
       .kill_on_drop(true)
       .spawn()
       .map_err(|_| {
-        ApiError(fc_common::CiError::Build(
+        ApiError(circus_common::CiError::Build(
           "Failed to start nix store dump-path".to_string(),
         ))
       })?;
     let stdout = child.stdout.take().ok_or_else(|| {
-      ApiError(fc_common::CiError::Build(
+      ApiError(circus_common::CiError::Build(
         "nix store dump-path produced no stdout".to_string(),
       ))
     })?;

--- a/crates/server/src/routes/channel_manifests.rs
+++ b/crates/server/src/routes/channel_manifests.rs
@@ -30,13 +30,13 @@ async fn git_revision(
   State(state): State<AppState>,
   Path(name): Path<String>,
 ) -> Result<Response, ApiError> {
-  let channel = fc_common::repo::channels::get_by_name(&state.pool, &name)
+  let channel = circus_common::repo::channels::get_by_name(&state.pool, &name)
     .await
     .map_err(ApiError)?;
   let Some(eval_id) = channel.current_evaluation_id else {
     return Ok(StatusCode::NOT_FOUND.into_response());
   };
-  let eval = fc_common::repo::evaluations::get(&state.pool, eval_id)
+  let eval = circus_common::repo::evaluations::get(&state.pool, eval_id)
     .await
     .map_err(ApiError)?;
 
@@ -56,7 +56,7 @@ async fn binary_cache_url(
 ) -> Result<Response, ApiError> {
   // Verify the channel exists; otherwise this endpoint would happily echo
   // the cache URL for any name and pollute clients' channel state.
-  let _ = fc_common::repo::channels::get_by_name(&state.pool, &name)
+  let _ = circus_common::repo::channels::get_by_name(&state.pool, &name)
     .await
     .map_err(ApiError)?;
 
@@ -78,7 +78,7 @@ async fn store_paths(
   State(state): State<AppState>,
   Path(name): Path<String>,
 ) -> Result<Response, ApiError> {
-  let channel = fc_common::repo::channels::get_by_name(&state.pool, &name)
+  let channel = circus_common::repo::channels::get_by_name(&state.pool, &name)
     .await
     .map_err(ApiError)?;
   let Some(eval_id) = channel.current_evaluation_id else {
@@ -86,7 +86,7 @@ async fn store_paths(
   };
 
   let builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, eval_id)
+    circus_common::repo::builds::list_for_evaluation(&state.pool, eval_id)
       .await
       .map_err(ApiError)?;
 
@@ -98,8 +98,11 @@ async fn store_paths(
     if let Some(p) = &build.build_output_path {
       paths.push(p.clone());
     }
-    match fc_common::repo::build_products::list_for_build(&state.pool, build.id)
-      .await
+    match circus_common::repo::build_products::list_for_build(
+      &state.pool,
+      build.id,
+    )
+    .await
     {
       Ok(products) => {
         for product in products {
@@ -126,10 +129,12 @@ async fn store_paths(
   })
   .await
   .map_err(|e| {
-    ApiError(fc_common::CiError::Build(format!("xz join error: {e}")))
+    ApiError(circus_common::CiError::Build(format!("xz join error: {e}")))
   })?
   .map_err(|e| {
-    ApiError(fc_common::CiError::Build(format!("xz encode failed: {e}")))
+    ApiError(circus_common::CiError::Build(format!(
+      "xz encode failed: {e}"
+    )))
   })?;
 
   Ok(

--- a/crates/server/src/routes/channels.rs
+++ b/crates/server/src/routes/channels.rs
@@ -9,7 +9,7 @@ use axum::{
   response::{IntoResponse, Response},
   routing::{get, post},
 };
-use fc_common::{
+use circus_common::{
   Validate,
   models::{BuildStatus, Channel, CreateChannel},
 };
@@ -20,7 +20,7 @@ use crate::{auth_middleware::RequireAdmin, error::ApiError, state::AppState};
 async fn list_channels(
   State(state): State<AppState>,
 ) -> Result<Json<Vec<Channel>>, ApiError> {
-  let channels = fc_common::repo::channels::list_all(&state.pool)
+  let channels = circus_common::repo::channels::list_all(&state.pool)
     .await
     .map_err(ApiError)?;
   Ok(Json(channels))
@@ -31,7 +31,7 @@ async fn list_project_channels(
   Path(project_id): Path<Uuid>,
 ) -> Result<Json<Vec<Channel>>, ApiError> {
   let channels =
-    fc_common::repo::channels::list_for_project(&state.pool, project_id)
+    circus_common::repo::channels::list_for_project(&state.pool, project_id)
       .await
       .map_err(ApiError)?;
   Ok(Json(channels))
@@ -41,7 +41,7 @@ async fn get_channel(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Channel>, ApiError> {
-  let channel = fc_common::repo::channels::get(&state.pool, id)
+  let channel = circus_common::repo::channels::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(channel))
@@ -54,17 +54,17 @@ async fn create_channel(
 ) -> Result<Json<Channel>, ApiError> {
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
   let jobset_id = input.jobset_id;
-  let channel = fc_common::repo::channels::create(&state.pool, input)
+  let channel = circus_common::repo::channels::create(&state.pool, input)
     .await
     .map_err(ApiError)?;
 
   // Catch-up: if the jobset already has a completed evaluation, promote now
   if let Ok(Some(eval)) =
-    fc_common::repo::evaluations::get_latest(&state.pool, jobset_id).await
-    && eval.status == fc_common::models::EvaluationStatus::Completed
-    && let Err(e) = fc_common::repo::channels::auto_promote_if_complete(
+    circus_common::repo::evaluations::get_latest(&state.pool, jobset_id).await
+    && eval.status == circus_common::models::EvaluationStatus::Completed
+    && let Err(e) = circus_common::repo::channels::auto_promote_if_complete(
       &state.pool,
       jobset_id,
       eval.id,
@@ -75,7 +75,7 @@ async fn create_channel(
   }
 
   // Re-fetch to include any promotion
-  let channel = fc_common::repo::channels::get(&state.pool, channel.id)
+  let channel = circus_common::repo::channels::get(&state.pool, channel.id)
     .await
     .map_err(ApiError)?;
   Ok(Json(channel))
@@ -86,7 +86,7 @@ async fn delete_channel(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-  fc_common::repo::channels::delete(&state.pool, id)
+  circus_common::repo::channels::delete(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(serde_json::json!({"deleted": true})))
@@ -98,7 +98,7 @@ async fn promote_channel(
   Path((channel_id, eval_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<Channel>, ApiError> {
   let channel =
-    fc_common::repo::channels::promote(&state.pool, channel_id, eval_id)
+    circus_common::repo::channels::promote(&state.pool, channel_id, eval_id)
       .await
       .map_err(ApiError)?;
   Ok(Json(channel))
@@ -111,20 +111,22 @@ async fn nixexprs_tarball(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Response, ApiError> {
-  let channel = fc_common::repo::channels::get(&state.pool, id)
+  let channel = circus_common::repo::channels::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
 
   let evaluation_id = channel.current_evaluation_id.ok_or_else(|| {
-    ApiError(fc_common::CiError::NotFound(
+    ApiError(circus_common::CiError::NotFound(
       "Channel has no current evaluation".to_string(),
     ))
   })?;
 
-  let builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, evaluation_id)
-      .await
-      .map_err(ApiError)?;
+  let builds = circus_common::repo::builds::list_for_evaluation(
+    &state.pool,
+    evaluation_id,
+  )
+  .await
+  .map_err(ApiError)?;
 
   let succeeded: Vec<_> = builds
     .iter()
@@ -132,7 +134,7 @@ async fn nixexprs_tarball(
     .collect();
 
   if succeeded.is_empty() {
-    return Err(ApiError(fc_common::CiError::NotFound(
+    return Err(ApiError(circus_common::CiError::NotFound(
       "No succeeded builds in current evaluation".to_string(),
     )));
   }
@@ -201,9 +203,11 @@ async fn nixexprs_tarball(
     })
     .await
     .map_err(|e| {
-      ApiError(fc_common::CiError::Build(format!("Task join error: {e}")))
+      ApiError(circus_common::CiError::Build(format!(
+        "Task join error: {e}"
+      )))
     })?
-    .map_err(|e| ApiError(fc_common::CiError::Build(e)))?;
+    .map_err(|e| ApiError(circus_common::CiError::Build(e)))?;
 
   Ok(
     (

--- a/crates/server/src/routes/dashboard.rs
+++ b/crates/server/src/routes/dashboard.rs
@@ -7,7 +7,7 @@ use axum::{
   response::{Html, IntoResponse, Redirect, Response},
   routing::get,
 };
-use fc_common::models::{
+use circus_common::models::{
   ApiKey,
   Build,
   BuildProduct,
@@ -457,34 +457,39 @@ async fn home(
   State(state): State<AppState>,
   extensions: Extensions,
 ) -> Html<String> {
-  let build_stats = fc_common::repo::builds::get_stats(&state.pool)
+  let build_stats = circus_common::repo::builds::get_stats(&state.pool)
     .await
     .unwrap_or_default();
-  let builds = fc_common::repo::builds::list_recent(&state.pool, 10)
+  let builds = circus_common::repo::builds::list_recent(&state.pool, 10)
     .await
     .unwrap_or_default();
-  let evals =
-    fc_common::repo::evaluations::list_filtered(&state.pool, None, None, 5, 0)
-      .await
-      .unwrap_or_default();
+  let evals = circus_common::repo::evaluations::list_filtered(
+    &state.pool,
+    None,
+    None,
+    5,
+    0,
+  )
+  .await
+  .unwrap_or_default();
 
   // Fetch project summaries
-  let all_projects = fc_common::repo::projects::list(&state.pool, 10, 0)
+  let all_projects = circus_common::repo::projects::list(&state.pool, 10, 0)
     .await
     .unwrap_or_default();
   let mut project_summaries = Vec::new();
   for p in &all_projects {
     let jobset_count =
-      fc_common::repo::jobsets::count_for_project(&state.pool, p.id)
+      circus_common::repo::jobsets::count_for_project(&state.pool, p.id)
         .await
         .unwrap_or(0);
     let jobsets =
-      fc_common::repo::jobsets::list_for_project(&state.pool, p.id, 100, 0)
+      circus_common::repo::jobsets::list_for_project(&state.pool, p.id, 100, 0)
         .await
         .unwrap_or_default();
     let mut last_eval: Option<Evaluation> = None;
     for js in &jobsets {
-      let js_evals = fc_common::repo::evaluations::list_filtered(
+      let js_evals = circus_common::repo::evaluations::list_filtered(
         &state.pool,
         Some(js.id),
         None,
@@ -550,10 +555,10 @@ async fn projects_page(
 ) -> Html<String> {
   let limit = params.limit.unwrap_or(50).clamp(1, 200);
   let offset = params.offset.unwrap_or(0).max(0);
-  let items = fc_common::repo::projects::list(&state.pool, limit, offset)
+  let items = circus_common::repo::projects::list(&state.pool, limit, offset)
     .await
     .unwrap_or_default();
-  let total = fc_common::repo::projects::count(&state.pool)
+  let total = circus_common::repo::projects::count(&state.pool)
     .await
     .unwrap_or(0);
 
@@ -583,19 +588,19 @@ async fn project_page(
   Path(id): Path<Uuid>,
   extensions: Extensions,
 ) -> Html<String> {
-  let Ok(project) = fc_common::repo::projects::get(&state.pool, id).await
+  let Ok(project) = circus_common::repo::projects::get(&state.pool, id).await
   else {
     return Html("Project not found".to_string());
   };
   let jobsets =
-    fc_common::repo::jobsets::list_for_project(&state.pool, id, 100, 0)
+    circus_common::repo::jobsets::list_for_project(&state.pool, id, 100, 0)
       .await
       .unwrap_or_default();
 
   // Get evaluations for this project's jobsets
   let mut evals = Vec::new();
   for js in &jobsets {
-    let mut js_evals = fc_common::repo::evaluations::list_filtered(
+    let mut js_evals = circus_common::repo::evaluations::list_filtered(
       &state.pool,
       Some(js.id),
       None,
@@ -627,16 +632,17 @@ async fn jobset_page(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Html<String> {
-  let Ok(jobset) = fc_common::repo::jobsets::get(&state.pool, id).await else {
+  let Ok(jobset) = circus_common::repo::jobsets::get(&state.pool, id).await
+  else {
     return Html("Jobset not found".to_string());
   };
   let Ok(project) =
-    fc_common::repo::projects::get(&state.pool, jobset.project_id).await
+    circus_common::repo::projects::get(&state.pool, jobset.project_id).await
   else {
     return Html("Project not found".to_string());
   };
 
-  let evals = fc_common::repo::evaluations::list_filtered(
+  let evals = circus_common::repo::evaluations::list_filtered(
     &state.pool,
     Some(id),
     None,
@@ -654,7 +660,7 @@ async fn jobset_page(
     } else {
       e.commit_hash.clone()
     };
-    let succeeded = fc_common::repo::builds::count_filtered(
+    let succeeded = circus_common::repo::builds::count_filtered(
       &state.pool,
       Some(e.id),
       Some("completed"),
@@ -663,7 +669,7 @@ async fn jobset_page(
     )
     .await
     .unwrap_or(0);
-    let failed = fc_common::repo::builds::count_filtered(
+    let failed = circus_common::repo::builds::count_filtered(
       &state.pool,
       Some(e.id),
       Some("failed"),
@@ -672,7 +678,7 @@ async fn jobset_page(
     )
     .await
     .unwrap_or(0);
-    let pending = fc_common::repo::builds::count_filtered(
+    let pending = circus_common::repo::builds::count_filtered(
       &state.pool,
       Some(e.id),
       Some("pending"),
@@ -712,7 +718,7 @@ async fn evaluations_page(
 ) -> Html<String> {
   let limit = params.limit.unwrap_or(50).clamp(1, 200);
   let offset = params.offset.unwrap_or(0).max(0);
-  let items = fc_common::repo::evaluations::list_filtered(
+  let items = circus_common::repo::evaluations::list_filtered(
     &state.pool,
     None,
     None,
@@ -722,7 +728,7 @@ async fn evaluations_page(
   .await
   .unwrap_or_default();
   let total =
-    fc_common::repo::evaluations::count_filtered(&state.pool, None, None)
+    circus_common::repo::evaluations::count_filtered(&state.pool, None, None)
       .await
       .unwrap_or(0);
 
@@ -730,10 +736,10 @@ async fn evaluations_page(
   let mut enriched = Vec::new();
   for e in &items {
     let (jname, pname) =
-      match fc_common::repo::jobsets::get(&state.pool, e.jobset_id).await {
+      match circus_common::repo::jobsets::get(&state.pool, e.jobset_id).await {
         Ok(js) => {
           let pname =
-            fc_common::repo::projects::get(&state.pool, js.project_id)
+            circus_common::repo::projects::get(&state.pool, js.project_id)
               .await
               .map_or_else(|_| "-".to_string(), |p| p.name);
           (js.name, pname)
@@ -766,23 +772,23 @@ async fn evaluation_page(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Html<String> {
-  let Ok(eval) = fc_common::repo::evaluations::get(&state.pool, id).await
+  let Ok(eval) = circus_common::repo::evaluations::get(&state.pool, id).await
   else {
     return Html("Evaluation not found".to_string());
   };
 
   let Ok(jobset) =
-    fc_common::repo::jobsets::get(&state.pool, eval.jobset_id).await
+    circus_common::repo::jobsets::get(&state.pool, eval.jobset_id).await
   else {
     return Html("Jobset not found".to_string());
   };
   let Ok(project) =
-    fc_common::repo::projects::get(&state.pool, jobset.project_id).await
+    circus_common::repo::projects::get(&state.pool, jobset.project_id).await
   else {
     return Html("Project not found".to_string());
   };
 
-  let builds = fc_common::repo::builds::list_filtered(
+  let builds = circus_common::repo::builds::list_filtered(
     &state.pool,
     Some(id),
     None,
@@ -794,7 +800,7 @@ async fn evaluation_page(
   .await
   .unwrap_or_default();
 
-  let succeeded = fc_common::repo::builds::count_filtered(
+  let succeeded = circus_common::repo::builds::count_filtered(
     &state.pool,
     Some(id),
     Some("completed"),
@@ -803,7 +809,7 @@ async fn evaluation_page(
   )
   .await
   .unwrap_or(0);
-  let failed = fc_common::repo::builds::count_filtered(
+  let failed = circus_common::repo::builds::count_filtered(
     &state.pool,
     Some(id),
     Some("failed"),
@@ -812,7 +818,7 @@ async fn evaluation_page(
   )
   .await
   .unwrap_or(0);
-  let running = fc_common::repo::builds::count_filtered(
+  let running = circus_common::repo::builds::count_filtered(
     &state.pool,
     Some(id),
     Some("running"),
@@ -821,7 +827,7 @@ async fn evaluation_page(
   )
   .await
   .unwrap_or(0);
-  let pending = fc_common::repo::builds::count_filtered(
+  let pending = circus_common::repo::builds::count_filtered(
     &state.pool,
     Some(id),
     Some("pending"),
@@ -865,7 +871,7 @@ async fn builds_page(
 ) -> Html<String> {
   let limit = params.limit.unwrap_or(50).clamp(1, 200);
   let offset = params.offset.unwrap_or(0).max(0);
-  let items = fc_common::repo::builds::list_filtered(
+  let items = circus_common::repo::builds::list_filtered(
     &state.pool,
     None,
     params.status.as_deref(),
@@ -876,7 +882,7 @@ async fn builds_page(
   )
   .await
   .unwrap_or_default();
-  let total = fc_common::repo::builds::count_filtered(
+  let total = circus_common::repo::builds::count_filtered(
     &state.pool,
     None,
     params.status.as_deref(),
@@ -912,22 +918,24 @@ async fn build_page(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Html<String> {
-  let Ok(build) = fc_common::repo::builds::get(&state.pool, id).await else {
+  let Ok(build) = circus_common::repo::builds::get(&state.pool, id).await
+  else {
     return Html("Build not found".to_string());
   };
 
   let Ok(eval) =
-    fc_common::repo::evaluations::get(&state.pool, build.evaluation_id).await
+    circus_common::repo::evaluations::get(&state.pool, build.evaluation_id)
+      .await
   else {
     return Html("Evaluation not found".to_string());
   };
   let Ok(jobset) =
-    fc_common::repo::jobsets::get(&state.pool, eval.jobset_id).await
+    circus_common::repo::jobsets::get(&state.pool, eval.jobset_id).await
   else {
     return Html("Jobset not found".to_string());
   };
   let Ok(project) =
-    fc_common::repo::projects::get(&state.pool, jobset.project_id).await
+    circus_common::repo::projects::get(&state.pool, jobset.project_id).await
   else {
     return Html("Project not found".to_string());
   };
@@ -938,11 +946,11 @@ async fn build_page(
     eval.commit_hash.clone()
   };
 
-  let steps = fc_common::repo::build_steps::list_for_build(&state.pool, id)
+  let steps = circus_common::repo::build_steps::list_for_build(&state.pool, id)
     .await
     .unwrap_or_default();
   let products =
-    fc_common::repo::build_products::list_for_build(&state.pool, id)
+    circus_common::repo::build_products::list_for_build(&state.pool, id)
       .await
       .unwrap_or_default();
 
@@ -965,7 +973,7 @@ async fn build_page(
 }
 
 async fn queue_page(State(state): State<AppState>) -> Html<String> {
-  let running = fc_common::repo::builds::list_filtered(
+  let running = circus_common::repo::builds::list_filtered(
     &state.pool,
     None,
     Some("running"),
@@ -976,7 +984,7 @@ async fn queue_page(State(state): State<AppState>) -> Html<String> {
   )
   .await
   .unwrap_or_default();
-  let pending = fc_common::repo::builds::list_filtered(
+  let pending = circus_common::repo::builds::list_filtered(
     &state.pool,
     None,
     Some("pending"),
@@ -989,7 +997,7 @@ async fn queue_page(State(state): State<AppState>) -> Html<String> {
   .unwrap_or_default();
 
   // Build builder ID -> name map
-  let builders = fc_common::repo::remote_builders::list(&state.pool)
+  let builders = circus_common::repo::remote_builders::list(&state.pool)
     .await
     .unwrap_or_default();
   let builder_map: std::collections::HashMap<Uuid, String> =
@@ -1068,7 +1076,7 @@ fn format_elapsed(secs: i64) -> String {
 }
 
 async fn channels_page(State(state): State<AppState>) -> Html<String> {
-  let channels = fc_common::repo::channels::list_all(&state.pool)
+  let channels = circus_common::repo::channels::list_all(&state.pool)
     .await
     .unwrap_or_default();
 
@@ -1098,10 +1106,10 @@ async fn admin_page(
     .fetch_one(pool)
     .await
     .unwrap_or((0,));
-  let build_stats = fc_common::repo::builds::get_stats(pool)
+  let build_stats = circus_common::repo::builds::get_stats(pool)
     .await
     .unwrap_or_default();
-  let builders_count = fc_common::repo::remote_builders::count(pool)
+  let builders_count = circus_common::repo::remote_builders::count(pool)
     .await
     .unwrap_or(0);
   let channels: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM channels")
@@ -1120,12 +1128,12 @@ async fn admin_page(
     remote_builders:   builders_count,
     channels_count:    channels.0,
   };
-  let raw_builders = fc_common::repo::remote_builders::list(pool)
+  let raw_builders = circus_common::repo::remote_builders::list(pool)
     .await
     .unwrap_or_default();
 
   // Get running builds to calculate builder load
-  let running_builds = fc_common::repo::builds::list_filtered(
+  let running_builds = circus_common::repo::builds::list_filtered(
     pool,
     None,
     Some("running"),
@@ -1171,7 +1179,7 @@ async fn admin_page(
     .collect();
 
   // Fetch API keys for admin view
-  let keys = fc_common::repo::api_keys::list(pool)
+  let keys = circus_common::repo::api_keys::list(pool)
     .await
     .unwrap_or_default();
   let api_keys: Vec<ApiKeyView> = keys
@@ -1244,13 +1252,13 @@ async fn login_action(
   if let (Some(username), Some(password)) =
     (form.username.as_ref(), form.password.as_ref())
   {
-    let creds = fc_common::models::LoginCredentials {
+    let creds = circus_common::models::LoginCredentials {
       username: username.clone(),
       password: password.clone(),
     };
 
     if let Ok(user) =
-      fc_common::repo::users::authenticate(&state.pool, &creds).await
+      circus_common::repo::users::authenticate(&state.pool, &creds).await
     {
       let session_id = Uuid::new_v4().to_string();
       state
@@ -1264,7 +1272,8 @@ async fn login_action(
       let security_flags =
         crate::routes::cookie_security_flags(&state.config.server);
       let cookie = format!(
-        "fc_user_session={session_id}; {security_flags}; Path=/; Max-Age=86400"
+        "circus_user_session={session_id}; {security_flags}; Path=/; \
+         Max-Age=86400"
       );
       return (
         [(axum::http::header::SET_COOKIE, cookie)],
@@ -1307,7 +1316,7 @@ async fn login_action(
     let key_hash = hex::encode(hasher.finalize());
 
     if let Ok(Some(api_key)) =
-      fc_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
+      circus_common::repo::api_keys::get_by_hash(&state.pool, &key_hash).await
     {
       let session_id = Uuid::new_v4().to_string();
       state
@@ -1321,7 +1330,7 @@ async fn login_action(
       let security_flags =
         crate::routes::cookie_security_flags(&state.config.server);
       let cookie = format!(
-        "fc_session={session_id}; {security_flags}; Path=/; Max-Age=86400"
+        "circus_session={session_id}; {security_flags}; Path=/; Max-Age=86400"
       );
       (
         [(axum::http::header::SET_COOKIE, cookie)],
@@ -1368,7 +1377,7 @@ async fn logout_action(
     if let Some(session_id) = cookie_header.split(';').find_map(|pair| {
       let pair = pair.trim();
       let (k, v) = pair.split_once('=')?;
-      if k.trim() == "fc_user_session" {
+      if k.trim() == "circus_user_session" {
         Some(v.trim().to_string())
       } else {
         None
@@ -1381,7 +1390,7 @@ async fn logout_action(
     if let Some(session_id) = cookie_header.split(';').find_map(|pair| {
       let pair = pair.trim();
       let (k, v) = pair.split_once('=')?;
-      if k.trim() == "fc_session" {
+      if k.trim() == "circus_session" {
         Some(v.trim().to_string())
       } else {
         None
@@ -1393,8 +1402,8 @@ async fn logout_action(
 
   // Clear both cookies
   let cookies = [
-    "fc_user_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0",
-    "fc_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0",
+    "circus_user_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0",
+    "circus_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0",
   ];
   (
     [
@@ -1419,10 +1428,10 @@ async fn users_page(
   let limit = params.limit.unwrap_or(50).clamp(1, 200);
   let offset = params.offset.unwrap_or(0).max(0);
 
-  let users_list = fc_common::repo::users::list(&state.pool, limit, offset)
+  let users_list = circus_common::repo::users::list(&state.pool, limit, offset)
     .await
     .unwrap_or_default();
-  let total = fc_common::repo::users::count(&state.pool)
+  let total = circus_common::repo::users::count(&state.pool)
     .await
     .unwrap_or(0);
 
@@ -1430,10 +1439,10 @@ async fn users_page(
     .into_iter()
     .map(|u| {
       let user_type = match u.user_type {
-        fc_common::models::UserType::Local => "Local",
-        fc_common::models::UserType::Github => "GitHub",
-        fc_common::models::UserType::Google => "Google",
-        fc_common::models::UserType::Ldap => "LDAP",
+        circus_common::models::UserType::Local => "Local",
+        circus_common::models::UserType::Github => "GitHub",
+        circus_common::models::UserType::Google => "Google",
+        circus_common::models::UserType::Ldap => "LDAP",
       };
       UserView {
         id:            u.id,
@@ -1477,26 +1486,30 @@ async fn starred_page(
   extensions: Extensions,
 ) -> Html<String> {
   // Check if user is logged in via session
-  let user = extensions.get::<fc_common::models::User>().cloned();
+  let user = extensions.get::<circus_common::models::User>().cloned();
   let is_logged_in = user.is_some();
 
   let starred_jobs = if let Some(ref u) = user {
-    let starred =
-      fc_common::repo::starred_jobs::list_for_user(&state.pool, u.id, 100, 0)
-        .await
-        .unwrap_or_default();
+    let starred = circus_common::repo::starred_jobs::list_for_user(
+      &state.pool,
+      u.id,
+      100,
+      0,
+    )
+    .await
+    .unwrap_or_default();
 
     let mut views = Vec::new();
     for s in starred {
       // Get project name
       let project_name =
-        fc_common::repo::projects::get(&state.pool, s.project_id)
+        circus_common::repo::projects::get(&state.pool, s.project_id)
           .await
           .map_or_else(|_| "-".to_string(), |p| p.name);
 
       // Get jobset name
       let jobset_name = if let Some(js_id) = s.jobset_id {
-        fc_common::repo::jobsets::get(&state.pool, js_id)
+        circus_common::repo::jobsets::get(&state.pool, js_id)
           .await
           .map_or_else(|_| "-".to_string(), |j| j.name)
       } else {
@@ -1507,7 +1520,7 @@ async fn starred_page(
       let (status_text, status_class, latest_build_id) =
         if let Some(js_id) = s.jobset_id {
           // Get latest evaluation for this jobset to find relevant builds
-          let evals = fc_common::repo::evaluations::list_filtered(
+          let evals = circus_common::repo::evaluations::list_filtered(
             &state.pool,
             Some(js_id),
             None,
@@ -1518,7 +1531,7 @@ async fn starred_page(
           .unwrap_or_default();
 
           let builds = if let Some(eval) = evals.first() {
-            fc_common::repo::builds::list_filtered(
+            circus_common::repo::builds::list_filtered(
               &state.pool,
               Some(eval.id),
               None,
@@ -1637,10 +1650,10 @@ async fn notifications_page(
   Path(project_id): Path<Uuid>,
   extensions: Extensions,
 ) -> Result<Html<String>, Response> {
-  let project = fc_common::repo::projects::get(&state.pool, project_id)
+  let project = circus_common::repo::projects::get(&state.pool, project_id)
     .await
     .map_err(|_| Redirect::to("/projects").into_response())?;
-  let configs = fc_common::repo::notification_configs::list_for_project(
+  let configs = circus_common::repo::notification_configs::list_for_project(
     &state.pool,
     project_id,
   )
@@ -1708,12 +1721,12 @@ async fn notifications_create(
         )
           .into_response()
       })?;
-    fc_common::validate::validate_webhook_url(url_str).map_err(|e| {
+    circus_common::validate::validate_webhook_url(url_str).map_err(|e| {
       (StatusCode::BAD_REQUEST, format!("Invalid URL: {e}")).into_response()
     })?;
   }
 
-  fc_common::repo::notification_configs::create(
+  circus_common::repo::notification_configs::create(
     &state.pool,
     CreateNotificationConfig {
       project_id,
@@ -1741,7 +1754,7 @@ async fn notifications_delete(
     return Err((StatusCode::FORBIDDEN, "Admin required").into_response());
   }
   check_csrf(&extensions, &form.csrf_token)?;
-  fc_common::repo::notification_configs::delete_for_project(
+  circus_common::repo::notification_configs::delete_for_project(
     &state.pool,
     project_id,
     config_id,

--- a/crates/server/src/routes/evaluations.rs
+++ b/crates/server/src/routes/evaluations.rs
@@ -7,7 +7,7 @@ use axum::{
   http::Extensions,
   routing::{get, post},
 };
-use fc_common::{
+use circus_common::{
   CreateEvaluation,
   Evaluation,
   PaginatedResponse,
@@ -37,7 +37,7 @@ async fn list_evaluations(
   };
   let limit = pagination.limit();
   let offset = pagination.offset();
-  let items = fc_common::repo::evaluations::list_filtered(
+  let items = circus_common::repo::evaluations::list_filtered(
     &state.pool,
     params.jobset_id,
     params.status.as_deref(),
@@ -46,7 +46,7 @@ async fn list_evaluations(
   )
   .await
   .map_err(ApiError)?;
-  let total = fc_common::repo::evaluations::count_filtered(
+  let total = circus_common::repo::evaluations::count_filtered(
     &state.pool,
     params.jobset_id,
     params.status.as_deref(),
@@ -65,7 +65,7 @@ async fn get_evaluation(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Evaluation>, ApiError> {
-  let evaluation = fc_common::repo::evaluations::get(&state.pool, id)
+  let evaluation = circus_common::repo::evaluations::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(evaluation))
@@ -78,15 +78,17 @@ async fn trigger_evaluation(
 ) -> Result<Json<Evaluation>, ApiError> {
   RequireRoles::check(&extensions, &["eval-jobset"]).map_err(|s| {
     ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
     } else {
-      fc_common::CiError::Unauthorized("Authentication required".to_string())
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
     })
   })?;
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  let evaluation = fc_common::repo::evaluations::create(&state.pool, input)
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  let evaluation = circus_common::repo::evaluations::create(&state.pool, input)
     .await
     .map_err(ApiError)?;
   Ok(Json(evaluation))
@@ -131,27 +133,27 @@ async fn compare_evaluations(
   Query(params): Query<CompareParams>,
 ) -> Result<Json<EvalComparison>, ApiError> {
   // Verify both evaluations exist
-  let _from_eval = fc_common::repo::evaluations::get(&state.pool, id)
+  let _from_eval = circus_common::repo::evaluations::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
-  let _to_eval = fc_common::repo::evaluations::get(&state.pool, params.to)
+  let _to_eval = circus_common::repo::evaluations::get(&state.pool, params.to)
     .await
     .map_err(ApiError)?;
 
   let from_builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, id)
+    circus_common::repo::builds::list_for_evaluation(&state.pool, id)
       .await
       .map_err(ApiError)?;
   let to_builds =
-    fc_common::repo::builds::list_for_evaluation(&state.pool, params.to)
+    circus_common::repo::builds::list_for_evaluation(&state.pool, params.to)
       .await
       .map_err(ApiError)?;
 
-  let from_map: HashMap<&str, &fc_common::Build> = from_builds
+  let from_map: HashMap<&str, &circus_common::Build> = from_builds
     .iter()
     .map(|b| (b.job_name.as_str(), b))
     .collect();
-  let to_map: HashMap<&str, &fc_common::Build> =
+  let to_map: HashMap<&str, &circus_common::Build> =
     to_builds.iter().map(|b| (b.job_name.as_str(), b)).collect();
 
   let mut new_jobs = Vec::new();

--- a/crates/server/src/routes/jobsets.rs
+++ b/crates/server/src/routes/jobsets.rs
@@ -4,7 +4,7 @@ use axum::{
   extract::{Path, State},
   routing::get,
 };
-use fc_common::{Jobset, JobsetInput, UpdateJobset, Validate};
+use circus_common::{Jobset, JobsetInput, UpdateJobset, Validate};
 use serde::Deserialize;
 use uuid::Uuid;
 
@@ -14,7 +14,7 @@ async fn get_jobset(
   State(state): State<AppState>,
   Path((_project_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<Jobset>, ApiError> {
-  let jobset = fc_common::repo::jobsets::get(&state.pool, id)
+  let jobset = circus_common::repo::jobsets::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(jobset))
@@ -28,8 +28,8 @@ async fn update_jobset(
 ) -> Result<Json<Jobset>, ApiError> {
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  let jobset = fc_common::repo::jobsets::update(&state.pool, id, input)
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  let jobset = circus_common::repo::jobsets::update(&state.pool, id, input)
     .await
     .map_err(ApiError)?;
   Ok(Json(jobset))
@@ -40,7 +40,7 @@ async fn delete_jobset(
   State(state): State<AppState>,
   Path((_project_id, id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-  fc_common::repo::jobsets::delete(&state.pool, id)
+  circus_common::repo::jobsets::delete(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(serde_json::json!({ "deleted": true })))
@@ -53,7 +53,7 @@ async fn list_jobset_inputs(
   Path((_project_id, jobset_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<Vec<JobsetInput>>, ApiError> {
   let inputs =
-    fc_common::repo::jobset_inputs::list_for_jobset(&state.pool, jobset_id)
+    circus_common::repo::jobset_inputs::list_for_jobset(&state.pool, jobset_id)
       .await
       .map_err(ApiError)?;
   Ok(Json(inputs))
@@ -73,7 +73,7 @@ async fn create_jobset_input(
   Path((_project_id, jobset_id)): Path<(Uuid, Uuid)>,
   Json(body): Json<CreateJobsetInputRequest>,
 ) -> Result<Json<JobsetInput>, ApiError> {
-  let input = fc_common::repo::jobset_inputs::create(
+  let input = circus_common::repo::jobset_inputs::create(
     &state.pool,
     jobset_id,
     &body.name,
@@ -91,7 +91,7 @@ async fn delete_jobset_input(
   State(state): State<AppState>,
   Path((_project_id, _jobset_id, input_id)): Path<(Uuid, Uuid, Uuid)>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-  fc_common::repo::jobset_inputs::delete(&state.pool, input_id)
+  circus_common::repo::jobset_inputs::delete(&state.pool, input_id)
     .await
     .map_err(ApiError)?;
   Ok(Json(serde_json::json!({ "deleted": true })))

--- a/crates/server/src/routes/ldap.rs
+++ b/crates/server/src/routes/ldap.rs
@@ -14,7 +14,7 @@ use axum::{
   response::{IntoResponse, Response},
   routing::post,
 };
-use fc_common::{models::UserType, repo};
+use circus_common::{models::UserType, repo};
 use serde::Deserialize;
 
 use crate::{error::ApiError, routes::cookie_security_flags, state::AppState};
@@ -105,7 +105,7 @@ async fn ldap_login(
     .map_err(ApiError)?;
 
   let cookie = format!(
-    "fc_user_session={}; {}; Path=/; Max-Age={}",
+    "circus_user_session={}; {}; Path=/; Max-Age={}",
     session.0,
     cookie_security_flags(&state.config.server),
     7 * 24 * 60 * 60

--- a/crates/server/src/routes/logs.rs
+++ b/crates/server/src/routes/logs.rs
@@ -19,13 +19,14 @@ async fn get_build_log(
   Path(id): Path<Uuid>,
 ) -> Result<Response, ApiError> {
   // Verify build exists
-  let _build = fc_common::repo::builds::get(&state.pool, id)
+  let _build = circus_common::repo::builds::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
 
-  let log_storage =
-    fc_common::log_storage::LogStorage::new(state.config.logs.log_dir.clone())
-      .map_err(|e| ApiError(fc_common::CiError::Io(e)))?;
+  let log_storage = circus_common::log_storage::LogStorage::new(
+    state.config.logs.log_dir.clone(),
+  )
+  .map_err(|e| ApiError(circus_common::CiError::Io(e)))?;
 
   match log_storage.read_log(&id) {
     Ok(Some(content)) => {
@@ -44,7 +45,7 @@ async fn get_build_log(
           .into_response(),
       )
     },
-    Err(e) => Err(ApiError(fc_common::CiError::Io(e))),
+    Err(e) => Err(ApiError(circus_common::CiError::Io(e))),
   }
 }
 
@@ -55,13 +56,14 @@ async fn stream_build_log(
   Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>,
   ApiError,
 > {
-  let build = fc_common::repo::builds::get(&state.pool, id)
+  let build = circus_common::repo::builds::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
 
-  let log_storage =
-    fc_common::log_storage::LogStorage::new(state.config.logs.log_dir.clone())
-      .map_err(|e| ApiError(fc_common::CiError::Io(e)))?;
+  let log_storage = circus_common::log_storage::LogStorage::new(
+    state.config.logs.log_dir.clone(),
+  )
+  .map_err(|e| ApiError(circus_common::CiError::Io(e)))?;
 
   let active_path = log_storage.log_path_for_active(&id);
   let final_path = log_storage.log_path(&id);
@@ -110,9 +112,9 @@ async fn stream_build_log(
                   consecutive_empty += 1;
                   if consecutive_empty > 5 {
                       // Check build status
-                      if let Ok(b) = fc_common::repo::builds::get(&pool, build_id).await
-                          && b.status != fc_common::models::BuildStatus::Running
-                              && b.status != fc_common::models::BuildStatus::Pending {
+                      if let Ok(b) = circus_common::repo::builds::get(&pool, build_id).await
+                          && b.status != circus_common::models::BuildStatus::Running
+                              && b.status != circus_common::models::BuildStatus::Pending {
                               yield Ok(Event::default().event("done").data("Build completed"));
                               return;
                           }

--- a/crates/server/src/routes/metrics.rs
+++ b/crates/server/src/routes/metrics.rs
@@ -66,7 +66,8 @@ fn escape_prometheus_label(s: &str) -> String {
 async fn prometheus_metrics(State(state): State<AppState>) -> Response {
   use std::fmt::Write;
 
-  let Ok(build_stats) = fc_common::repo::builds::get_stats(&state.pool).await
+  let Ok(build_stats) =
+    circus_common::repo::builds::get_stats(&state.pool).await
   else {
     return StatusCode::INTERNAL_SERVER_ERROR.into_response();
   };
@@ -125,130 +126,135 @@ async fn prometheus_metrics(State(state): State<AppState>) -> Response {
   let mut output = String::with_capacity(2048);
 
   // Build counts by status
-  output.push_str("# HELP fc_builds_total Total number of builds by status\n");
-  output.push_str("# TYPE fc_builds_total gauge\n");
+  output
+    .push_str("# HELP circus_builds_total Total number of builds by status\n");
+  output.push_str("# TYPE circus_builds_total gauge\n");
   let _ = writeln!(
     output,
-    "fc_builds_total{{status=\"succeeded\"}} {}",
+    "circus_builds_total{{status=\"succeeded\"}} {}",
     build_stats.completed_builds.unwrap_or(0)
   );
   let _ = writeln!(
     output,
-    "fc_builds_total{{status=\"failed\"}} {}",
+    "circus_builds_total{{status=\"failed\"}} {}",
     build_stats.failed_builds.unwrap_or(0)
   );
   let _ = writeln!(
     output,
-    "fc_builds_total{{status=\"running\"}} {}",
+    "circus_builds_total{{status=\"running\"}} {}",
     build_stats.running_builds.unwrap_or(0)
   );
   let _ = writeln!(
     output,
-    "fc_builds_total{{status=\"pending\"}} {}",
+    "circus_builds_total{{status=\"pending\"}} {}",
     build_stats.pending_builds.unwrap_or(0)
   );
   let _ = writeln!(
     output,
-    "fc_builds_total{{status=\"all\"}} {}",
+    "circus_builds_total{{status=\"all\"}} {}",
     build_stats.total_builds.unwrap_or(0)
   );
 
   // Build duration stats
   output.push_str(
-    "\n# HELP fc_builds_avg_duration_seconds Average build duration in \
+    "\n# HELP circus_builds_avg_duration_seconds Average build duration in \
      seconds\n",
   );
-  output.push_str("# TYPE fc_builds_avg_duration_seconds gauge\n");
+  output.push_str("# TYPE circus_builds_avg_duration_seconds gauge\n");
   let _ = writeln!(
     output,
-    "fc_builds_avg_duration_seconds {:.2}",
+    "circus_builds_avg_duration_seconds {:.2}",
     build_stats.avg_duration_seconds.unwrap_or(0.0)
   );
 
   output.push_str(
-    "\n# HELP fc_builds_duration_seconds Build duration percentiles\n",
+    "\n# HELP circus_builds_duration_seconds Build duration percentiles\n",
   );
-  output.push_str("# TYPE fc_builds_duration_seconds gauge\n");
+  output.push_str("# TYPE circus_builds_duration_seconds gauge\n");
   if let Some(p50) = duration_p50 {
     let _ = writeln!(
       output,
-      "fc_builds_duration_seconds{{quantile=\"0.5\"}} {p50:.2}"
+      "circus_builds_duration_seconds{{quantile=\"0.5\"}} {p50:.2}"
     );
   }
   if let Some(p95) = duration_p95 {
     let _ = writeln!(
       output,
-      "fc_builds_duration_seconds{{quantile=\"0.95\"}} {p95:.2}"
+      "circus_builds_duration_seconds{{quantile=\"0.95\"}} {p95:.2}"
     );
   }
   if let Some(p99) = duration_p99 {
     let _ = writeln!(
       output,
-      "fc_builds_duration_seconds{{quantile=\"0.99\"}} {p99:.2}"
+      "circus_builds_duration_seconds{{quantile=\"0.99\"}} {p99:.2}"
     );
   }
 
   // Evaluations
-  output
-    .push_str("\n# HELP fc_evaluations_total Total number of evaluations\n");
-  output.push_str("# TYPE fc_evaluations_total gauge\n");
-  let _ = writeln!(output, "fc_evaluations_total {eval_count}");
+  output.push_str(
+    "\n# HELP circus_evaluations_total Total number of evaluations\n",
+  );
+  output.push_str("# TYPE circus_evaluations_total gauge\n");
+  let _ = writeln!(output, "circus_evaluations_total {eval_count}");
 
-  output.push_str("\n# HELP fc_evaluations_by_status Evaluations by status\n");
-  output.push_str("# TYPE fc_evaluations_by_status gauge\n");
+  output
+    .push_str("\n# HELP circus_evaluations_by_status Evaluations by status\n");
+  output.push_str("# TYPE circus_evaluations_by_status gauge\n");
   for (status, count) in &eval_by_status {
     let _ = writeln!(
       output,
-      "fc_evaluations_by_status{{status=\"{status}\"}} {count}"
+      "circus_evaluations_by_status{{status=\"{status}\"}} {count}"
     );
   }
 
   // Queue depth (pending builds)
-  output
-    .push_str("\n# HELP fc_queue_depth Number of pending builds in queue\n");
-  output.push_str("# TYPE fc_queue_depth gauge\n");
+  output.push_str(
+    "\n# HELP circus_queue_depth Number of pending builds in queue\n",
+  );
+  output.push_str("# TYPE circus_queue_depth gauge\n");
   let _ = writeln!(
     output,
-    "fc_queue_depth {}",
+    "circus_queue_depth {}",
     build_stats.pending_builds.unwrap_or(0)
   );
 
   // Infrastructure
-  output.push_str("\n# HELP fc_projects_total Total number of projects\n");
-  output.push_str("# TYPE fc_projects_total gauge\n");
-  let _ = writeln!(output, "fc_projects_total {project_count}");
+  output.push_str("\n# HELP circus_projects_total Total number of projects\n");
+  output.push_str("# TYPE circus_projects_total gauge\n");
+  let _ = writeln!(output, "circus_projects_total {project_count}");
 
-  output.push_str("\n# HELP fc_channels_total Total number of channels\n");
-  output.push_str("# TYPE fc_channels_total gauge\n");
-  let _ = writeln!(output, "fc_channels_total {channel_count}");
+  output.push_str("\n# HELP circus_channels_total Total number of channels\n");
+  output.push_str("# TYPE circus_channels_total gauge\n");
+  let _ = writeln!(output, "circus_channels_total {channel_count}");
 
-  output
-    .push_str("\n# HELP fc_remote_builders_active Active remote builders\n");
-  output.push_str("# TYPE fc_remote_builders_active gauge\n");
-  let _ = writeln!(output, "fc_remote_builders_active {builder_count}");
+  output.push_str(
+    "\n# HELP circus_remote_builders_active Active remote builders\n",
+  );
+  output.push_str("# TYPE circus_remote_builders_active gauge\n");
+  let _ = writeln!(output, "circus_remote_builders_active {builder_count}");
 
   // Per-project build counts
   if !per_project.is_empty() {
     output.push_str(
-      "\n# HELP fc_project_builds_completed Completed builds per project\n",
+      "\n# HELP circus_project_builds_completed Completed builds per project\n",
     );
-    output.push_str("# TYPE fc_project_builds_completed gauge\n");
+    output.push_str("# TYPE circus_project_builds_completed gauge\n");
     for (name, completed, _) in &per_project {
       let escaped = escape_prometheus_label(name);
       let _ = writeln!(
         output,
-        "fc_project_builds_completed{{project=\"{escaped}\"}} {completed}"
+        "circus_project_builds_completed{{project=\"{escaped}\"}} {completed}"
       );
     }
     output.push_str(
-      "\n# HELP fc_project_builds_failed Failed builds per project\n",
+      "\n# HELP circus_project_builds_failed Failed builds per project\n",
     );
-    output.push_str("# TYPE fc_project_builds_failed gauge\n");
+    output.push_str("# TYPE circus_project_builds_failed gauge\n");
     for (name, _, failed) in &per_project {
       let escaped = escape_prometheus_label(name);
       let _ = writeln!(
         output,
-        "fc_project_builds_failed{{project=\"{escaped}\"}} {failed}"
+        "circus_project_builds_failed{{project=\"{escaped}\"}} {failed}"
       );
     }
   }
@@ -266,7 +272,7 @@ async fn build_stats_timeseries(
   State(state): State<AppState>,
   Query(params): Query<TimeseriesQuery>,
 ) -> Response {
-  match fc_common::repo::build_metrics::get_build_stats_timeseries(
+  match circus_common::repo::build_metrics::get_build_stats_timeseries(
     &state.pool,
     params.project_id,
     params.jobset_id,
@@ -299,7 +305,7 @@ async fn duration_percentiles_timeseries(
   State(state): State<AppState>,
   Query(params): Query<TimeseriesQuery>,
 ) -> Response {
-  match fc_common::repo::build_metrics::get_duration_percentiles_timeseries(
+  match circus_common::repo::build_metrics::get_duration_percentiles_timeseries(
     &state.pool,
     params.project_id,
     params.jobset_id,
@@ -332,7 +338,7 @@ async fn system_distribution(
   State(state): State<AppState>,
   Query(params): Query<TimeseriesQuery>,
 ) -> Response {
-  match fc_common::repo::build_metrics::get_system_distribution(
+  match circus_common::repo::build_metrics::get_system_distribution(
     &state.pool,
     params.project_id,
     params.hours,

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -30,8 +30,8 @@ use axum::{
   response::{IntoResponse, Response},
   routing::get,
 };
+use circus_common::config::ServerConfig;
 use dashmap::DashMap;
-use fc_common::config::ServerConfig;
 use tower_http::{
   cors::{AllowOrigin, CorsLayer},
   limit::RequestBodyLimitLayer,
@@ -57,7 +57,7 @@ static STYLE_CSS: &str = include_str!("../../static/style.css");
 ///    mode
 #[must_use]
 pub fn cookie_security_flags(
-  config: &fc_common::config::ServerConfig,
+  config: &circus_common::config::ServerConfig,
 ) -> String {
   let is_localhost = config.host == "127.0.0.1"
     || config.host == "localhost"

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -7,7 +7,7 @@ use axum::{
   response::{IntoResponse, Response},
   routing::get,
 };
-use fc_common::{config::GitHubOAuthConfig, models::UserType, repo};
+use circus_common::{config::GitHubOAuthConfig, models::UserType, repo};
 use oauth2::{
   AuthUrl,
   AuthorizationCode,
@@ -119,7 +119,7 @@ async fn github_login(State(state): State<AppState>) -> impl IntoResponse {
   };
 
   let cookie = format!(
-    "fc_oauth_state={}; {}; Path=/; Max-Age=600",
+    "circus_oauth_state={}; {}; Path=/; Max-Age=600",
     csrf_token.secret(),
     security_flags
   );
@@ -139,7 +139,7 @@ async fn github_callback(
   Query(params): Query<OAuthCallbackParams>,
 ) -> Result<impl IntoResponse, ApiError> {
   let Some(config) = &state.config.oauth.github else {
-    return Err(ApiError(fc_common::CiError::NotFound(
+    return Err(ApiError(circus_common::CiError::NotFound(
       "GitHub OAuth not configured".to_string(),
     )));
   };
@@ -151,12 +151,12 @@ async fn github_callback(
     .and_then(|cookies| {
       cookies.split(';').find_map(|c| {
         let c = c.trim();
-        c.strip_prefix("fc_oauth_state=")
+        c.strip_prefix("circus_oauth_state=")
       })
     });
 
   if stored_state != Some(&params.state) {
-    return Err(ApiError(fc_common::CiError::Unauthorized(
+    return Err(ApiError(circus_common::CiError::Unauthorized(
       "Invalid OAuth state".to_string(),
     )));
   }
@@ -168,7 +168,7 @@ async fn github_callback(
     .redirect(oauth2::reqwest::redirect::Policy::none())
     .build()
     .map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "Failed to create HTTP client: {e}"
       )))
     })?;
@@ -179,7 +179,7 @@ async fn github_callback(
     .request_async(&http_client)
     .await
     .map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "Token exchange failed: {e}"
       )))
     })?;
@@ -191,18 +191,18 @@ async fn github_callback(
     .http_client
     .get("https://api.github.com/user")
     .header("Authorization", format!("Bearer {access_token}"))
-    .header("User-Agent", "FC-CI")
+    .header("User-Agent", "circus")
     .header("Accept", "application/vnd.github+json")
     .send()
     .await
     .map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "GitHub API request failed: {e}"
       )))
     })?;
 
   if !user_response.status().is_success() {
-    return Err(ApiError(fc_common::CiError::Internal(format!(
+    return Err(ApiError(circus_common::CiError::Internal(format!(
       "GitHub API returned status: {}",
       user_response.status()
     ))));
@@ -210,7 +210,7 @@ async fn github_callback(
 
   let user_info: GitHubUserResponse =
     user_response.json().await.map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "Failed to parse GitHub user: {e}"
       )))
     })?;
@@ -220,18 +220,18 @@ async fn github_callback(
     .http_client
     .get("https://api.github.com/user/emails")
     .header("Authorization", format!("Bearer {access_token}"))
-    .header("User-Agent", "FC-CI")
+    .header("User-Agent", "circus")
     .header("Accept", "application/vnd.github+json")
     .send()
     .await
     .map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "GitHub emails API failed: {e}"
       )))
     })?;
 
   if !emails_response.status().is_success() {
-    return Err(ApiError(fc_common::CiError::Internal(format!(
+    return Err(ApiError(circus_common::CiError::Internal(format!(
       "GitHub emails API returned status: {}",
       emails_response.status()
     ))));
@@ -239,7 +239,7 @@ async fn github_callback(
 
   let emails: Vec<GitHubEmailResponse> =
     emails_response.json().await.map_err(|e| {
-      ApiError(fc_common::CiError::Internal(format!(
+      ApiError(circus_common::CiError::Internal(format!(
         "Failed to parse GitHub emails: {e}"
       )))
     })?;
@@ -284,9 +284,9 @@ async fn github_callback(
   };
 
   let clear_state =
-    format!("fc_oauth_state=; {security_flags}; Path=/; Max-Age=0");
+    format!("circus_oauth_state=; {security_flags}; Path=/; Max-Age=0");
   let session_cookie = format!(
-    "fc_user_session={}; {}; Path=/; Max-Age={}",
+    "circus_user_session={}; {}; Path=/; Max-Age={}",
     session.0,
     security_flags,
     7 * 24 * 60 * 60 // 7 days
@@ -505,11 +505,11 @@ mod tests {
   fn test_cookie_parsing() {
     // Simulate parsing cookies to find OAuth state
     let cookie_header =
-      "other_cookie=value; fc_oauth_state=abc123; another=xyz";
+      "other_cookie=value; circus_oauth_state=abc123; another=xyz";
 
     let stored_state = cookie_header.split(';').find_map(|c| {
       let c = c.trim();
-      c.strip_prefix("fc_oauth_state=")
+      c.strip_prefix("circus_oauth_state=")
     });
 
     assert_eq!(stored_state, Some("abc123"));
@@ -521,7 +521,7 @@ mod tests {
 
     let stored_state = cookie_header.split(';').find_map(|c| {
       let c = c.trim();
-      c.strip_prefix("fc_oauth_state=")
+      c.strip_prefix("circus_oauth_state=")
     });
 
     assert!(stored_state.is_none());
@@ -534,11 +534,11 @@ mod tests {
     let max_age = 7 * 24 * 60 * 60;
 
     let cookie = format!(
-      "fc_user_session={session_token}; HttpOnly; SameSite=Lax; Path=/; \
+      "circus_user_session={session_token}; HttpOnly; SameSite=Lax; Path=/; \
        Max-Age={max_age}{secure_flag}"
     );
 
-    assert!(cookie.contains("fc_user_session=test-session-token"));
+    assert!(cookie.contains("circus_user_session=test-session-token"));
     assert!(cookie.contains("HttpOnly"));
     assert!(cookie.contains("SameSite=Lax"));
     assert!(cookie.contains("Path=/"));

--- a/crates/server/src/routes/openapi.rs
+++ b/crates/server/src/routes/openapi.rs
@@ -21,9 +21,9 @@ fn document() -> Value {
   json!({
     "openapi": "3.1.0",
     "info": {
-      "title":       "FC CI API",
+      "title":       "circus API",
       "version":     env!("CARGO_PKG_VERSION"),
-      "description": "REST API for the FC continuous integration server.",
+      "description": "REST API for the circus continuous integration server.",
       "license":     { "name": "MPL-2.0" }
     },
     "servers": [

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -5,7 +5,7 @@ use axum::{
   http::Extensions,
   routing::{delete, get, post},
 };
-use fc_common::{
+use circus_common::{
   CreateJobset,
   CreateProject,
   Jobset,
@@ -33,10 +33,10 @@ async fn list_projects(
 ) -> Result<Json<PaginatedResponse<Project>>, ApiError> {
   let limit = pagination.limit();
   let offset = pagination.offset();
-  let items = fc_common::repo::projects::list(&state.pool, limit, offset)
+  let items = circus_common::repo::projects::list(&state.pool, limit, offset)
     .await
     .map_err(ApiError)?;
-  let total = fc_common::repo::projects::count(&state.pool)
+  let total = circus_common::repo::projects::count(&state.pool)
     .await
     .map_err(ApiError)?;
   Ok(Json(PaginatedResponse {
@@ -54,20 +54,22 @@ async fn create_project(
 ) -> Result<Json<Project>, ApiError> {
   RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
     ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
     } else {
-      fc_common::CiError::Unauthorized("Authentication required".to_string())
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
     })
   })?;
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  fc_common::validate::validate_url_scheme(
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  circus_common::validate::validate_url_scheme(
     &input.repository_url,
     &state.config.server.allowed_url_schemes,
   )
-  .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  let project = fc_common::repo::projects::create(&state.pool, input)
+  .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  let project = circus_common::repo::projects::create(&state.pool, input)
     .await
     .map_err(ApiError)?;
   Ok(Json(project))
@@ -77,7 +79,7 @@ async fn get_project(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Project>, ApiError> {
-  let project = fc_common::repo::projects::get(&state.pool, id)
+  let project = circus_common::repo::projects::get(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(project))
@@ -91,15 +93,15 @@ async fn update_project(
 ) -> Result<Json<Project>, ApiError> {
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
   if let Some(ref url) = input.repository_url {
-    fc_common::validate::validate_url_scheme(
+    circus_common::validate::validate_url_scheme(
       url,
       &state.config.server.allowed_url_schemes,
     )
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
   }
-  let project = fc_common::repo::projects::update(&state.pool, id, input)
+  let project = circus_common::repo::projects::update(&state.pool, id, input)
     .await
     .map_err(ApiError)?;
   Ok(Json(project))
@@ -110,7 +112,7 @@ async fn delete_project(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-  fc_common::repo::projects::delete(&state.pool, id)
+  circus_common::repo::projects::delete(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(serde_json::json!({ "deleted": true })))
@@ -123,11 +125,15 @@ async fn list_project_jobsets(
 ) -> Result<Json<PaginatedResponse<Jobset>>, ApiError> {
   let limit = pagination.limit();
   let offset = pagination.offset();
-  let items =
-    fc_common::repo::jobsets::list_for_project(&state.pool, id, limit, offset)
-      .await
-      .map_err(ApiError)?;
-  let total = fc_common::repo::jobsets::count_for_project(&state.pool, id)
+  let items = circus_common::repo::jobsets::list_for_project(
+    &state.pool,
+    id,
+    limit,
+    offset,
+  )
+  .await
+  .map_err(ApiError)?;
+  let total = circus_common::repo::jobsets::count_for_project(&state.pool, id)
     .await
     .map_err(ApiError)?;
   Ok(Json(PaginatedResponse {
@@ -147,7 +153,7 @@ struct CreateJobsetBody {
   check_interval:    Option<i32>,
   branch:            Option<String>,
   scheduling_shares: Option<i32>,
-  state:             Option<fc_common::models::JobsetState>,
+  state:             Option<circus_common::models::JobsetState>,
 }
 
 async fn create_project_jobset(
@@ -158,9 +164,11 @@ async fn create_project_jobset(
 ) -> Result<Json<Jobset>, ApiError> {
   RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
     ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
     } else {
-      fc_common::CiError::Unauthorized("Authentication required".to_string())
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
     })
   })?;
   let input = CreateJobset {
@@ -177,8 +185,8 @@ async fn create_project_jobset(
   };
   input
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  let jobset = fc_common::repo::jobsets::create(&state.pool, input)
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  let jobset = circus_common::repo::jobsets::create(&state.pool, input)
     .await
     .map_err(ApiError)?;
   Ok(Json(jobset))
@@ -230,9 +238,11 @@ async fn setup_project(
 ) -> Result<Json<SetupProjectResponse>, ApiError> {
   RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
     ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
     } else {
-      fc_common::CiError::Unauthorized("Authentication required".to_string())
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
     })
   })?;
 
@@ -243,16 +253,17 @@ async fn setup_project(
   };
   create_project
     .validate()
-    .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-  fc_common::validate::validate_url_scheme(
+    .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+  circus_common::validate::validate_url_scheme(
     &create_project.repository_url,
     &state.config.server.allowed_url_schemes,
   )
-  .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
+  .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
 
-  let project = fc_common::repo::projects::create(&state.pool, create_project)
-    .await
-    .map_err(ApiError)?;
+  let project =
+    circus_common::repo::projects::create(&state.pool, create_project)
+      .await
+      .map_err(ApiError)?;
 
   let mut jobsets = Vec::new();
   for js_input in body.jobsets {
@@ -270,8 +281,8 @@ async fn setup_project(
     };
     input
       .validate()
-      .map_err(|msg| ApiError(fc_common::CiError::Validation(msg)))?;
-    let jobset = fc_common::repo::jobsets::create(&state.pool, input)
+      .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
+    let jobset = circus_common::repo::jobsets::create(&state.pool, input)
       .await
       .map_err(ApiError)?;
     jobsets.push(jobset);
@@ -293,7 +304,7 @@ async fn list_project_webhooks(
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<WebhookConfig>>, ApiError> {
   let configs =
-    fc_common::repo::webhook_configs::list_for_project(&state.pool, id)
+    circus_common::repo::webhook_configs::list_for_project(&state.pool, id)
       .await
       .map_err(ApiError)?;
   Ok(Json(configs))
@@ -307,16 +318,18 @@ async fn create_project_webhook(
 ) -> Result<Json<WebhookConfig>, ApiError> {
   RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
     ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      fc_common::CiError::Forbidden("Insufficient permissions".to_string())
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
     } else {
-      fc_common::CiError::Unauthorized("Authentication required".to_string())
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
     })
   })?;
 
   // Validate forge type
   let valid_forges = ["github", "gitlab", "gitea", "forgejo"];
   if !valid_forges.contains(&body.forge_type.as_str()) {
-    return Err(ApiError(fc_common::CiError::Validation(format!(
+    return Err(ApiError(circus_common::CiError::Validation(format!(
       "Invalid forge_type '{}'. Must be one of: {}",
       body.forge_type,
       valid_forges.join(", ")
@@ -332,7 +345,7 @@ async fn create_project_webhook(
   // For webhook configs, we store the secret directly (used for token
   // comparison) GitHub/Gitea use HMAC verification, GitLab uses direct token
   // comparison
-  let config = fc_common::repo::webhook_configs::create(
+  let config = circus_common::repo::webhook_configs::create(
     &state.pool,
     input,
     body.secret.as_deref(),
@@ -356,17 +369,17 @@ async fn delete_project_webhook(
 ) -> Result<Json<serde_json::Value>, ApiError> {
   // Verify the webhook belongs to the project
   let config =
-    fc_common::repo::webhook_configs::get(&state.pool, params.webhook_id)
+    circus_common::repo::webhook_configs::get(&state.pool, params.webhook_id)
       .await
       .map_err(ApiError)?;
 
   if config.project_id != params.id {
-    return Err(ApiError(fc_common::CiError::NotFound(
+    return Err(ApiError(circus_common::CiError::NotFound(
       "Webhook not found for this project".to_string(),
     )));
   }
 
-  fc_common::repo::webhook_configs::delete(&state.pool, params.webhook_id)
+  circus_common::repo::webhook_configs::delete(&state.pool, params.webhook_id)
     .await
     .map_err(ApiError)?;
 

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -14,7 +14,7 @@ use axum::{
   routing::get,
 };
 use chrono::{DateTime, Utc};
-use fc_common::{
+use circus_common::{
   models::{Build, Evaluation, Jobset, Project},
   repo::search::{
     BuildSearchFilters,

--- a/crates/server/src/routes/users.rs
+++ b/crates/server/src/routes/users.rs
@@ -7,7 +7,7 @@ use axum::{
   http::StatusCode,
   routing::get,
 };
-use fc_common::{
+use circus_common::{
   models::{CreateStarredJob, CreateUser, PaginationParams, UpdateUser, User},
   repo::{self},
 };
@@ -177,10 +177,10 @@ async fn get_current_user(
 
   // Fall back to API key
   let api_key = extensions
-    .get::<fc_common::models::ApiKey>()
+    .get::<circus_common::models::ApiKey>()
     .cloned()
     .ok_or_else(|| {
-      ApiError(fc_common::error::CiError::Unauthorized(
+      ApiError(circus_common::error::CiError::Unauthorized(
         "Not authenticated".to_string(),
       ))
     })?;
@@ -211,7 +211,7 @@ async fn update_current_user(
   Json(req): Json<UpdateUserRequest>,
 ) -> Result<Json<UserResponse>, ApiError> {
   let user = extensions.get::<User>().cloned().ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "User authentication required".to_string(),
     ))
   })?;
@@ -250,22 +250,22 @@ async fn change_password(
   Json(req): Json<ChangePasswordRequest>,
 ) -> Result<StatusCode, ApiError> {
   let user = extensions.get::<User>().cloned().ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "User authentication required".to_string(),
     ))
   })?;
 
   // Verify current password (OAuth users don't have passwords)
   let hash = user.password_hash.ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "OAuth user - use OAuth login".to_string(),
     ))
   })?;
 
-  if !repo::users::verify_password(&req.current_password, &hash)
-    .map_err(|e| ApiError(fc_common::error::CiError::Internal(e.to_string())))?
-  {
-    return Err(ApiError(fc_common::error::CiError::Unauthorized(
+  if !repo::users::verify_password(&req.current_password, &hash).map_err(
+    |e| ApiError(circus_common::error::CiError::Internal(e.to_string())),
+  )? {
+    return Err(ApiError(circus_common::error::CiError::Unauthorized(
       "Current password is incorrect".to_string(),
     )));
   }
@@ -291,7 +291,7 @@ async fn list_starred_jobs(
   Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<StarredJobResponse>>, ApiError> {
   let user = extensions.get::<User>().cloned().ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "User authentication required".to_string(),
     ))
   })?;
@@ -327,7 +327,7 @@ async fn create_starred_job(
   Json(req): Json<CreateStarredJobRequest>,
 ) -> Result<Json<StarredJobResponse>, ApiError> {
   let user = extensions.get::<User>().cloned().ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "User authentication required".to_string(),
     ))
   })?;
@@ -364,7 +364,7 @@ async fn delete_starred_job(
   Path(id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
   let _user = extensions.get::<User>().cloned().ok_or_else(|| {
-    ApiError(fc_common::error::CiError::Unauthorized(
+    ApiError(circus_common::error::CiError::Unauthorized(
       "User authentication required".to_string(),
     ))
   })?;

--- a/crates/server/src/routes/webhooks.rs
+++ b/crates/server/src/routes/webhooks.rs
@@ -6,7 +6,7 @@ use axum::{
   http::{HeaderMap, StatusCode},
   routing::post,
 };
-use fc_common::{models::CreateEvaluation, repo};
+use circus_common::{models::CreateEvaluation, repo};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -217,7 +217,7 @@ async fn handle_github_push(
 ) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
   let payload: GithubPushPayload =
     serde_json::from_slice(body).map_err(|e| {
-      ApiError(fc_common::CiError::Validation(format!(
+      ApiError(circus_common::CiError::Validation(format!(
         "Invalid payload: {e}"
       )))
     })?;
@@ -255,7 +255,7 @@ async fn handle_github_push(
     .await
     {
       Ok(_) => triggered += 1,
-      Err(fc_common::CiError::Conflict(_)) => {}, // already exists
+      Err(circus_common::CiError::Conflict(_)) => {}, // already exists
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
   }
@@ -278,7 +278,7 @@ async fn handle_github_pull_request(
 ) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
   let payload: GithubPullRequestPayload = serde_json::from_slice(body)
     .map_err(|e| {
-      ApiError(fc_common::CiError::Validation(format!(
+      ApiError(circus_common::CiError::Validation(format!(
         "Invalid GitHub PR payload: {e}"
       )))
     })?;
@@ -358,7 +358,7 @@ async fn handle_github_pull_request(
     .await
     {
       Ok(_) => triggered += 1,
-      Err(fc_common::CiError::Conflict(_)) => {},
+      Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
   }
@@ -448,7 +448,7 @@ async fn handle_gitea_push(
 
   let payload: GiteaPushPayload =
     serde_json::from_slice(&body).map_err(|e| {
-      ApiError(fc_common::CiError::Validation(format!(
+      ApiError(circus_common::CiError::Validation(format!(
         "Invalid payload: {e}"
       )))
     })?;
@@ -485,7 +485,7 @@ async fn handle_gitea_push(
     .await
     {
       Ok(_) => triggered += 1,
-      Err(fc_common::CiError::Conflict(_)) => {},
+      Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
   }
@@ -581,7 +581,7 @@ async fn handle_gitlab_push(
 ) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
   let payload: GitLabPushPayload =
     serde_json::from_slice(body).map_err(|e| {
-      ApiError(fc_common::CiError::Validation(format!(
+      ApiError(circus_common::CiError::Validation(format!(
         "Invalid GitLab push payload: {e}"
       )))
     })?;
@@ -620,7 +620,7 @@ async fn handle_gitlab_push(
     .await
     {
       Ok(_) => triggered += 1,
-      Err(fc_common::CiError::Conflict(_)) => {},
+      Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
   }
@@ -643,7 +643,7 @@ async fn handle_gitlab_merge_request(
 ) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
   let payload: GitLabMergeRequestPayload = serde_json::from_slice(body)
     .map_err(|e| {
-      ApiError(fc_common::CiError::Validation(format!(
+      ApiError(circus_common::CiError::Validation(format!(
         "Invalid GitLab MR payload: {e}"
       )))
     })?;
@@ -720,7 +720,7 @@ async fn handle_gitlab_merge_request(
     .await
     {
       Ok(_) => triggered += 1,
-      Err(fc_common::CiError::Conflict(_)) => {},
+      Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
   }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,10 +1,10 @@
 use std::{sync::Arc, time::Instant};
 
-use dashmap::DashMap;
-use fc_common::{
+use circus_common::{
   config::Config,
   models::{ApiKey, User},
 };
+use dashmap::DashMap;
 use sqlx::PgPool;
 
 /// Maximum session lifetime before automatic eviction (24 hours).

--- a/crates/server/templates/admin.html
+++ b/crates/server/templates/admin.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Admin - FC CI{% endblock %}
+{% block title %}Admin - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/base.html
+++ b/crates/server/templates/base.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}FC CI{% endblock %}</title>
+  <title>{% block title %}circus{% endblock %}</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
   <nav class="navbar">
-    <div class="nav-brand"><a href="/">FC CI</a></div>
+    <div class="nav-brand"><a href="/">circus</a></div>
     <div class="nav-links">
       <a href="/projects">Projects</a>
       <a href="/evaluations">Evaluations</a>
@@ -31,7 +31,7 @@
     </div>
   </main>
   <footer class="footer">
-    <p>FC CI &mdash; Nix-based continuous integration</p>
+    <p>circus &mdash; Nix-based continuous integration</p>
   </footer>
   <script>
   function escapeHtml(s) {

--- a/crates/server/templates/build.html
+++ b/crates/server/templates/build.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Build {{ build.job_name }} - FC CI{% endblock %}
+{% block title %}Build {{ build.job_name }} - circus{% endblock %}
 {% block breadcrumbs %}
 <nav class="breadcrumbs">
   <a href="/">Home</a> <span class="sep">/</span>

--- a/crates/server/templates/builds.html
+++ b/crates/server/templates/builds.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Builds - FC CI{% endblock %}
+{% block title %}Builds - circus{% endblock %}
 {% block content %}
 <h1>Builds</h1>
 

--- a/crates/server/templates/channels.html
+++ b/crates/server/templates/channels.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Channels - FC CI{% endblock %}
+{% block title %}Channels - circus{% endblock %}
 {% block content %}
 <h1>Channels</h1>
 {% if channels.is_empty() %}

--- a/crates/server/templates/evaluation.html
+++ b/crates/server/templates/evaluation.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Evaluation {{ eval.commit_short }} - FC CI{% endblock %}
+{% block title %}Evaluation {{ eval.commit_short }} - circus{% endblock %}
 {% block breadcrumbs %}
 <nav class="breadcrumbs">
   <a href="/">Home</a> <span class="sep">/</span>

--- a/crates/server/templates/evaluations.html
+++ b/crates/server/templates/evaluations.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Evaluations - FC CI{% endblock %}
+{% block title %}Evaluations - circus{% endblock %}
 {% block content %}
 <h1>Evaluations</h1>
 {% if evals.is_empty() %}

--- a/crates/server/templates/home.html
+++ b/crates/server/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}FC CI - Dashboard{% endblock %}
+{% block title %}circus - Dashboard{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/jobset.html
+++ b/crates/server/templates/jobset.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ jobset.name }} - FC CI{% endblock %}
+{% block title %}{{ jobset.name }} - circus{% endblock %}
 {% block breadcrumbs %}
 <nav class="breadcrumbs">
   <a href="/">Home</a> <span class="sep">/</span>
@@ -18,13 +18,13 @@
   <dt>State</dt>
   <dd>
     {% match jobset.state %}
-      {% when fc_common::models::JobsetState::Disabled %}
+      {% when circus_common::models::JobsetState::Disabled %}
         <span class="badge badge-cancelled">Disabled</span>
-      {% when fc_common::models::JobsetState::Enabled %}
+      {% when circus_common::models::JobsetState::Enabled %}
         <span class="badge badge-completed">Enabled</span>
-      {% when fc_common::models::JobsetState::OneShot %}
+      {% when circus_common::models::JobsetState::OneShot %}
         <span class="badge badge-pending">One-Shot</span>
-      {% when fc_common::models::JobsetState::OneAtATime %}
+      {% when circus_common::models::JobsetState::OneAtATime %}
         <span class="badge badge-running">One-at-a-Time</span>
     {% endmatch %}
   </dd>

--- a/crates/server/templates/login.html
+++ b/crates/server/templates/login.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Login - FC CI{% endblock %}
+{% block title %}Login - circus{% endblock %}
 {% block content %}
 <div class="login-container">
   <div class="login-card">
-    <h1>FC CI</h1>
+    <h1>circus</h1>
     <p class="login-subtitle">Sign in with your account or API key</p>
     {% match error %}
       {% when Some with (msg) %}

--- a/crates/server/templates/metrics.html
+++ b/crates/server/templates/metrics.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Metrics - FC CI{% endblock %}
+{% block title %}Metrics - circus{% endblock %}
 
 {% block auth %}
 {% if !auth_name.is_empty() %}

--- a/crates/server/templates/project.html
+++ b/crates/server/templates/project.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ project.name }} - FC CI{% endblock %}
+{% block title %}{{ project.name }} - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/project_setup.html
+++ b/crates/server/templates/project_setup.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}New Project - FC CI{% endblock %}
+{% block title %}New Project - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/projects.html
+++ b/crates/server/templates/projects.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Projects - FC CI{% endblock %}
+{% block title %}Projects - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/queue.html
+++ b/crates/server/templates/queue.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Queue - FC CI{% endblock %}
+{% block title %}Queue - circus{% endblock %}
 {% block breadcrumbs %}
 <nav class="breadcrumbs">
   <a href="/">Home</a> <span class="sep">/</span>

--- a/crates/server/templates/starred.html
+++ b/crates/server/templates/starred.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Starred Jobs - FC CI{% endblock %}
+{% block title %}Starred Jobs - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/templates/users.html
+++ b/crates/server/templates/users.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Users - FC CI{% endblock %}
+{% block title %}Users - circus{% endblock %}
 {% block auth %}
 {% if !auth_name.is_empty() %}
 <span class="auth-user">{{ auth_name }}</span>

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -28,16 +28,16 @@ async fn get_pool() -> Option<sqlx::PgPool> {
 }
 
 fn build_app(pool: sqlx::PgPool) -> axum::Router {
-  let config = fc_common::config::Config::default();
+  let config = circus_common::config::Config::default();
   let server_config = config.server.clone();
-  let state = fc_server::state::AppState {
+  let state = circus_server::state::AppState {
     pool,
     config,
     sessions: std::sync::Arc::new(dashmap::DashMap::new()),
     http_client: reqwest::Client::new(),
     csrf_secret: std::sync::Arc::new([0u8; 32]),
   };
-  fc_server::routes::router(state, &server_config)
+  circus_server::routes::router(state, &server_config)
 }
 
 #[tokio::test]
@@ -46,9 +46,9 @@ async fn test_router_no_duplicate_routes() {
     return;
   };
 
-  let config = fc_common::config::Config::default();
+  let config = circus_common::config::Config::default();
   let server_config = config.server.clone();
-  let state = fc_server::state::AppState {
+  let state = circus_server::state::AppState {
     pool,
     config,
     sessions: std::sync::Arc::new(dashmap::DashMap::new()),
@@ -56,22 +56,22 @@ async fn test_router_no_duplicate_routes() {
     csrf_secret: std::sync::Arc::new([0u8; 32]),
   };
 
-  let _app = fc_server::routes::router(state, &server_config);
+  let _app = circus_server::routes::router(state, &server_config);
 }
 
 fn build_app_with_config(
   pool: sqlx::PgPool,
-  config: fc_common::config::Config,
+  config: circus_common::config::Config,
 ) -> axum::Router {
   let server_config = config.server.clone();
-  let state = fc_server::state::AppState {
+  let state = circus_server::state::AppState {
     pool,
     config,
     sessions: std::sync::Arc::new(dashmap::DashMap::new()),
     http_client: reqwest::Client::new(),
     csrf_secret: std::sync::Arc::new([0u8; 32]),
   };
-  fc_server::routes::router(state, &server_config)
+  circus_server::routes::router(state, &server_config)
 }
 
 // API endpoint tests
@@ -274,7 +274,7 @@ async fn test_cache_invalid_hash_returns_404() {
     return;
   };
 
-  let mut config = fc_common::config::Config::default();
+  let mut config = circus_common::config::Config::default();
   config.cache.enabled = true;
   let app = build_app_with_config(pool, config);
 
@@ -350,7 +350,7 @@ async fn test_cache_nar_invalid_hash_returns_404() {
     return;
   };
 
-  let mut config = fc_common::config::Config::default();
+  let mut config = circus_common::config::Config::default();
   config.cache.enabled = true;
   let app = build_app_with_config(pool, config);
 
@@ -387,7 +387,7 @@ async fn test_cache_disabled_returns_404() {
     return;
   };
 
-  let mut config = fc_common::config::Config::default();
+  let mut config = circus_common::config::Config::default();
   config.cache.enabled = false;
   let app = build_app_with_config(pool, config);
 
@@ -585,7 +585,7 @@ async fn test_cache_info_returns_correct_headers() {
     return;
   };
 
-  let mut config = fc_common::config::Config::default();
+  let mut config = circus_common::config::Config::default();
   config.cache.enabled = true;
   let app = build_app_with_config(pool, config);
 
@@ -649,33 +649,33 @@ async fn test_metrics_endpoint() {
   let body_str = String::from_utf8(body.to_vec()).unwrap();
 
   // Verify metric names are present
-  assert!(body_str.contains("fc_builds_total"));
-  assert!(body_str.contains("fc_projects_total"));
-  assert!(body_str.contains("fc_evaluations_total"));
+  assert!(body_str.contains("circus_builds_total"));
+  assert!(body_str.contains("circus_projects_total"));
+  assert!(body_str.contains("circus_evaluations_total"));
 
   // Verify Prometheus format: HELP/TYPE headers and label syntax
   assert!(
-    body_str.contains("# HELP fc_builds_total"),
-    "Missing HELP header for fc_builds_total"
+    body_str.contains("# HELP circus_builds_total"),
+    "Missing HELP header for circus_builds_total"
   );
   assert!(
-    body_str.contains("# TYPE fc_builds_total gauge"),
-    "Missing TYPE header for fc_builds_total"
+    body_str.contains("# TYPE circus_builds_total gauge"),
+    "Missing TYPE header for circus_builds_total"
   );
   assert!(
-    body_str.contains("fc_builds_total{status=\"succeeded\"}"),
+    body_str.contains("circus_builds_total{status=\"succeeded\"}"),
     "Missing succeeded status label"
   );
   assert!(
-    body_str.contains("fc_builds_total{status=\"failed\"}"),
+    body_str.contains("circus_builds_total{status=\"failed\"}"),
     "Missing failed status label"
   );
   assert!(
-    body_str.contains("fc_queue_depth"),
+    body_str.contains("circus_queue_depth"),
     "Missing queue depth metric"
   );
   assert!(
-    body_str.contains("fc_builds_avg_duration_seconds"),
+    body_str.contains("circus_builds_avg_duration_seconds"),
     "Missing avg duration metric"
   );
 
@@ -842,11 +842,15 @@ async fn test_project_create_with_auth() {
 
   // Create an admin API key
   let mut hasher = sha2::Sha256::new();
-  hasher.update(b"fc_test_project_auth");
+  hasher.update(b"circus_test_project_auth");
   let key_hash = hex::encode(hasher.finalize());
-  let _ =
-    fc_common::repo::api_keys::upsert(&pool, "test-auth", &key_hash, "admin")
-      .await;
+  let _ = circus_common::repo::api_keys::upsert(
+    &pool,
+    "test-auth",
+    &key_hash,
+    "admin",
+  )
+  .await;
 
   let app = build_app(pool);
 
@@ -861,7 +865,7 @@ async fn test_project_create_with_auth() {
         .method("POST")
         .uri("/api/v1/projects")
         .header("content-type", "application/json")
-        .header("authorization", "Bearer fc_test_project_auth")
+        .header("authorization", "Bearer circus_test_project_auth")
         .body(Body::from(serde_json::to_vec(&body).unwrap()))
         .unwrap(),
     )
@@ -916,11 +920,15 @@ async fn test_setup_endpoint_creates_project_and_jobsets() {
 
   // Create an admin API key
   let mut hasher = sha2::Sha256::new();
-  hasher.update(b"fc_test_setup_key");
+  hasher.update(b"circus_test_setup_key");
   let key_hash = hex::encode(hasher.finalize());
-  let _ =
-    fc_common::repo::api_keys::upsert(&pool, "test-setup", &key_hash, "admin")
-      .await;
+  let _ = circus_common::repo::api_keys::upsert(
+    &pool,
+    "test-setup",
+    &key_hash,
+    "admin",
+  )
+  .await;
 
   let app = build_app(pool.clone());
 
@@ -948,7 +956,7 @@ async fn test_setup_endpoint_creates_project_and_jobsets() {
         .method("POST")
         .uri("/api/v1/projects/setup")
         .header("content-type", "application/json")
-        .header("authorization", "Bearer fc_test_setup_key")
+        .header("authorization", "Bearer circus_test_setup_key")
         .body(Body::from(serde_json::to_vec(&body).unwrap()))
         .unwrap(),
     )

--- a/crates/server/tests/e2e_test.rs
+++ b/crates/server/tests/e2e_test.rs
@@ -8,7 +8,7 @@ use axum::{
   body::Body,
   http::{Request, StatusCode},
 };
-use fc_common::models::*;
+use circus_common::models::*;
 use tower::ServiceExt;
 
 async fn get_pool() -> Option<sqlx::PgPool> {
@@ -39,7 +39,7 @@ async fn test_e2e_project_eval_build_flow() {
 
   // 1. Create a project
   let project_name = format!("e2e-test-{}", uuid::Uuid::new_v4());
-  let project = fc_common::repo::projects::create(&pool, CreateProject {
+  let project = circus_common::repo::projects::create(&pool, CreateProject {
     name:           project_name.clone(),
     description:    Some("E2E test project".to_string()),
     repository_url: "https://github.com/test/e2e".to_string(),
@@ -50,7 +50,7 @@ async fn test_e2e_project_eval_build_flow() {
   assert_eq!(project.name, project_name);
 
   // 2. Create a jobset
-  let jobset = fc_common::repo::jobsets::create(&pool, CreateJobset {
+  let jobset = circus_common::repo::jobsets::create(&pool, CreateJobset {
     project_id:        project.id,
     name:              "default".to_string(),
     nix_expression:    "packages".to_string(),
@@ -69,7 +69,7 @@ async fn test_e2e_project_eval_build_flow() {
   assert!(jobset.enabled);
 
   // 3. Verify active jobsets include our new one
-  let active = fc_common::repo::jobsets::list_active(&pool)
+  let active = circus_common::repo::jobsets::list_active(&pool)
     .await
     .expect("list active");
   assert!(
@@ -78,22 +78,23 @@ async fn test_e2e_project_eval_build_flow() {
   );
 
   // 4. Create an evaluation
-  let eval = fc_common::repo::evaluations::create(&pool, CreateEvaluation {
-    jobset_id:      jobset.id,
-    commit_hash:    "e2e0000000000000000000000000000000000000".to_string(),
-    pr_number:      None,
-    pr_head_branch: None,
-    pr_base_branch: None,
-    pr_action:      None,
-  })
-  .await
-  .expect("create evaluation");
+  let eval =
+    circus_common::repo::evaluations::create(&pool, CreateEvaluation {
+      jobset_id:      jobset.id,
+      commit_hash:    "e2e0000000000000000000000000000000000000".to_string(),
+      pr_number:      None,
+      pr_head_branch: None,
+      pr_base_branch: None,
+      pr_action:      None,
+    })
+    .await
+    .expect("create evaluation");
 
   assert_eq!(eval.jobset_id, jobset.id);
   assert_eq!(eval.status, EvaluationStatus::Pending);
 
   // 5. Mark evaluation as running
-  fc_common::repo::evaluations::update_status(
+  circus_common::repo::evaluations::update_status(
     &pool,
     eval.id,
     EvaluationStatus::Running,
@@ -103,7 +104,7 @@ async fn test_e2e_project_eval_build_flow() {
   .expect("update eval status");
 
   // 6. Create builds as if nix evaluation found jobs
-  let build1 = fc_common::repo::builds::create(&pool, CreateBuild {
+  let build1 = circus_common::repo::builds::create(&pool, CreateBuild {
     evaluation_id: eval.id,
     job_name:      "hello".to_string(),
     drv_path:      "/nix/store/e2e000-hello.drv".to_string(),
@@ -115,7 +116,7 @@ async fn test_e2e_project_eval_build_flow() {
   .await
   .expect("create build 1");
 
-  let build2 = fc_common::repo::builds::create(&pool, CreateBuild {
+  let build2 = circus_common::repo::builds::create(&pool, CreateBuild {
     evaluation_id: eval.id,
     job_name:      "world".to_string(),
     drv_path:      "/nix/store/e2e000-world.drv".to_string(),
@@ -131,23 +132,25 @@ async fn test_e2e_project_eval_build_flow() {
   assert_eq!(build2.status, BuildStatus::Pending);
 
   // 7. Create build dependency (hello depends on world)
-  fc_common::repo::build_dependencies::create(&pool, build1.id, build2.id)
+  circus_common::repo::build_dependencies::create(&pool, build1.id, build2.id)
     .await
     .expect("create dependency");
 
   // 8. Verify dependency check: build1 deps NOT complete (world is still
   //    pending)
   let deps_complete =
-    fc_common::repo::build_dependencies::all_deps_completed(&pool, build1.id)
-      .await
-      .expect("check deps");
+    circus_common::repo::build_dependencies::all_deps_completed(
+      &pool, build1.id,
+    )
+    .await
+    .expect("check deps");
   assert!(!deps_complete, "deps should NOT be complete yet");
 
   // 9. Complete build2 (world)
-  fc_common::repo::builds::start(&pool, build2.id)
+  circus_common::repo::builds::start(&pool, build2.id)
     .await
     .expect("start build2");
-  fc_common::repo::builds::complete(
+  circus_common::repo::builds::complete(
     &pool,
     build2.id,
     BuildStatus::Succeeded,
@@ -160,17 +163,19 @@ async fn test_e2e_project_eval_build_flow() {
 
   // 10. Now build1 deps should be complete
   let deps_complete =
-    fc_common::repo::build_dependencies::all_deps_completed(&pool, build1.id)
-      .await
-      .expect("check deps again");
+    circus_common::repo::build_dependencies::all_deps_completed(
+      &pool, build1.id,
+    )
+    .await
+    .expect("check deps again");
   assert!(deps_complete, "deps should be complete after build2 done");
 
   // 11. Complete build1 (hello)
-  fc_common::repo::builds::start(&pool, build1.id)
+  circus_common::repo::builds::start(&pool, build1.id)
     .await
     .expect("start build1");
 
-  let step = fc_common::repo::build_steps::create(&pool, CreateBuildStep {
+  let step = circus_common::repo::build_steps::create(&pool, CreateBuildStep {
     build_id:    build1.id,
     step_number: 1,
     command:     "nix build /nix/store/e2e000-hello.drv".to_string(),
@@ -178,7 +183,7 @@ async fn test_e2e_project_eval_build_flow() {
   .await
   .expect("create step");
 
-  fc_common::repo::build_steps::complete(
+  circus_common::repo::build_steps::complete(
     &pool,
     step.id,
     0,
@@ -188,7 +193,7 @@ async fn test_e2e_project_eval_build_flow() {
   .await
   .expect("complete step");
 
-  fc_common::repo::build_products::create(&pool, CreateBuildProduct {
+  circus_common::repo::build_products::create(&pool, CreateBuildProduct {
     build_id:     build1.id,
     name:         "out".to_string(),
     path:         "/nix/store/e2e000-hello".to_string(),
@@ -200,7 +205,7 @@ async fn test_e2e_project_eval_build_flow() {
   .await
   .expect("create product");
 
-  fc_common::repo::builds::complete(
+  circus_common::repo::builds::complete(
     &pool,
     build1.id,
     BuildStatus::Succeeded,
@@ -212,7 +217,7 @@ async fn test_e2e_project_eval_build_flow() {
   .expect("complete build1");
 
   // 12. Mark evaluation as completed
-  fc_common::repo::evaluations::update_status(
+  circus_common::repo::evaluations::update_status(
     &pool,
     eval.id,
     EvaluationStatus::Completed,
@@ -222,12 +227,12 @@ async fn test_e2e_project_eval_build_flow() {
   .expect("complete eval");
 
   // 13. Verify everything is in the expected state
-  let final_eval = fc_common::repo::evaluations::get(&pool, eval.id)
+  let final_eval = circus_common::repo::evaluations::get(&pool, eval.id)
     .await
     .expect("get eval");
   assert_eq!(final_eval.status, EvaluationStatus::Completed);
 
-  let final_build1 = fc_common::repo::builds::get(&pool, build1.id)
+  let final_build1 = circus_common::repo::builds::get(&pool, build1.id)
     .await
     .expect("get build1");
   assert_eq!(final_build1.status, BuildStatus::Succeeded);
@@ -237,26 +242,27 @@ async fn test_e2e_project_eval_build_flow() {
   );
 
   let products =
-    fc_common::repo::build_products::list_for_build(&pool, build1.id)
+    circus_common::repo::build_products::list_for_build(&pool, build1.id)
       .await
       .expect("list products");
   assert_eq!(products.len(), 1);
   assert_eq!(products[0].name, "out");
 
-  let steps = fc_common::repo::build_steps::list_for_build(&pool, build1.id)
-    .await
-    .expect("list steps");
+  let steps =
+    circus_common::repo::build_steps::list_for_build(&pool, build1.id)
+      .await
+      .expect("list steps");
   assert_eq!(steps.len(), 1);
   assert_eq!(steps[0].exit_code, Some(0));
 
   // 14. Verify build stats reflect our changes
-  let build_stats = fc_common::repo::builds::get_stats(&pool)
+  let build_stats = circus_common::repo::builds::get_stats(&pool)
     .await
     .expect("get stats");
   assert!(build_stats.completed_builds.unwrap_or(0) >= 2);
 
   // 15. Create a channel and verify it works
-  let channel = fc_common::repo::channels::create(&pool, CreateChannel {
+  let channel = circus_common::repo::channels::create(&pool, CreateChannel {
     project_id: project.id,
     name:       "stable".to_string(),
     jobset_id:  jobset.id,
@@ -264,22 +270,22 @@ async fn test_e2e_project_eval_build_flow() {
   .await
   .expect("create channel");
 
-  let channels = fc_common::repo::channels::list_all(&pool)
+  let channels = circus_common::repo::channels::list_all(&pool)
     .await
     .expect("list channels");
   assert!(channels.iter().any(|c| c.id == channel.id));
 
   // 16. Test the HTTP API layer
-  let config = fc_common::config::Config::default();
+  let config = circus_common::config::Config::default();
   let server_config = config.server.clone();
-  let state = fc_server::state::AppState {
+  let state = circus_server::state::AppState {
     pool: pool.clone(),
     config,
     sessions: std::sync::Arc::new(dashmap::DashMap::new()),
     http_client: reqwest::Client::new(),
     csrf_secret: std::sync::Arc::new([0u8; 32]),
   };
-  let app = fc_server::routes::router(state, &server_config);
+  let app = circus_server::routes::router(state, &server_config);
 
   // GET /health
   let resp = app
@@ -334,5 +340,5 @@ async fn test_e2e_project_eval_build_flow() {
   assert!(body_str.contains("Dashboard"));
 
   // Clean up
-  let _ = fc_common::repo::projects::delete(&pool, project.id).await;
+  let _ = circus_common::repo::projects::delete(&pool, project.id).await;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,10 @@
     inherit (nixpkgs) lib;
     forAllSystems = lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
-    # NixOS module for feel-ci
+    # NixOS module for circus
     nixosModules = {
-      fc-ci = ./nix/modules/nixos.nix;
-      default = self.nixosModules.fc-ci;
+      circus = ./nix/modules/nixos.nix;
+      default = self.nixosModules.circus;
     };
 
     packages = forAllSystems (system: let
@@ -50,7 +50,7 @@
         };
 
       commonArgs = {
-        pname = "feel-ci";
+        pname = "circus";
         inherit src;
         strictDeps = true;
         nativeBuildInputs = with pkgs; [pkg-config];
@@ -61,24 +61,24 @@
     in {
       demo-vm = pkgs.callPackage ./nix/demo-vm.nix {inherit self;};
 
-      # FC Packages
-      fc-common = pkgs.callPackage ./nix/packages/fc-common.nix {
+      # circus Packages
+      circus-common = pkgs.callPackage ./nix/packages/circus-common.nix {
         inherit craneLib commonArgs cargoArtifacts;
       };
 
-      fc-evaluator = pkgs.callPackage ./nix/packages/fc-evaluator.nix {
+      circus-evaluator = pkgs.callPackage ./nix/packages/circus-evaluator.nix {
         inherit craneLib commonArgs cargoArtifacts;
       };
 
-      fc-migrate-cli = pkgs.callPackage ./nix/packages/fc-migrate-cli.nix {
+      circus-migrate-cli = pkgs.callPackage ./nix/packages/circus-migrate-cli.nix {
         inherit craneLib commonArgs cargoArtifacts;
       };
 
-      fc-queue-runner = pkgs.callPackage ./nix/packages/fc-queue-runner.nix {
+      circus-queue-runner = pkgs.callPackage ./nix/packages/circus-queue-runner.nix {
         inherit craneLib commonArgs cargoArtifacts;
       };
 
-      fc-server = pkgs.callPackage ./nix/packages/fc-server.nix {
+      circus-server = pkgs.callPackage ./nix/packages/circus-server.nix {
         inherit craneLib commonArgs cargoArtifacts;
       };
     });
@@ -112,7 +112,7 @@
     in {
       default = pkgs.mkShell {
         name = "fc-dev";
-        inputsFrom = [self.packages.${system}.fc-server];
+        inputsFrom = [self.packages.${system}.circus-server];
 
         strictDeps = true;
         packages = with pkgs; [

--- a/nix/demo-vm.nix
+++ b/nix/demo-vm.nix
@@ -4,7 +4,7 @@
   lib,
 }: let
   inherit (lib.modules) mkForce;
-  fc-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+  circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
 
   # Demo password file to demonstrate passwordFile option
   # Password must be at least 12 characters with at least one uppercase letter
@@ -16,20 +16,20 @@
     ...
   }: {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       (modulesPath + "/virtualisation/qemu-vm.nix")
       ./vm-common.nix
 
       {config._module.args = {inherit self;};}
     ];
 
-    services.fc-ci = {
+    services.circus = {
       enable = true;
 
-      package = fc-packages.fc-server;
-      evaluatorPackage = fc-packages.fc-evaluator;
-      queueRunnerPackage = fc-packages.fc-queue-runner;
-      migratePackage = fc-packages.fc-migrate-cli;
+      package = circus-packages.circus-server;
+      evaluatorPackage = circus-packages.circus-evaluator;
+      queueRunnerPackage = circus-packages.circus-queue-runner;
+      migratePackage = circus-packages.circus-migrate-cli;
 
       server.enable = true;
       evaluator.enable = true;
@@ -38,7 +38,7 @@
       settings = {
         database.url = "postgresql:///fc?host=/run/postgresql";
         gc.enabled = false;
-        logs.log_dir = "/var/lib/fc/logs";
+        logs.log_dir = "/var/lib/circus/logs";
         cache.enabled = true;
         signing.enabled = false;
         server = {
@@ -64,18 +64,18 @@
     };
 
     ## Seed an admin API key on first boot
-    # Token: fc_demo_admin_key, SHA-256 hash inserted into api_keys
+    # Token: circus_demo_admin_key, SHA-256 hash inserted into api_keys
     # A read-only key is also seeded for testing RBAC.
-    systemd.services.fc-seed-keys = {
+    systemd.services.circus-seed-keys = {
       description = "Seed demo API keys";
-      after = ["fc-server.service"];
-      requires = ["fc-server.service"];
+      after = ["circus-server.service"];
+      requires = ["circus-server.service"];
       wantedBy = ["multi-user.target"];
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        User = "fc";
-        Group = "fc";
+        User = "circus";
+        Group = "circus";
       };
       path = [pkgs.postgresql pkgs.curl];
       script = ''
@@ -87,13 +87,13 @@
           sleep 1
         done
 
-        # Admin key: fc_demo_admin_key
-        ADMIN_HASH="$(echo -n 'fc_demo_admin_key' | sha256sum | cut -d' ' -f1)"
-        psql -U fc -d fc -c "INSERT INTO api_keys (name, key_hash, role) VALUES ('demo-admin', '$ADMIN_HASH', 'admin') ON CONFLICT DO NOTHING" 2>/dev/null || true
+        # Admin key: circus_demo_admin_key
+        ADMIN_HASH="$(echo -n 'circus_demo_admin_key' | sha256sum | cut -d' ' -f1)"
+        psql -U circus -d circus -c "INSERT INTO api_keys (name, key_hash, role) VALUES ('demo-admin', '$ADMIN_HASH', 'admin') ON CONFLICT DO NOTHING" 2>/dev/null || true
 
-        # Read-only key: fc_demo_readonly_key
-        RO_HASH="$(echo -n 'fc_demo_readonly_key' | sha256sum | cut -d' ' -f1)"
-        psql -U fc -d fc -c "INSERT INTO api_keys (name, key_hash, role) VALUES ('demo-readonly', '$RO_HASH', 'read-only') ON CONFLICT DO NOTHING" 2>/dev/null || true
+        # Read-only key: circus_demo_readonly_key
+        RO_HASH="$(echo -n 'circus_demo_readonly_key' | sha256sum | cut -d' ' -f1)"
+        psql -U circus -d circus -c "INSERT INTO api_keys (name, key_hash, role) VALUES ('demo-readonly', '$RO_HASH', 'read-only') ON CONFLICT DO NOTHING" 2>/dev/null || true
 
         echo ""
         echo "====================================================="
@@ -105,8 +105,8 @@
         echo "  Web login:     admin / AdminPassword123! (admin)"
         echo "                 demo / DemoPassword123! (read-only)"
         echo ""
-        echo "  Admin API key: fc_demo_admin_key"
-        echo "  Read-only key: fc_demo_readonly_key"
+        echo "  Admin API key: circus_demo_admin_key"
+        echo "  Read-only key: circus_demo_readonly_key"
         echo ""
         echo "  Login at http://localhost:3000/login using"
         echo "  the credentials or the API key provided above."
@@ -127,13 +127,13 @@
     ];
 
     # Misc VM settings
-    networking.hostName = "fc-demo";
+    networking.hostName = "circus-demo";
     networking.firewall.allowedTCPPorts = [3000];
     services.getty.autologinUser = "root";
     system.stateVersion = "26.11";
   });
 in
   pkgs.writeShellApplication {
-    name = "run-fc-demo-vm";
-    text = "exec ${nixos.config.system.build.vm}/bin/run-fc-demo-vm";
+    name = "run-circus-demo-vm";
+    text = "exec ${nixos.config.system.build.vm}/bin/run-circus-demo-vm";
   }

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -10,7 +10,7 @@
   inherit (lib.attrsets) recursiveUpdate optionalAttrs mapAttrsToList filterAttrs;
   inherit (lib.lists) optional map;
 
-  cfg = config.services.fc-ci;
+  cfg = config.services.circus;
 
   settingsFormat = pkgs.formats.toml {};
   settingsType = settingsFormat.type;
@@ -115,7 +115,7 @@
     };
   });
 
-  settingsFile = settingsFormat.generate "fc.toml" finalSettings;
+  settingsFile = settingsFormat.generate "circus.toml" finalSettings;
 
   jobsetOpts = {
     options = {
@@ -470,41 +470,41 @@
     };
   };
 in {
-  options.services.fc-ci = {
-    enable = mkEnableOption "FC CI system";
+  options.services.circus = {
+    enable = mkEnableOption "circus system";
 
     # TODO: could we use `mkPackageOption` here?
     # Also for the options below
     package = mkOption {
       type = package;
-      description = "The FC server package.";
+      description = "The circus server package.";
     };
 
     evaluatorPackage = mkOption {
       type = package;
       default = cfg.package;
       defaultText = "cfg.package";
-      description = "The FC evaluator package.";
+      description = "The circus evaluator package.";
     };
 
     queueRunnerPackage = mkOption {
       type = package;
       default = cfg.package;
       defaultText = "cfg.package";
-      description = "The FC queue runner package.";
+      description = "The circus queue runner package.";
     };
 
     migratePackage = mkOption {
       type = package;
-      description = "The FC migration CLI package.";
+      description = "The circus migration CLI package.";
     };
 
     settings = mkOption {
       type = settingsType;
       default = {};
       description = ''
-        FC configuration as a Nix attribute set. Will be converted to TOML
-        and written to {file}`fc.toml`.
+        circus configuration as a Nix attribute set. Will be converted to TOML
+        and written to {file}`circus.toml`.
       '';
     };
 
@@ -550,7 +550,7 @@ in {
           }
           {
             name = "ci-bot";
-            key = "fc_ci_bot_key";
+            key = "circus_bot_key";
             role = "eval-jobset";
           }
         ];
@@ -568,12 +568,12 @@ in {
         example = {
           admin = {
             email = "admin@example.com";
-            passwordFile = "/run/secrets/fc-admin-password";
+            passwordFile = "/run/secrets/circus-admin-password";
             role = "admin";
           };
           readonly = {
             email = "readonly@example.com";
-            passwordFile = "/run/secrets/fc-readonly-password";
+            passwordFile = "/run/secrets/circus-readonly-password";
             role = "read-only";
           };
         };
@@ -607,15 +607,15 @@ in {
     };
 
     server = {
-      enable = mkEnableOption "FC server (REST API)";
+      enable = mkEnableOption "circus server (REST API)";
     };
 
     evaluator = {
-      enable = mkEnableOption "FC evaluator (Git polling and nix evaluation)";
+      enable = mkEnableOption "circus evaluator (Git polling and nix evaluation)";
     };
 
     queueRunner = {
-      enable = mkEnableOption "FC queue runner (build dispatch)";
+      enable = mkEnableOption "circus queue runner (build dispatch)";
     };
   };
 
@@ -629,30 +629,30 @@ in {
       )
       cfg.declarative.users;
 
-    users.users.fc = {
+    users.users.circus = {
       isSystemUser = true;
-      group = "fc";
-      home = "/var/lib/fc";
+      group = "circus";
+      home = "/var/lib/circus";
       createHome = true;
     };
 
-    users.groups.fc = {};
+    users.groups.circus = {};
 
     services.postgresql = mkIf cfg.database.createLocally {
       enable = true;
-      ensureDatabases = ["fc"];
+      ensureDatabases = ["circus"];
       ensureUsers = [
         {
-          name = "fc";
+          name = "circus";
           ensureDBOwnership = true;
         }
       ];
     };
 
-    services.fc-ci.settings = {
-      database.url = mkDefault "postgresql:///fc?host=/run/postgresql";
-      server.host = mkDefault "127.0.0.1";
-      server.port = mkDefault 3000;
+    services.circus.settings = mkDefault {
+      database.url = "postgresql:///fc?host=/run/postgresql";
+      server.host = "127.0.0.1";
+      server.port = 3000;
 
       gc = {
         gc_roots_dir = mkDefault "/nix/var/nix/gcroots/per-user/fc/fc-roots";
@@ -670,13 +670,13 @@ in {
 
     systemd = {
       tmpfiles.rules = [
-        (mkIf cfg.server.enable "d /var/lib/fc/logs 0750 fc fc -")
-        (mkIf cfg.queueRunner.enable "d /nix/var/nix/gcroots/per-user/fc 0755 fc fc -")
+        (mkIf cfg.server.enable "d /var/lib/circus/logs 0750 fc fc -")
+        (mkIf cfg.queueRunner.enable "d /nix/var/nix/gcroots/per-user/circus 0755 fc fc -")
       ];
 
       services = {
-        fc-server = mkIf cfg.server.enable {
-          description = "FC CI Server";
+        circus-server = mkIf cfg.server.enable {
+          description = "circus Server";
           wantedBy = ["multi-user.target"];
           after = ["network.target"] ++ optional cfg.database.createLocally "postgresql.target";
           requires = optional cfg.database.createLocally "postgresql.target";
@@ -684,16 +684,16 @@ in {
           path = with pkgs; [nix zstd];
 
           serviceConfig = {
-            ExecStartPre = "${cfg.migratePackage}/bin/fc-migrate up ${finalSettings.database.url or "postgresql:///fc?host=/run/postgresql"}";
-            ExecStart = "${cfg.package}/bin/fc-server";
+            ExecStartPre = "${cfg.migratePackage}/bin/circus-migrate up ${finalSettings.database.url or "postgresql:///fc?host=/run/postgresql"}";
+            ExecStart = "${cfg.package}/bin/circus-server";
             Restart = "on-failure";
             RestartSec = 5;
-            User = "fc";
-            Group = "fc";
-            StateDirectory = "fc";
-            LogsDirectory = "fc";
-            WorkingDirectory = "/var/lib/fc";
-            ReadWritePaths = ["/var/lib/fc"];
+            User = "circus";
+            Group = "circus";
+            StateDirectory = "circus";
+            LogsDirectory = "circus";
+            WorkingDirectory = "/var/lib/circus";
+            ReadWritePaths = ["/var/lib/circus"];
 
             # Hardening
             ProtectSystem = "strict";
@@ -707,15 +707,15 @@ in {
           };
 
           environment = {
-            FC_CONFIG_FILE = "${settingsFile}";
+            CIRCUS_CONFIG_FILE = "${settingsFile}";
           };
         };
 
-        fc-evaluator = mkIf cfg.evaluator.enable {
-          description = "FC CI Evaluator";
+        circus-evaluator = mkIf cfg.evaluator.enable {
+          description = "circus Evaluator";
           wantedBy = ["multi-user.target"];
-          after = ["network.target" "fc-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
-          requires = ["fc-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          after = ["network.target" "circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          requires = ["circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
 
           path = with pkgs; [
             nix
@@ -724,14 +724,14 @@ in {
           ];
 
           serviceConfig = {
-            ExecStart = "${cfg.evaluatorPackage}/bin/fc-evaluator";
+            ExecStart = "${cfg.evaluatorPackage}/bin/circus-evaluator";
             Restart = "on-failure";
             RestartSec = 10;
-            User = "fc";
-            Group = "fc";
-            StateDirectory = "fc";
-            WorkingDirectory = "/var/lib/fc";
-            ReadWritePaths = ["/var/lib/fc"];
+            User = "circus";
+            Group = "circus";
+            StateDirectory = "circus";
+            WorkingDirectory = "/var/lib/circus";
+            ReadWritePaths = ["/var/lib/circus"];
 
             # Hardening
             ProtectSystem = "strict";
@@ -745,34 +745,34 @@ in {
           };
 
           environment = {
-            FC_CONFIG_FILE = "${settingsFile}";
-            FC_EVALUATOR__WORK_DIR = "/var/lib/fc/evaluator";
-            FC_EVALUATOR__RESTRICT_EVAL = "true";
+            CIRCUS_CONFIG_FILE = "${settingsFile}";
+            CIRCUS_EVALUATOR__WORK_DIR = "/var/lib/circus/evaluator";
+            CIRCUS_EVALUATOR__RESTRICT_EVAL = "true";
           };
         };
 
-        fc-queue-runner = mkIf cfg.queueRunner.enable {
-          description = "FC CI Queue Runner";
+        circus-queue-runner = mkIf cfg.queueRunner.enable {
+          description = "circus Queue Runner";
           wantedBy = ["multi-user.target"];
-          after = ["network.target" "fc-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
-          requires = ["fc-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          after = ["network.target" "circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          requires = ["circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
 
           path = with pkgs; [
             nix
           ];
 
           serviceConfig = {
-            ExecStart = "${cfg.queueRunnerPackage}/bin/fc-queue-runner";
+            ExecStart = "${cfg.queueRunnerPackage}/bin/circus-queue-runner";
             Restart = "on-failure";
             RestartSec = 10;
-            User = "fc";
-            Group = "fc";
-            StateDirectory = "fc";
-            LogsDirectory = "fc";
-            WorkingDirectory = "/var/lib/fc";
+            User = "circus";
+            Group = "circus";
+            StateDirectory = "circus";
+            LogsDirectory = "circus";
+            WorkingDirectory = "/var/lib/circus";
             ReadWritePaths = [
-              "/var/lib/fc"
-              "/nix/var/nix/gcroots/per-user/fc"
+              "/var/lib/circus"
+              "/nix/var/nix/gcroots/per-user/circus"
             ];
 
             # Hardening
@@ -787,8 +787,8 @@ in {
           };
 
           environment = {
-            FC_CONFIG_FILE = "${settingsFile}";
-            FC_QUEUE_RUNNER__WORK_DIR = "/var/lib/fc/queue-runner";
+            CIRCUS_CONFIG_FILE = "${settingsFile}";
+            CIRCUS_QUEUE_RUNNER__WORK_DIR = "/var/lib/circus/queue-runner";
           };
         };
       };

--- a/nix/packages/circus-common.nix
+++ b/nix/packages/circus-common.nix
@@ -6,6 +6,6 @@
 craneLib.buildPackage (commonArgs
   // {
     inherit cargoArtifacts;
-    pname = "fc-evaluator";
-    cargoExtraArgs = "--package fc-evaluator";
+    pname = "circus-common";
+    cargoExtraArgs = "--package circus-common";
   })

--- a/nix/packages/circus-evaluator.nix
+++ b/nix/packages/circus-evaluator.nix
@@ -6,6 +6,6 @@
 craneLib.buildPackage (commonArgs
   // {
     inherit cargoArtifacts;
-    pname = "fc-migrate-cli";
-    cargoExtraArgs = "--package fc-migrate-cli";
+    pname = "circus-evaluator";
+    cargoExtraArgs = "--package circus-evaluator";
   })

--- a/nix/packages/circus-migrate-cli.nix
+++ b/nix/packages/circus-migrate-cli.nix
@@ -6,6 +6,6 @@
 craneLib.buildPackage (commonArgs
   // {
     inherit cargoArtifacts;
-    pname = "fc-queue-runner";
-    cargoExtraArgs = "--package fc-queue-runner";
+    pname = "circus-migrate-cli";
+    cargoExtraArgs = "--package circus-migrate-cli";
   })

--- a/nix/packages/circus-queue-runner.nix
+++ b/nix/packages/circus-queue-runner.nix
@@ -6,6 +6,6 @@
 craneLib.buildPackage (commonArgs
   // {
     inherit cargoArtifacts;
-    pname = "fc-common";
-    cargoExtraArgs = "--package fc-common";
+    pname = "circus-queue-runner";
+    cargoExtraArgs = "--package circus-queue-runner";
   })

--- a/nix/packages/circus-server.nix
+++ b/nix/packages/circus-server.nix
@@ -6,6 +6,6 @@
 craneLib.buildPackage (commonArgs
   // {
     inherit cargoArtifacts;
-    pname = "fc-server";
-    cargoExtraArgs = "--package fc-server";
+    pname = "circus-server";
+    cargoExtraArgs = "--package circus-server";
   })

--- a/nix/tests/api-crud.nix
+++ b/nix/tests/api-crud.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-api-crud";
+  name = "circus-api-crud";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
 
@@ -24,10 +24,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -37,7 +37,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -45,7 +45,7 @@ pkgs.testers.nixosTest {
     ro_token = "fc_readonly_key"
     ro_hash = hashlib.sha256(ro_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
     )
     ro_header = f"-H 'Authorization: Bearer {ro_token}'"
 
@@ -225,7 +225,7 @@ pkgs.testers.nixosTest {
     # Create a build via SQL since builds are normally created by the evaluator
     with subtest("Create test build via SQL"):
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, system, priority, created_at) "
             f"VALUES ('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '{test_eval_id}', 'hello', '/nix/store/fake.drv', 'failed', 'x86_64-linux', 5, NOW())"
             "\""
@@ -255,12 +255,12 @@ pkgs.testers.nixosTest {
         assert code.strip() == "403", f"Expected 403 for read-only restart, got {code.strip()}"
 
     # Stop the queue runner so it cannot claim the build before we bump it
-    machine.systemctl("stop fc-queue-runner.service")
+    machine.systemctl("stop circus-queue-runner.service")
 
     # Create a pending build to test bump
     with subtest("Create pending build for bump test"):
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, system, priority, created_at) "
             f"VALUES ('bbbbbbbb-cccc-dddd-eeee-ffffffffffff', '{test_eval_id}', 'world', '/nix/store/fake2.drv', 'pending', 'x86_64-linux', 5, NOW())"
             "\""
@@ -291,7 +291,7 @@ pkgs.testers.nixosTest {
         )
         assert "cancelled" in result.strip().lower(), f"Expected cancelled, got: {result.strip()}"
 
-    machine.systemctl("start fc-queue-runner.service")
+    machine.systemctl("start circus-queue-runner.service")
 
     # Evaluation comparison
     with subtest("Trigger second evaluation for comparison"):
@@ -305,13 +305,13 @@ pkgs.testers.nixosTest {
         second_eval_id = result.strip()
         # Add a build to the second evaluation
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, system, priority, created_at) "
             f"VALUES ('cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa', '{second_eval_id}', 'hello', '/nix/store/changed.drv', 'pending', 'x86_64-linux', 5, NOW())"
             "\""
         )
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, system, priority, created_at) "
             f"VALUES ('dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb', '{second_eval_id}', 'new-pkg', '/nix/store/new.drv', 'pending', 'x86_64-linux', 5, NOW())"
             "\""
@@ -454,7 +454,7 @@ pkgs.testers.nixosTest {
     with subtest("Delete remote builder with admin key"):
         # First clear the builder_id from builds that reference it
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c "
+            "sudo -u circus psql -U circus -d circus -c "
             f"\"UPDATE builds SET builder_id = NULL WHERE builder_id = '{builder_id}'\""
         )
         # Now delete the builder
@@ -627,7 +627,7 @@ pkgs.testers.nixosTest {
             "-X POST http://127.0.0.1:3000/login "
             f"-d 'api_key={api_token}'"
         )
-        assert "fc_session=" in result, f"Expected fc_session cookie in response: {result}"
+        assert "circus_session=" in result, f"Expected circus_session cookie in response: {result}"
         assert "HttpOnly" in result, "Expected HttpOnly flag on session cookie"
 
     with subtest("Login with invalid API key shows error"):
@@ -654,11 +654,11 @@ pkgs.testers.nixosTest {
             f"-d 'api_key={api_token}' "
             "| grep -i set-cookie | head -1"
         )
-        match = re.search(r'fc_session=([^;]+)', cookie)
+        match = re.search(r'circus_session=([^;]+)', cookie)
         if match:
             session_val = match.group(1)
             body = machine.succeed(
-                f"curl -sf -H 'Cookie: fc_session={session_val}' http://127.0.0.1:3000/admin"
+                f"curl -sf -H 'Cookie: circus_session={session_val}' http://127.0.0.1:3000/admin"
             )
             # Admin page with session should show API Keys section and admin controls
             assert "API Keys" in body, "Admin page with session should show API Keys section"
@@ -674,7 +674,7 @@ pkgs.testers.nixosTest {
     cp_token = "fc_createprojects_key"
     cp_hash = hashlib.sha256(cp_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('creator', '{cp_hash}', 'create-projects')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('creator', '{cp_hash}', 'create-projects')\""
     )
     cp_header = f"-H 'Authorization: Bearer {cp_token}'"
 

--- a/nix/tests/auth-rbac.nix
+++ b/nix/tests/auth-rbac.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-auth-rbac";
+  name = "circus-auth-rbac";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -21,10 +21,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -34,7 +34,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -80,7 +80,7 @@ pkgs.testers.nixosTest {
     ro_token = "fc_readonly_key"
     ro_hash = hashlib.sha256(ro_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
     )
     ro_header = f"-H 'Authorization: Bearer {ro_token}'"
 
@@ -257,7 +257,7 @@ pkgs.testers.nixosTest {
         assert result.strip() == "0", f"Expected 0, got {result.strip()}"
         # Verify projects table is intact
         count = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -t -c 'SELECT COUNT(*) FROM projects'"
+            "sudo -u circus psql -U circus -d circus -t -c 'SELECT COUNT(*) FROM projects'"
         )
         assert int(count.strip()) > 0, "Projects table seems damaged"
 

--- a/nix/tests/basic-api.nix
+++ b/nix/tests/basic-api.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-basic-api";
+  name = "circus-basic-api";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -19,10 +19,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -32,7 +32,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -161,19 +161,19 @@ pkgs.testers.nixosTest {
             f"CORS should not allow arbitrary origins: {result}"
 
     # Systemd hardening
-    with subtest("fc-server runs as fc user"):
-        result = machine.succeed("systemctl show fc-server --property=User --value")
-        assert result.strip() == "fc", f"Expected fc user, got '{result.strip()}'"
+    with subtest("circus-server runs as fc user"):
+        result = machine.succeed("systemctl show circus-server --property=User --value")
+        assert result.strip() == "circus", f"Expected fc user, got '{result.strip()}'"
 
-    with subtest("fc-server has NoNewPrivileges"):
-        result = machine.succeed("systemctl show fc-server --property=NoNewPrivileges --value")
+    with subtest("circus-server has NoNewPrivileges"):
+        result = machine.succeed("systemctl show circus-server --property=NoNewPrivileges --value")
         assert result.strip() == "yes", f"Expected NoNewPrivileges, got '{result.strip()}'"
 
     with subtest("fc user home directory exists"):
-        machine.succeed("test -d /var/lib/fc")
+        machine.succeed("test -d /var/lib/circus")
 
     with subtest("Log directory exists"):
-        machine.succeed("test -d /var/lib/fc/logs || mkdir -p /var/lib/fc/logs")
+        machine.succeed("test -d /var/lib/circus/logs || mkdir -p /var/lib/circus/logs")
 
     # Stats endpoint
     with subtest("Build stats endpoint returns data"):

--- a/nix/tests/channel-tarball.nix
+++ b/nix/tests/channel-tarball.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-channel-tarball";
+  name = "circus-channel-tarball";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -19,14 +19,14 @@ pkgs.testers.nixosTest {
 
     machine.start()
     machine.wait_for_unit("postgresql.service")
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
+    machine.wait_for_unit("circus-server.service")
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -50,25 +50,25 @@ pkgs.testers.nixosTest {
 
     # Create evaluation via SQL
     eval_id = machine.succeed(
-        "sudo -u fc psql -U fc -d fc -tA -c "
+        "sudo -u circus psql -U circus -d circus -tA -c "
         "\"INSERT INTO evaluations (jobset_id, commit_hash, status) "
         f"VALUES ('{jobset_id}', 'abc123', 'completed') RETURNING id\" | head -1"
     ).strip()
 
     # Create succeeded builds with output paths
     machine.succeed(
-        "sudo -u fc psql -U fc -d fc -c "
+        "sudo -u circus psql -U circus -d circus -c "
         "\"INSERT INTO builds (evaluation_id, job_name, drv_path, status, system, build_output_path) "
         f"VALUES ('{eval_id}', 'hello', '/nix/store/fake-hello.drv', 'succeeded', 'x86_64-linux', '/nix/store/aaaa-hello-1.0')\""
     )
     machine.succeed(
-        "sudo -u fc psql -U fc -d fc -c "
+        "sudo -u circus psql -U circus -d circus -c "
         "\"INSERT INTO builds (evaluation_id, job_name, drv_path, status, system, build_output_path) "
         f"VALUES ('{eval_id}', 'world', '/nix/store/fake-world.drv', 'succeeded', 'x86_64-linux', '/nix/store/bbbb-world-2.0')\""
     )
     # A failed build should not appear in the tarball
     machine.succeed(
-        "sudo -u fc psql -U fc -d fc -c "
+        "sudo -u circus psql -U circus -d circus -c "
         "\"INSERT INTO builds (evaluation_id, job_name, drv_path, status, system) "
         f"VALUES ('{eval_id}', 'broken', '/nix/store/fake-broken.drv', 'failed', 'x86_64-linux')\""
     )

--- a/nix/tests/declarative.nix
+++ b/nix/tests/declarative.nix
@@ -2,7 +2,7 @@
   pkgs,
   self,
 }: let
-  fc-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+  circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
 
   # Password files for testing passwordFile option
   # Passwords must be at least 12 characters with at least one uppercase letter
@@ -11,22 +11,22 @@
   disabledPasswordFile = pkgs.writeText "disabled-password" "DisabledPass123!";
 in
   pkgs.testers.nixosTest {
-    name = "fc-declarative";
+    name = "circus-declarative";
 
     nodes.machine = {
-      imports = [self.nixosModules.fc-ci];
+      imports = [self.nixosModules.circus];
       _module.args.self = self;
 
       programs.git.enable = true;
       security.sudo.enable = true;
       environment.systemPackages = with pkgs; [nix nix-eval-jobs zstd curl jq openssl];
 
-      services.fc-ci = {
+      services.circus = {
         enable = true;
-        package = fc-packages.fc-server;
-        evaluatorPackage = fc-packages.fc-evaluator;
-        queueRunnerPackage = fc-packages.fc-queue-runner;
-        migratePackage = fc-packages.fc-migrate-cli;
+        package = circus-packages.circus-server;
+        evaluatorPackage = circus-packages.circus-evaluator;
+        queueRunnerPackage = circus-packages.circus-queue-runner;
+        migratePackage = circus-packages.circus-migrate-cli;
 
         server.enable = true;
         evaluator.enable = true;
@@ -40,7 +40,7 @@ in
             cors_permissive = false;
           };
           gc.enabled = false;
-          logs.log_dir = "/var/lib/fc/logs";
+          logs.log_dir = "/var/lib/circus/logs";
           cache.enabled = true;
           signing.enabled = false;
         };
@@ -139,45 +139,45 @@ in
     testScript = ''
       machine.start()
       machine.wait_for_unit("postgresql.service")
-      machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
-      machine.wait_for_unit("fc-server.service")
+      machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
+      machine.wait_for_unit("circus-server.service")
       machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
       # DECLARATIVE USERS
       with subtest("Declarative users are created in database"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM users WHERE username LIKE 'decl-%'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM users WHERE username LIKE 'decl-%'\""
           )
           count = int(result.strip())
           assert count == 4, f"Expected 4 declarative users, got {count}"
 
       with subtest("Declarative admin user has admin role"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT role FROM users WHERE username = 'decl-admin'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT role FROM users WHERE username = 'decl-admin'\""
           )
           assert result.strip() == "admin", f"Expected admin role, got '{result.strip()}'"
 
       with subtest("Declarative regular users have read-only role"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT role FROM users WHERE username = 'decl-user'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT role FROM users WHERE username = 'decl-user'\""
           )
           assert result.strip() == "read-only", f"Expected read-only role, got '{result.strip()}'"
 
       with subtest("Declarative disabled user is disabled"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT enabled FROM users WHERE username = 'decl-disabled'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT enabled FROM users WHERE username = 'decl-disabled'\""
           )
           assert result.strip() == "f", f"Expected disabled (f), got '{result.strip()}'"
 
       with subtest("Declarative enabled users are enabled"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT enabled FROM users WHERE username = 'decl-admin'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT enabled FROM users WHERE username = 'decl-admin'\""
           )
           assert result.strip() == "t", f"Expected enabled (t), got '{result.strip()}'"
 
       with subtest("Declarative users have password hashes set"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT password_hash FROM users WHERE username = 'decl-admin'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT password_hash FROM users WHERE username = 'decl-admin'\""
           )
           # Argon2 hashes start with $argon2
           assert result.strip().startswith("$argon2"), f"Expected argon2 hash, got '{result.strip()[:20]}...'"
@@ -185,13 +185,13 @@ in
       with subtest("User with passwordFile has correct password hash"):
           # The password in the file is 'SecretAdmin123!'
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT password_hash FROM users WHERE username = 'decl-admin'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT password_hash FROM users WHERE username = 'decl-admin'\""
           )
           assert len(result.strip()) > 50, "Password hash should be substantial length"
 
       with subtest("User with inline password has correct password hash"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT password_hash FROM users WHERE username = 'decl-user'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT password_hash FROM users WHERE username = 'decl-user'\""
           )
           assert result.strip().startswith("$argon2"), f"Expected argon2 hash for inline password user, got '{result.strip()[:20]}...'"
 
@@ -253,7 +253,7 @@ in
       # DECLARATIVE API KEYS
       with subtest("Declarative API keys are created"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM api_keys WHERE name LIKE 'decl-%'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM api_keys WHERE name LIKE 'decl-%'\""
           )
           count = int(result.strip())
           assert count == 2, f"Expected 2 declarative API keys, got {count}"
@@ -363,28 +363,28 @@ in
 
       with subtest("Disabled jobset is not in active_jobsets view"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'disabled-jobset'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'disabled-jobset'\""
           )
           count = int(result.strip())
           assert count == 0, f"Disabled jobset should not be in active_jobsets, got {count}"
 
       with subtest("Enabled jobsets are in active_jobsets view"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'enabled-jobset'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'enabled-jobset'\""
           )
           count = int(result.strip())
           assert count == 1, f"Enabled jobset should be in active_jobsets, got {count}"
 
       with subtest("One-shot jobset is in active_jobsets view"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'oneshot-jobset'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'oneshot-jobset'\""
           )
           count = int(result.strip())
           assert count == 1, f"One-shot jobset should be in active_jobsets, got {count}"
 
       with subtest("One-at-a-time jobset is in active_jobsets view"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'oneatatime-jobset'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM active_jobsets WHERE name = 'oneatatime-jobset'\""
           )
           count = int(result.strip())
           assert count == 1, f"One-at-a-time jobset should be in active_jobsets, got {count}"
@@ -401,7 +401,7 @@ in
       # IDEMPOTENCY
       with subtest("Bootstrap is idempotent - no duplicate users"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM users WHERE username = 'decl-admin'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM users WHERE username = 'decl-admin'\""
           )
           count = int(result.strip())
           assert count == 1, f"Expected exactly 1 decl-admin user, got {count}"
@@ -415,7 +415,7 @@ in
 
       with subtest("Bootstrap is idempotent - no duplicate API keys"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -t -c \"SELECT COUNT(*) FROM api_keys WHERE name = 'decl-admin-key'\""
+              "sudo -u circus psql -U circus -d circus -t -c \"SELECT COUNT(*) FROM api_keys WHERE name = 'decl-admin-key'\""
           )
           count = int(result.strip())
           assert count == 1, f"Expected exactly 1 decl-admin-key, got {count}"

--- a/nix/tests/e2e.nix
+++ b/nix/tests/e2e.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-e2e";
+  name = "circus-e2e";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -24,10 +24,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -37,7 +37,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -45,13 +45,13 @@ pkgs.testers.nixosTest {
     ro_token = "fc_readonly_key"
     ro_hash = hashlib.sha256(ro_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
     )
     ro_header = f"-H 'Authorization: Bearer {ro_token}'"
 
     with subtest("PostgreSQL LISTEN/NOTIFY triggers are installed"):
         result = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT tgname FROM pg_trigger WHERE tgname LIKE 'trg_%_notify'\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT tgname FROM pg_trigger WHERE tgname LIKE 'trg_%_notify'\" -t"
         )
         assert "trg_builds_insert_notify" in result, f"Missing trg_builds_insert_notify in: {result}"
         assert "trg_builds_status_notify" in result, f"Missing trg_builds_status_notify in: {result}"
@@ -61,25 +61,25 @@ pkgs.testers.nixosTest {
 
     # Create a test flake inside the VM
     with subtest("Create bare git repo with test flake"):
-        machine.succeed("mkdir -p /var/lib/fc/test-repos")
-        machine.succeed("git init --bare /var/lib/fc/test-repos/test-flake.git")
+        machine.succeed("mkdir -p /var/lib/circus/test-repos")
+        machine.succeed("git init --bare /var/lib/circus/test-repos/test-flake.git")
 
-        # Allow root to push to fc-owned repos (ownership changes after chown below)
-        machine.succeed("git config --global --add safe.directory /var/lib/fc/test-repos/test-flake.git")
+        # Allow root to push to circus-owned repos (ownership changes after chown below)
+        machine.succeed("git config --global --add safe.directory /var/lib/circus/test-repos/test-flake.git")
 
         # Create a working copy, write the flake, commit, push
         machine.succeed("mkdir -p /tmp/test-flake-work")
         machine.succeed("cd /tmp/test-flake-work && git init")
-        machine.succeed("cd /tmp/test-flake-work && git config user.email 'test@fc' && git config user.name 'FC Test'")
+        machine.succeed("cd /tmp/test-flake-work && git config user.email 'test@circus' && git config user.name 'circus Test'")
 
         # Write a minimal flake.nix that builds a simple derivation
         machine.succeed(
             "cat > /tmp/test-flake-work/flake.nix << 'FLAKE'\n"
             "{\n"
-            '  description = "FC CI test flake";\n'
+            '  description = "circus test flake";\n'
             '  outputs = { self, ... }: {\n'
             '    packages.x86_64-linux.hello = derivation {\n'
-            '      name = "fc-test-hello";\n'
+            '      name = "circus-test-hello";\n'
             '      system = "x86_64-linux";\n'
             '      builder = "/bin/sh";\n'
             '      args = [ "-c" "echo hello > $out" ];\n'
@@ -89,11 +89,11 @@ pkgs.testers.nixosTest {
             "FLAKE\n"
         )
         machine.succeed("cd /tmp/test-flake-work && git add -A && git commit -m 'initial flake'")
-        machine.succeed("cd /tmp/test-flake-work && git remote add origin /var/lib/fc/test-repos/test-flake.git")
+        machine.succeed("cd /tmp/test-flake-work && git remote add origin /var/lib/circus/test-repos/test-flake.git")
         machine.succeed("cd /tmp/test-flake-work && git push origin HEAD:refs/heads/master")
 
         # Set ownership for fc user
-        machine.succeed("chown -R fc:fc /var/lib/fc/test-repos")
+        machine.succeed("chown -R fc:fc /var/lib/circus/test-repos")
 
     # Create project + jobset pointing to the local repo via API
     with subtest("Create E2E project and jobset via API"):
@@ -101,7 +101,7 @@ pkgs.testers.nixosTest {
             "curl -sf -X POST http://127.0.0.1:3000/api/v1/projects "
             f"{auth_header} "
             "-H 'Content-Type: application/json' "
-            "-d '{\"name\": \"e2e-test\", \"repository_url\": \"file:///var/lib/fc/test-repos/test-flake.git\"}' "
+            "-d '{\"name\": \"e2e-test\", \"repository_url\": \"file:///var/lib/circus/test-repos/test-flake.git\"}' "
             "| jq -r .id"
         )
         e2e_project_id = result.strip()
@@ -177,10 +177,10 @@ pkgs.testers.nixosTest {
             "cd /tmp/test-flake-work && \\\n"
             "cat > flake.nix << 'FLAKE'\n"
             "{\n"
-            '  description = "FC CI test flake v2";\n'
+            '  description = "circus test flake v2";\n'
             '  outputs = { self, ... }: {\n'
             '    packages.x86_64-linux.hello = derivation {\n'
-            '      name = "fc-test-hello-v2";\n'
+            '      name = "circus-test-hello-v2";\n'
             '      system = "x86_64-linux";\n'
             '      builder = "/bin/sh";\n'
             '      args = [ "-c" "echo hello-v2 > $out" ];\n'
@@ -355,7 +355,7 @@ pkgs.testers.nixosTest {
     with subtest("Build with invalid drv_path fails and retries"):
         # Insert a build with an invalid drv_path via SQL
         machine.succeed(
-            "sudo -u postgres psql -d fc -c \""
+            "sudo -u postgres psql -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, priority, retry_count, max_retries, is_aggregate, signed) "
             f"VALUES (gen_random_uuid(), '{e2e_eval_id}', 'bad-build', '/nix/store/invalid-does-not-exist.drv', 'pending', 0, 0, 3, false, false);\""
         )
@@ -377,7 +377,7 @@ pkgs.testers.nixosTest {
         # Insert a build directly via SQL and verify the queue-runner picks it up
         # reactively (within seconds, not waiting for the full poll interval)
         machine.succeed(
-            f"sudo -u fc psql -U fc -d fc -c \""
+            f"sudo -u circus psql -U circus -d circus -c \""
             "INSERT INTO builds (id, evaluation_id, job_name, drv_path, status, priority, retry_count, max_retries, is_aggregate, signed) "
             f"VALUES (gen_random_uuid(), '{e2e_eval_id}', 'notify-build', '/nix/store/invalid-notify-test.drv', 'pending', 0, 0, 1, false, false);\""
         )
@@ -415,26 +415,26 @@ pkgs.testers.nixosTest {
         machine.succeed("rm -f /tmp/webhook.json")
 
         # Configure queue-runner to send webhook notifications
-        machine.succeed("mkdir -p /run/systemd/system/fc-queue-runner.service.d")
+        machine.succeed("mkdir -p /run/systemd/system/circus-queue-runner.service.d")
         machine.succeed(
-            "cat > /run/systemd/system/fc-queue-runner.service.d/webhook.conf << 'EOF'\n"
+            "cat > /run/systemd/system/circus-queue-runner.service.d/webhook.conf << 'EOF'\n"
             "[Service]\n"
-            "Environment=FC_NOTIFICATIONS__WEBHOOK_URL=http://127.0.0.1:9998/notify\n"
+            "Environment=CIRCUS_NOTIFICATIONS__WEBHOOK_URL=http://127.0.0.1:9998/notify\n"
             "EOF\n"
         )
         machine.succeed("systemctl daemon-reload")
-        machine.succeed("systemctl restart fc-queue-runner")
-        machine.wait_for_unit("fc-queue-runner.service", timeout=30)
+        machine.succeed("systemctl restart circus-queue-runner")
+        machine.wait_for_unit("circus-queue-runner.service", timeout=30)
 
         # Push a new commit to trigger a fresh evaluation and build
         machine.succeed(
             "cd /tmp/test-flake-work && \\\n"
             "cat > flake.nix << 'FLAKE'\n"
             "{\n"
-            '  description = "FC CI test flake notify";\n'
+            '  description = "circus test flake notify";\n'
             '  outputs = { self, ... }: {\n'
             '    packages.x86_64-linux.notify-test = derivation {\n'
-            '      name = "fc-notify-test";\n'
+            '      name = "circus-notify-test";\n'
             '      system = "x86_64-linux";\n'
             '      builder = "/bin/sh";\n'
             '      args = [ "-c" "echo notify-test > $out" ];\n'
@@ -456,23 +456,23 @@ pkgs.testers.nixosTest {
 
     with subtest("Generate signing key and configure signing"):
         # Generate a Nix signing key
-        machine.succeed("mkdir -p /var/lib/fc/keys")
-        machine.succeed("nix-store --generate-binary-cache-key fc-test /var/lib/fc/keys/signing-key /var/lib/fc/keys/signing-key.pub")
-        machine.succeed("chown -R fc:fc /var/lib/fc/keys")
-        machine.succeed("chmod 600 /var/lib/fc/keys/signing-key")
+        machine.succeed("mkdir -p /var/lib/circus/keys")
+        machine.succeed("nix-store --generate-binary-cache-key circus-test /var/lib/circus/keys/signing-key /var/lib/circus/keys/signing-key.pub")
+        machine.succeed("chown -R fc:fc /var/lib/circus/keys")
+        machine.succeed("chmod 600 /var/lib/circus/keys/signing-key")
 
         # Enable signing via systemd drop-in override
-        machine.succeed("mkdir -p /run/systemd/system/fc-queue-runner.service.d")
+        machine.succeed("mkdir -p /run/systemd/system/circus-queue-runner.service.d")
         machine.succeed(
-            "cat > /run/systemd/system/fc-queue-runner.service.d/signing.conf << 'EOF'\n"
+            "cat > /run/systemd/system/circus-queue-runner.service.d/signing.conf << 'EOF'\n"
             "[Service]\n"
-            "Environment=FC_SIGNING__ENABLED=true\n"
-            "Environment=FC_SIGNING__KEY_FILE=/var/lib/fc/keys/signing-key\n"
+            "Environment=CIRCUS_SIGNING__ENABLED=true\n"
+            "Environment=CIRCUS_SIGNING__KEY_FILE=/var/lib/circus/keys/signing-key\n"
             "EOF\n"
         )
         machine.succeed("systemctl daemon-reload")
-        machine.succeed("systemctl restart fc-queue-runner")
-        machine.wait_for_unit("fc-queue-runner.service", timeout=30)
+        machine.succeed("systemctl restart circus-queue-runner")
+        machine.wait_for_unit("circus-queue-runner.service", timeout=30)
 
     with subtest("Signed builds have valid signatures"):
         # Create a new build to test signing
@@ -480,10 +480,10 @@ pkgs.testers.nixosTest {
             "cd /tmp/test-flake-work && \\\n"
             "cat > flake.nix << 'FLAKE'\n"
             "{\n"
-            '  description = "FC CI test flake signing";\n'
+            '  description = "circus test flake signing";\n'
             '  outputs = { self, ... }: {\n'
             '    packages.x86_64-linux.sign-test = derivation {\n'
-            '      name = "fc-sign-test";\n'
+            '      name = "circus-sign-test";\n'
             '      system = "x86_64-linux";\n'
             '      builder = "/bin/sh";\n'
             '      args = [ "-c" "echo signed-build > $out" ];\n'
@@ -525,33 +525,33 @@ pkgs.testers.nixosTest {
 
     with subtest("GC roots are created for build products"):
         # Enable GC via systemd drop-in override
-        machine.succeed("mkdir -p /run/systemd/system/fc-queue-runner.service.d")
+        machine.succeed("mkdir -p /run/systemd/system/circus-queue-runner.service.d")
         machine.succeed(
-            "cat > /run/systemd/system/fc-queue-runner.service.d/gc.conf << 'EOF'\n"
+            "cat > /run/systemd/system/circus-queue-runner.service.d/gc.conf << 'EOF'\n"
             "[Service]\n"
-            "Environment=FC_GC__ENABLED=true\n"
-            "Environment=FC_GC__GC_ROOTS_DIR=/nix/var/nix/gcroots/per-user/fc\n"
-            "Environment=FC_GC__MAX_AGE_DAYS=30\n"
-            "Environment=FC_GC__CLEANUP_INTERVAL=3600\n"
+            "Environment=CIRCUS_GC__ENABLED=true\n"
+            "Environment=CIRCUS_GC__GC_ROOTS_DIR=/nix/var/nix/gcroots/per-user/circus\n"
+            "Environment=CIRCUS_GC__MAX_AGE_DAYS=30\n"
+            "Environment=CIRCUS_GC__CLEANUP_INTERVAL=3600\n"
             "EOF\n"
         )
         machine.succeed("systemctl daemon-reload")
-        machine.succeed("systemctl restart fc-queue-runner")
-        machine.wait_for_unit("fc-queue-runner.service", timeout=30)
+        machine.succeed("systemctl restart circus-queue-runner")
+        machine.wait_for_unit("circus-queue-runner.service", timeout=30)
 
         # Ensure the gc roots directory exists
-        machine.succeed("mkdir -p /nix/var/nix/gcroots/per-user/fc")
-        machine.succeed("chown -R fc:fc /nix/var/nix/gcroots/per-user/fc")
+        machine.succeed("mkdir -p /nix/var/nix/gcroots/per-user/circus")
+        machine.succeed("chown -R fc:fc /nix/var/nix/gcroots/per-user/circus")
 
         # Create a new build to test GC root creation
         machine.succeed(
             "cd /tmp/test-flake-work && \\\n"
             "cat > flake.nix << 'FLAKE'\n"
             "{\n"
-            '  description = "FC CI test flake gc";\n'
+            '  description = "circus test flake gc";\n'
             '  outputs = { self, ... }: {\n'
             '    packages.x86_64-linux.gc-test = derivation {\n'
-            '      name = "fc-gc-test";\n'
+            '      name = "circus-gc-test";\n'
             '      system = "x86_64-linux";\n'
             '      builder = "/bin/sh";\n'
             '      args = [ "-c" "echo gc-test > $out" ];\n'
@@ -575,10 +575,10 @@ pkgs.testers.nixosTest {
         ).strip()
 
         # Verify GC root symlink was created
-        # The symlink should be in /nix/var/nix/gcroots/per-user/fc/ and point to the build output
+        # The symlink should be in /nix/var/nix/gcroots/per-user/circus/ and point to the build output
         # Wait for GC root to be created (polling with timeout)
         def wait_for_gc_root():
-            gc_roots = machine.succeed("find /nix/var/nix/gcroots/per-user/fc -type l 2>/dev/null || true").strip()
+            gc_roots = machine.succeed("find /nix/var/nix/gcroots/per-user/circus -type l 2>/dev/null || true").strip()
             if not gc_roots:
                 return False
             for root in gc_roots.split('\n'):
@@ -590,7 +590,7 @@ pkgs.testers.nixosTest {
 
         # Poll for GC root creation (give queue-runner time to create it)
         machine.wait_until_succeeds(
-            "test -e /nix/var/nix/gcroots/per-user/fc",
+            "test -e /nix/var/nix/gcroots/per-user/circus",
             timeout=30
         )
 
@@ -605,11 +605,11 @@ pkgs.testers.nixosTest {
         # Verify build output exists and is protected from GC
         machine.succeed(f"test -e {gc_build_output}")
 
-    with subtest("Declarative .fc.toml in repo auto-creates jobset"):
-        # Add .fc.toml to the test repo with a new jobset definition
+    with subtest("Declarative .circus.toml in repo auto-creates jobset"):
+        # Add .circus.toml to the test repo with a new jobset definition
         machine.succeed(
             "cd /tmp/test-flake-work && "
-            "cat > .fc.toml << 'FCTOML'\n"
+            "cat > .circus.toml << 'FCTOML'\n"
             "[[jobsets]]\n"
             'name = "declarative-checks"\n'
             'nix_expression = "checks"\n'
@@ -630,7 +630,7 @@ pkgs.testers.nixosTest {
     with subtest("Webhook endpoint accepts valid GitHub push"):
         # Create a webhook config via SQL (no REST endpoint for creation)
         machine.succeed(
-            "sudo -u postgres psql -d fc -c \""
+            "sudo -u postgres psql -d circus -c \""
             "INSERT INTO webhook_configs (id, project_id, forge_type, secret_hash, enabled) "
             f"VALUES (gen_random_uuid(), '{e2e_project_id}', 'github', 'test-secret', true);\""
         )
@@ -641,7 +641,7 @@ pkgs.testers.nixosTest {
         ).strip())
 
         # Compute HMAC-SHA256 of the payload
-        payload = '{"ref":"refs/heads/main","after":"abcdef1234567890abcdef1234567890abcdef12","repository":{"clone_url":"file:///var/lib/fc/test-repos/test-flake.git"}}'
+        payload = '{"ref":"refs/heads/main","after":"abcdef1234567890abcdef1234567890abcdef12","repository":{"clone_url":"file:///var/lib/circus/test-repos/test-flake.git"}}'
 
         # Generate HMAC with the secret
         hmac_sig = machine.succeed(

--- a/nix/tests/features.nix
+++ b/nix/tests/features.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-features";
+  name = "circus-features";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -21,10 +21,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -34,7 +34,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -42,14 +42,14 @@ pkgs.testers.nixosTest {
     ro_token = "fc_readonly_key"
     ro_hash = hashlib.sha256(ro_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
     )
     ro_header = f"-H 'Authorization: Bearer {ro_token}'"
 
     # Structured logging
     with subtest("Server produces structured log output"):
         # The server should log via tracing with the configured format
-        result = machine.succeed("journalctl -u fc-server --no-pager -n 50 2>&1")
+        result = machine.succeed("journalctl -u circus-server --no-pager -n 50 2>&1")
         # With compact/full format, tracing outputs level and target info
         assert "INFO" in result or "info" in result, \
             "Expected structured log lines with INFO level in journalctl output"
@@ -86,11 +86,11 @@ pkgs.testers.nixosTest {
             f"-d 'api_key={api_token}' "
             "| grep -i set-cookie | head -1"
         )
-        match = re.search(r'fc_session=([^;]+)', cookie)
+        match = re.search(r'circus_session=([^;]+)', cookie)
         if match:
             session_val = match.group(1)
             body = machine.succeed(
-                f"curl -sf -H 'Cookie: fc_session={session_val}' http://127.0.0.1:3000/projects"
+                f"curl -sf -H 'Cookie: circus_session={session_val}' http://127.0.0.1:3000/projects"
             )
             assert '/projects/new' in body, "Projects page should link to /projects/new wizard"
 
@@ -177,7 +177,7 @@ pkgs.testers.nixosTest {
         # Login to get admin view
         if match:
             body = machine.succeed(
-                f"curl -sf -H 'Cookie: fc_session={session_val}' http://127.0.0.1:3000/admin"
+                f"curl -sf -H 'Cookie: circus_session={session_val}' http://127.0.0.1:3000/admin"
             )
             assert "escapeHtml" in body, "Admin page JS should use escapeHtml"
 

--- a/nix/tests/gc-pinning.nix
+++ b/nix/tests/gc-pinning.nix
@@ -6,18 +6,18 @@
   inherit (lib.modules) mkForce;
 in
   pkgs.testers.nixosTest {
-    name = "fc-gc-pinning";
+    name = "circus-gc-pinning";
 
     nodes.machine = {
       imports = [
-        self.nixosModules.fc-ci
+        self.nixosModules.circus
         ../vm-common.nix
       ];
       _module.args.self = self;
 
-      services.fc-ci.settings.gc = {
+      services.circus.settings.gc = {
         enabled = mkForce true;
-        gc_roots_dir = "/var/lib/fc/gc-roots";
+        gc_roots_dir = "/var/lib/circus/gc-roots";
         cleanup_interval = 9999;
         max_age_days = 1;
       };
@@ -29,21 +29,21 @@ in
 
       machine.start()
       machine.wait_for_unit("postgresql.service")
-      machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
-      machine.wait_for_unit("fc-server.service")
+      machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
+      machine.wait_for_unit("circus-server.service")
       machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
       api_token = "fc_testkey123"
       api_hash = hashlib.sha256(api_token.encode()).hexdigest()
       machine.succeed(
-          f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+          f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
       )
       auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
       ro_token = "fc_readonly_key"
       ro_hash = hashlib.sha256(ro_token.encode()).hexdigest()
       machine.succeed(
-          f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
+          f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('readonly', '{ro_hash}', 'read-only')\""
       )
       ro_header = f"-H 'Authorization: Bearer {ro_token}'"
 
@@ -68,35 +68,35 @@ in
 
       with subtest("keep_nr persists in database"):
           machine.succeed(
-              "sudo -u fc psql -U fc -d fc -c "
+              "sudo -u circus psql -U circus -d circus -c "
               "\"UPDATE jobsets SET keep_nr = 7 WHERE name = 'default'\""
           )
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -tA -c "
+              "sudo -u circus psql -U circus -d circus -tA -c "
               "\"SELECT keep_nr FROM jobsets WHERE name = 'default'\""
           )
           assert result.strip() == "7", f"Expected keep_nr=7, got {result.strip()}"
 
       with subtest("keep_nr visible in active_jobsets view"):
           result = machine.succeed(
-              "sudo -u fc psql -U fc -d fc -tA -c "
+              "sudo -u circus psql -U circus -d circus -tA -c "
               "\"SELECT keep_nr FROM active_jobsets WHERE name = 'default' LIMIT 1\""
           )
           assert result.strip() == "7", f"Expected keep_nr=7 in view, got {result.strip()}"
 
       # Create evaluation + build for keep flag tests
       jobset_id = machine.succeed(
-          "sudo -u fc psql -U fc -d fc -tA -c "
+          "sudo -u circus psql -U circus -d circus -tA -c "
           f"\"SELECT id FROM jobsets WHERE project_id = '{project_id}' AND name = 'default'\""
       ).strip()
 
       eval_id = machine.succeed(
-          "sudo -u fc psql -U fc -d fc -tA -c "
+          "sudo -u circus psql -U circus -d circus -tA -c "
           f"\"INSERT INTO evaluations (jobset_id, commit_hash, status) VALUES ('{jobset_id}', 'abc123', 'completed') RETURNING id\" | head -1"
       ).strip()
 
       build_id = machine.succeed(
-          "sudo -u fc psql -U fc -d fc -tA -c "
+          "sudo -u circus psql -U circus -d circus -tA -c "
           f"\"INSERT INTO builds (evaluation_id, job_name, drv_path, status, system) "
           f"VALUES ('{eval_id}', 'hello', '/nix/store/fake.drv', 'succeeded', 'x86_64-linux') RETURNING id\" | head -1"
       ).strip()

--- a/nix/tests/machine-health.nix
+++ b/nix/tests/machine-health.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-machine-health";
+  name = "circus-machine-health";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -19,14 +19,14 @@ pkgs.testers.nixosTest {
 
     machine.start()
     machine.wait_for_unit("postgresql.service")
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
+    machine.wait_for_unit("circus-server.service")
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -50,7 +50,7 @@ pkgs.testers.nixosTest {
 
     with subtest("Recording failure increments consecutive_failures"):
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = LEAST(consecutive_failures + 1, 4), "
             "last_failure = NOW(), "
@@ -70,12 +70,12 @@ pkgs.testers.nixosTest {
 
     with subtest("Failures cap at 4"):
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             f"UPDATE remote_builders SET consecutive_failures = 10 WHERE id = '{builder_id}'\""
         )
         # Simulate record_failure SQL (same as repo code)
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = LEAST(consecutive_failures + 1, 4), "
             "last_failure = NOW(), "
@@ -83,7 +83,7 @@ pkgs.testers.nixosTest {
             f"WHERE id = '{builder_id}'\""
         )
         result = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -tA -c "
+            "sudo -u circus psql -U circus -d circus -tA -c "
             f"\"SELECT consecutive_failures FROM remote_builders WHERE id = '{builder_id}'\""
         )
         assert result.strip() == "4", f"Expected failures capped at 4, got {result.strip()}"
@@ -91,12 +91,12 @@ pkgs.testers.nixosTest {
     with subtest("Disabled builder excluded from find_for_system"):
         # Set disabled_until far in the future
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET disabled_until = NOW() + interval '1 hour' "
             f"WHERE id = '{builder_id}'\""
         )
         result = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -tA -c "
+            "sudo -u circus psql -U circus -d circus -tA -c "
             "\"SELECT count(*) FROM remote_builders "
             "WHERE enabled = true "
             "AND 'x86_64-linux' = ANY(systems) "
@@ -108,11 +108,11 @@ pkgs.testers.nixosTest {
     with subtest("Non-disabled builder included in find_for_system"):
         # Clear disabled_until
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             f"UPDATE remote_builders SET disabled_until = NULL WHERE id = '{builder_id}'\""
         )
         result = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -tA -c "
+            "sudo -u circus psql -U circus -d circus -tA -c "
             "\"SELECT count(*) FROM remote_builders "
             "WHERE enabled = true "
             "AND 'x86_64-linux' = ANY(systems) "
@@ -124,7 +124,7 @@ pkgs.testers.nixosTest {
     with subtest("Recording success resets health state"):
         # First set some failures
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = 3, "
             "disabled_until = NOW() + interval '1 hour', "
@@ -133,7 +133,7 @@ pkgs.testers.nixosTest {
         )
         # Simulate record_success (same as repo code)
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = 0, "
             "disabled_until = NULL "
@@ -162,11 +162,11 @@ pkgs.testers.nixosTest {
     with subtest("Exponential backoff increases with failures"):
         # Record 1st failure: expect ~60s backoff
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             f"UPDATE remote_builders SET consecutive_failures = 0, disabled_until = NULL WHERE id = '{builder_id}'\""
         )
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = LEAST(consecutive_failures + 1, 4), "
             "last_failure = NOW(), "
@@ -174,7 +174,7 @@ pkgs.testers.nixosTest {
             f"WHERE id = '{builder_id}'\""
         )
         delta1 = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -tA -c "
+            "sudo -u circus psql -U circus -d circus -tA -c "
             f"\"SELECT EXTRACT(EPOCH FROM (disabled_until - last_failure))::int FROM remote_builders WHERE id = '{builder_id}'\""
         )
         d1 = int(delta1.strip())
@@ -182,7 +182,7 @@ pkgs.testers.nixosTest {
 
         # Record 2nd failure: expect ~180s backoff
         machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \""
+            "sudo -u circus psql -U circus -d circus -c \""
             "UPDATE remote_builders SET "
             "consecutive_failures = LEAST(consecutive_failures + 1, 4), "
             "last_failure = NOW(), "
@@ -190,7 +190,7 @@ pkgs.testers.nixosTest {
             f"WHERE id = '{builder_id}'\""
         )
         delta2 = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -tA -c "
+            "sudo -u circus psql -U circus -d circus -tA -c "
             f"\"SELECT EXTRACT(EPOCH FROM (disabled_until - last_failure))::int FROM remote_builders WHERE id = '{builder_id}'\""
         )
         d2 = int(delta2.strip())

--- a/nix/tests/s3-cache.nix
+++ b/nix/tests/s3-cache.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-s3-cache-upload";
+  name = "circus-s3-cache-upload";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -22,12 +22,12 @@ pkgs.testers.nixosTest {
       '';
     };
 
-    # Configure FC to upload to the local MinIO instance
-    services.fc-ci = {
+    # Configure circus to upload to the local MinIO instance
+    services.circus = {
       settings = {
         cache_upload = {
           enabled = true;
-          store_uri = "s3://fc-cache?endpoint=http://127.0.0.1:9000&region=us-east-1";
+          store_uri = "s3://circus-cache?endpoint=http://127.0.0.1:9000&region=us-east-1";
           s3 = {
             region = "us-east-1";
             access_key_id = "minioadmin";
@@ -49,7 +49,7 @@ pkgs.testers.nixosTest {
 
     # Wait for PostgreSQL
     machine.wait_for_unit("postgresql.service")
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
     # Wait for MinIO to be ready
     machine.wait_for_unit("minio.service")
@@ -57,38 +57,38 @@ pkgs.testers.nixosTest {
 
     # Configure MinIO client and create bucket
     machine.succeed("${pkgs.minio-client}/bin/mc alias set local http://127.0.0.1:9000 minioadmin minioadmin")
-    machine.succeed("${pkgs.minio-client}/bin/mc mb local/fc-cache")
-    machine.succeed("${pkgs.minio-client}/bin/mc policy set public local/fc-cache")
+    machine.succeed("${pkgs.minio-client}/bin/mc mb local/circus-cache")
+    machine.succeed("${pkgs.minio-client}/bin/mc policy set public local/circus-cache")
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
     # Seed an API key for write operations
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
     # Create a test flake inside the VM
     with subtest("Create bare git repo with test flake"):
-        machine.succeed("mkdir -p /var/lib/fc/test-repos")
-        machine.succeed("git init --bare /var/lib/fc/test-repos/s3-test-flake.git")
+        machine.succeed("mkdir -p /var/lib/circus/test-repos")
+        machine.succeed("git init --bare /var/lib/circus/test-repos/s3-test-flake.git")
 
         # Create a working copy, write the flake, commit, push
         machine.succeed("mkdir -p /tmp/s3-test-flake")
         machine.succeed("cd /tmp/s3-test-flake && git init")
-        machine.succeed("cd /tmp/s3-test-flake && git config user.email 'test@fc' && git config user.name 'FC Test'")
+        machine.succeed("cd /tmp/s3-test-flake && git config user.email 'test@circus' && git config user.name 'circus Test'")
 
         # Write a minimal flake.nix that builds a simple derivation
         machine.succeed("""
             cat > /tmp/s3-test-flake/flake.nix << 'FLAKE'
             {
-              description = "FC CI S3 cache test flake";
+              description = "circus S3 cache test flake";
               outputs = { self, ... }: {
                 packages.x86_64-linux.s3-test = derivation {
-                  name = "fc-s3-test";
+                  name = "circus-s3-test";
                   system = "x86_64-linux";
                   builder = "/bin/sh";
                   args = [ "-c" "echo s3-cache-test-content > $out" ];
@@ -98,9 +98,9 @@ pkgs.testers.nixosTest {
             FLAKE
         """)
         machine.succeed("cd /tmp/s3-test-flake && git add -A && git commit -m 'initial flake'")
-        machine.succeed("cd /tmp/s3-test-flake && git remote add origin /var/lib/fc/test-repos/s3-test-flake.git")
+        machine.succeed("cd /tmp/s3-test-flake && git remote add origin /var/lib/circus/test-repos/s3-test-flake.git")
         machine.succeed("cd /tmp/s3-test-flake && git push origin HEAD:refs/heads/master")
-        machine.succeed("chown -R fc:fc /var/lib/fc/test-repos")
+        machine.succeed("chown -R fc:fc /var/lib/circus/test-repos")
 
     # Create project + jobset
     with subtest("Create S3 test project and jobset"):
@@ -108,7 +108,7 @@ pkgs.testers.nixosTest {
             "curl -sf -X POST http://127.0.0.1:3000/api/v1/projects "
             f"{auth_header} "
             "-H 'Content-Type: application/json' "
-            "-d '{\"name\": \"s3-test-project\", \"repository_url\": \"file:///var/lib/fc/test-repos/s3-test-flake.git\"}' "
+            "-d '{\"name\": \"s3-test-project\", \"repository_url\": \"file:///var/lib/circus/test-repos/s3-test-flake.git\"}' "
             "| jq -r .id"
         )
         project_id = result.strip()
@@ -165,7 +165,7 @@ pkgs.testers.nixosTest {
     # Verify the build output was uploaded to S3
     with subtest("Build output was uploaded to S3 cache"):
         # List objects in the S3 bucket
-        bucket_contents = machine.succeed("${pkgs.minio-client}/bin/mc ls --recursive local/fc-cache/")
+        bucket_contents = machine.succeed("${pkgs.minio-client}/bin/mc ls --recursive local/circus-cache/")
 
         # Should have the .narinfo file and the .nar file
         assert ".narinfo" in bucket_contents, f"Expected .narinfo file in bucket, got: {bucket_contents}"
@@ -178,7 +178,7 @@ pkgs.testers.nixosTest {
 
         # Try to get the narinfo from S3
         narinfo_content = machine.succeed(
-            f"curl -sf http://127.0.0.1:9000/fc-cache/{store_hash}.narinfo"
+            f"curl -sf http://127.0.0.1:9000/circus-cache/{store_hash}.narinfo"
         )
         assert "StorePath:" in narinfo_content, f"Expected StorePath in narinfo: {narinfo_content}"
         assert "NarHash:" in narinfo_content, f"Expected NarHash in narinfo: {narinfo_content}"
@@ -190,7 +190,7 @@ pkgs.testers.nixosTest {
         )
         # The nix copy output should appear in the log or the system log
         # We'll check that the cache upload was attempted by looking at system logs
-        journal_log = machine.succeed("journalctl -u fc-queue-runner --since '5 minutes ago' --no-pager")
+        journal_log = machine.succeed("journalctl -u circus-queue-runner --since '5 minutes ago' --no-pager")
         assert "Pushed to binary cache" in journal_log or "nix copy" in journal_log, \
             f"Expected cache upload in logs: {journal_log}"
 

--- a/nix/tests/startup.nix
+++ b/nix/tests/startup.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-service-startup";
+  name = "circus-service-startup";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -18,29 +18,29 @@ pkgs.testers.nixosTest {
     machine.wait_for_unit("postgresql.service")
 
     # Ensure PostgreSQL is actually ready to accept connections
-    # before fc-server starts. Not actually implied by the wait_for_unit
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # before circus-server starts. Not actually implied by the wait_for_unit
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
 
     # Verify all three services start
-    with subtest("fc-evaluator.service starts without crash"):
-        machine.wait_for_unit("fc-evaluator.service", timeout=30)
-        result = machine.succeed("journalctl -u fc-evaluator --no-pager -n 20 2>&1")
+    with subtest("circus-evaluator.service starts without crash"):
+        machine.wait_for_unit("circus-evaluator.service", timeout=30)
+        result = machine.succeed("journalctl -u circus-evaluator --no-pager -n 20 2>&1")
         assert "binary not found" not in result.lower(), f"Evaluator has 'binary not found' error: {result}"
         assert "No such file" not in result, f"Evaluator has 'No such file' error: {result}"
 
-    with subtest("fc-queue-runner.service starts without crash"):
-        machine.wait_for_unit("fc-queue-runner.service", timeout=30)
-        result = machine.succeed("journalctl -u fc-queue-runner --no-pager -n 20 2>&1")
+    with subtest("circus-queue-runner.service starts without crash"):
+        machine.wait_for_unit("circus-queue-runner.service", timeout=30)
+        result = machine.succeed("journalctl -u circus-queue-runner --no-pager -n 20 2>&1")
         assert "binary not found" not in result.lower(), f"Queue runner has 'binary not found' error: {result}"
         assert "No such file" not in result, f"Queue runner has 'No such file' error: {result}"
 
-    with subtest("All three FC services are active"):
-        for svc in ["fc-server", "fc-evaluator", "fc-queue-runner"]:
+    with subtest("All three circus services are active"):
+        for svc in ["circus-server", "circus-evaluator", "circus-queue-runner"]:
             result = machine.succeed(f"systemctl is-active {svc}")
             assert result.strip() == "active", f"Expected {svc} to be active, got '{result.strip()}'"
 

--- a/nix/tests/webhooks.nix
+++ b/nix/tests/webhooks.nix
@@ -3,11 +3,11 @@
   self,
 }:
 pkgs.testers.nixosTest {
-  name = "fc-webhooks";
+  name = "circus-webhooks";
 
   nodes.machine = {
     imports = [
-      self.nixosModules.fc-ci
+      self.nixosModules.circus
       ../vm-common.nix
     ];
     _module.args.self = self;
@@ -21,10 +21,10 @@ pkgs.testers.nixosTest {
     machine.start()
     machine.wait_for_unit("postgresql.service")
 
-    # Ensure PostgreSQL is actually ready to accept connections before fc-server starts
-    machine.wait_until_succeeds("sudo -u fc psql -U fc -d fc -c 'SELECT 1'", timeout=30)
+    # Ensure PostgreSQL is actually ready to accept connections before circus-server starts
+    machine.wait_until_succeeds("sudo -u circus psql -U circus -d circus -c 'SELECT 1'", timeout=30)
 
-    machine.wait_for_unit("fc-server.service")
+    machine.wait_for_unit("circus-server.service")
 
     # Wait for the server to start listening
     machine.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=30)
@@ -33,7 +33,7 @@ pkgs.testers.nixosTest {
     api_token = "fc_testkey123"
     api_hash = hashlib.sha256(api_token.encode()).hexdigest()
     machine.succeed(
-        f"sudo -u fc psql -U fc -d fc -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
+        f"sudo -u circus psql -U circus -d circus -c \"INSERT INTO api_keys (name, key_hash, role) VALUES ('test', '{api_hash}', 'admin')\""
     )
     auth_header = f"-H 'Authorization: Bearer {api_token}'"
 
@@ -88,7 +88,7 @@ pkgs.testers.nixosTest {
     with subtest("GitHub push webhook triggers evaluation"):
         # First count evaluations
         count_before = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
 
         # Send push event (signature would normally be verified but we're testing)
@@ -108,7 +108,7 @@ pkgs.testers.nixosTest {
 
         # Check evaluation was created
         count_after = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
         assert int(count_after) > int(count_before), \
             f"Expected new evaluation, count before={count_before}, after={count_after}"
@@ -140,7 +140,7 @@ pkgs.testers.nixosTest {
 
     with subtest("GitHub pull_request webhook triggers evaluation with PR metadata"):
         count_before = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
         ).strip()
 
         payload = json.dumps({
@@ -164,14 +164,14 @@ pkgs.testers.nixosTest {
         )
 
         count_after = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
         ).strip()
         assert int(count_after) > int(count_before), \
             f"Expected PR evaluation, count before={count_before}, after={count_after}"
 
         # Verify PR metadata was stored
         pr_data = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT pr_number, pr_head_branch, pr_base_branch FROM evaluations WHERE pr_number = 42\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT pr_number, pr_head_branch, pr_base_branch FROM evaluations WHERE pr_number = 42\" -t"
         ).strip()
         assert "42" in pr_data, f"Expected PR number 42 in {pr_data}"
         assert "feature-branch" in pr_data, f"Expected feature-branch in {pr_data}"
@@ -231,7 +231,7 @@ pkgs.testers.nixosTest {
 
     with subtest("GitLab Push Hook triggers evaluation"):
         count_before = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
 
         machine.succeed(
@@ -243,7 +243,7 @@ pkgs.testers.nixosTest {
         )
 
         count_after = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
         assert int(count_after) > int(count_before), \
             "Expected new evaluation from GitLab push"
@@ -260,7 +260,7 @@ pkgs.testers.nixosTest {
 
     with subtest("GitLab Merge Request Hook triggers evaluation with PR metadata"):
         count_before = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
         ).strip()
 
         payload = json.dumps({
@@ -285,7 +285,7 @@ pkgs.testers.nixosTest {
         )
 
         count_after = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations WHERE pr_number IS NOT NULL\" -t"
         ).strip()
         assert int(count_after) > int(count_before), \
             f"Expected MR evaluation, count before={count_before}, after={count_after}"
@@ -342,7 +342,7 @@ pkgs.testers.nixosTest {
 
     with subtest("Gitea push webhook triggers evaluation"):
         count_before = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
 
         payload = '{"ref":"refs/heads/main","after":"gitea123456789012345678901234567890abcd"}'
@@ -356,7 +356,7 @@ pkgs.testers.nixosTest {
         )
 
         count_after = machine.succeed(
-            "sudo -u fc psql -U fc -d fc -c \"SELECT COUNT(*) FROM evaluations\" -t"
+            "sudo -u circus psql -U circus -d circus -c \"SELECT COUNT(*) FROM evaluations\" -t"
         ).strip()
         assert int(count_after) > int(count_before), \
             "Expected new evaluation from Gitea push"

--- a/nix/vm-common.nix
+++ b/nix/vm-common.nix
@@ -5,9 +5,9 @@
   ...
 }: let
   inherit (lib.modules) mkDefault;
-  fc-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+  circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
 in {
-  # Common machine configuration for all FC integration tests
+  # Common machine configuration for all circus integration tests
   config = {
     ## VM hardware
     virtualisation = {
@@ -44,13 +44,13 @@ in {
     # the host machine.
     networking.firewall.allowedTCPPorts = [3000];
 
-    services.fc-ci = {
+    services.circus = {
       enable = true;
 
-      package = mkDefault fc-packages.fc-server;
-      evaluatorPackage = mkDefault fc-packages.fc-evaluator;
-      queueRunnerPackage = mkDefault fc-packages.fc-queue-runner;
-      migratePackage = mkDefault fc-packages.fc-migrate-cli;
+      package = mkDefault circus-packages.circus-server;
+      evaluatorPackage = mkDefault circus-packages.circus-evaluator;
+      queueRunnerPackage = mkDefault circus-packages.circus-queue-runner;
+      migratePackage = mkDefault circus-packages.circus-migrate-cli;
 
       server.enable = true;
       evaluator.enable = true;
@@ -67,7 +67,7 @@ in {
         };
 
         gc.enabled = false;
-        logs.log_dir = "/var/lib/fc/logs";
+        logs.log_dir = "/var/lib/circus/logs";
         cache.enabled = true;
         signing.enabled = false;
 
@@ -80,14 +80,14 @@ in {
 
         evaluator = {
           poll_interval = 5;
-          work_dir = "/var/lib/fc/evaluator";
+          work_dir = "/var/lib/circus/evaluator";
           nix_timeout = 60;
           strict_errors = true;
         };
 
         queue_runner = {
           poll_interval = 3;
-          work_dir = "/var/lib/fc/queue-runner";
+          work_dir = "/var/lib/circus/queue-runner";
           strict_errors = true;
         };
       };


### PR DESCRIPTION
It's called circus because it has "ci" in the name, and CI is for clowns.

Change-Id: I6d7a4ecb5e1e28ee6f1227786cdf65ef6a6a6964