### PR TITLE
build: fix broken migrations after sqlx version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "uuid",
+ "whoami",
 ]
 
 [[package]]
@@ -1196,7 +1197,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1815,6 +1816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2024,6 +2034,24 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3702,6 +3730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3851,6 +3897,13 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = [ "env-filter", "json" ] }
 urlencoding = "2.1.3"
 uuid = { version = "1.23.1", features = [ "v4", "serde" ] }
+whoami = { version = "2.1.2", features = [ "std" ] }
 xz2 = "0.1.7"
 
 # See:

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -32,3 +32,4 @@ tracing.workspace            = true
 tracing-subscriber.workspace = true
 urlencoding.workspace        = true
 uuid.workspace               = true
+whoami.workspace             = true


### PR DESCRIPTION
sqlx-postgres 0.8.6 -> 0.9.0 caused whoami 1.6.1 -> 2.1.2. In v2 of whoami it's no_std by default (as sqlx-postgres uses it) meaning it falls back to a stub seen here:
<https://github.com/ardaku/whoami/blob/23f3b8f06c663a2c131ebb9c101e9526b9d685cf/whoami/src/os/stub.rs#L27-L30>

Adding whoami with the "std" feature as a dependency fixes it.

This appears as a migration error during server launch because authentication fails for the user "anonymous" because sqlx-postgres was unable to get the username:

```log
May 27 19:08:57 plum systemd[1]: circus-server.service: Scheduled restart job, restart counter is at 54.
May 27 19:08:57 plum systemd[1]: Starting circus Server...
May 27 19:08:57 plum circus-migrate[1116359]: Error: error returned from database: Peer authentication failed for user "anonymous" at line 332
May 27 19:08:57 plum circus-migrate[1116359]: Caused by:
May 27 19:08:57 plum circus-migrate[1116359]:     Peer authentication failed for user "anonymous" at line 332
May 27 19:08:57 plum systemd[1]: circus-server.service: Control process exited, code=exited, status=1/FAILURE
May 27 19:08:57 plum systemd[1]: circus-server.service: Failed with result 'exit-code'.
May 27 19:08:57 plum systemd[1]: Failed to start circus Server.
```

Alternatively, we could do it at the config level, I think, if we give sqlx a username to use.