### PR TITLE
nix: add circus user to allowed-users for nix-eval-jobs

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -638,6 +638,11 @@ in {
 
     users.groups.circus = {};
 
+    # NOTE: needed by nix-eval-jobs to access the Nix daemon.
+    # This is completely undocumented but used by other projects in a similar
+    # fashion to solve the same problem without clobbering `allowed-users`.
+    nix.settings.extra-allowed-users = [ "circus" ];
+
     services.postgresql = mkIf cfg.database.createLocally {
       enable = true;
       ensureDatabases = ["circus"];


### PR DESCRIPTION
#19 contains more detail so I'll keep it brief here:

- circus-evaluator failed to find nix-eval-jobs despite being in PATH
- error was misleading, circus-evaluator couldn't access the Nix daemon
- fix by adding "circus" user to the (undocumented) `extra-allowed-users` list to avoid clobbering `allowed-users`

closes #19