### PR TITLE
build: fix common build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ circus-queue-runner = { path = "./crates/queue-runner", version = "0.4.0-dev" }
 circus-server       = { path = "./crates/server", version = "0.4.0-dev" }
 
 anyhow = "1.0.102"
-argon2 = "0.5.3"
+# `rand_core::OsRng` in ./crates/common/src/repo/users.rs:28
+# Item `os::OsRng` is configured out by feature flag.
+# crate/feature flag chain:
+# argon/std -> password-hash/std -> rand_core/std -> getrandom
+argon2 = { version = "0.5.3", features = [ "std" ] }
 askama = "0.16.0"
 async-stream = "0.3.6"
 axum = "0.8.9"


### PR DESCRIPTION
I just started using the project today and noticed a dependency issue with argon2 when building from main via the NixOS module.

I didn't see any contribution guidelines so please let me know if anything is wrong or if you aren't accepting pull requests.