### PR TITLE
evaluator: fix unavailable TLS stream git error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -1811,6 +1814,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -2049,9 +2053,27 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -2603,7 +2625,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4.6.1", features = [ "derive" ] }
 config = "0.15.23"
 dashmap = "6.2.1"
 futures = "0.3.32"
-git2 = "0.21.0"
+git2 = { version = "0.21.0", features = ["https"] }
 hex = "0.4.3"
 hmac = "0.13.0"
 humantime-serde = "1.1.1"


### PR DESCRIPTION
git2 needs "https" feature.

```log
May 27 19:35:48 plum circus-evaluator[1128995]: 2026-05-27T17:35:48.858918Z 
ERROR circus_evaluator::eval_loop: Failed to evaluate jobset: Git error: there 
is no TLS stream available; class=Ssl (16) jobset_id=356b93a4-15bf-4c57-aee2-
be279cf13362 jobset_name=checks
```