### PR TITLE
various: allow adding API keys as path to a secret

### DIFF
--- a/crates/common/src/bootstrap.rs
+++ b/crates/common/src/bootstrap.rs
@@ -219,8 +219,37 @@ pub async fn run(pool: &PgPool, config: &DeclarativeConfig) -> Result<()> {
 
   // Upsert API keys
   for decl_key in &config.api_keys {
+    // Resolve key from inline or file
+    let key = decl_key.key.as_ref().map_or_else(
+      || {
+        decl_key.key_file.as_ref().and_then(|file| {
+          let expanded = expand_path(file);
+          match std::fs::read_to_string(&expanded) {
+            Ok(k) => Some(k.trim().to_string()),
+            Err(e) => {
+              tracing::warn!(
+                name = %decl_key.name,
+                file = %expanded,
+                "Failed to read API key file: {e}"
+              );
+              None
+            },
+          }
+        })
+      },
+      |k| Some(k.clone()),
+    );
+
+    let Some(key) = key else {
+      tracing::warn!(
+        name = %decl_key.name,
+        "Declarative API key has no key or key_file set, skipping"
+      );
+      continue;
+    };
+
     let mut hasher = Sha256::new();
-    hasher.update(decl_key.key.as_bytes());
+    hasher.update(key.as_bytes());
     let key_hash = hex::encode(hasher.finalize());
 
     let api_key =

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -499,10 +499,13 @@ pub struct DeclarativeJobsetInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeclarativeApiKey {
-  pub name: String,
-  pub key:  String,
+  pub name:     String,
+  /// API key provided inline (for dev/testing only).
+  pub key:      Option<String>,
+  /// Path to a file containing the API key (for production use with secrets).
+  pub key_file: Option<String>,
   #[serde(default = "default_role")]
-  pub role: String,
+  pub role:     String,
 }
 
 /// Declarative user definition for configuration-driven user management.
@@ -1003,9 +1006,10 @@ mod tests {
         members:        vec![],
       }],
       api_keys:        vec![DeclarativeApiKey {
-        name: "test-key".to_string(),
-        key:  "circus_test".to_string(),
-        role: "admin".to_string(),
+        name:     "test-key".to_string(),
+        key:      Some("circus_test".to_string()),
+        key_file: None,
+        role:     "admin".to_string(),
       }],
       users:           vec![],
       remote_builders: vec![],

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -73,13 +73,20 @@
         })
       cfg.declarative.projects;
 
-      api_keys =
-        map (k: {
+      api_keys = map (k: let
+        hasInlineKey = k.key != null;
+        _ =
+          if hasInlineKey
+          then lib.warn "API key '${k.name}' has inline key set. Use keyFile instead to avoid plaintext keys in the Nix store." null
+          else null;
+      in
+        filterAttrs (_: v: v != null) {
           name = k.name;
           key = k.key;
+          key_file = k.keyFile;
           role = k.role;
         })
-        cfg.declarative.apiKeys;
+      cfg.declarative.apiKeys;
 
       users = mapAttrsToList (username: u:
         filterAttrs (_: v: v != null) {
@@ -322,10 +329,21 @@
       };
 
       key = mkOption {
-        type = str;
+        type = nullOr str;
+        default = null;
         description = ''
           The raw API key value (e.g. "circus_mykey123").
-          Will be hashed before storage. Consider using a secrets manager.
+          Will be hashed before storage.
+          For development/testing only. Use {option}`keyFile` for production.
+        '';
+      };
+
+      keyFile = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          Path to a file containing the API key.
+          Preferred for production deployments.
         '';
       };
 
@@ -543,12 +561,12 @@ in {
         example = [
           {
             name = "admin";
-            key = "circus_admin_secret";
+            keyFile = "/run/secrets/circus-admin-key";
             role = "admin";
           }
           {
             name = "ci-bot";
-            key = "circus_bot_key";
+            keyFile = "/run/secrets/circus-bot-key";
             role = "eval-jobset";
           }
         ];
@@ -619,13 +637,20 @@ in {
 
   config = mkIf cfg.enable {
     assertions =
-      mapAttrsToList (
-        username: user: {
-          assertion = user.password != null || user.passwordFile != null;
-          message = "User '${username}' must have either 'password' or 'passwordFile' set.";
-        }
-      )
-      cfg.declarative.users;
+      (map (
+          k: {
+            assertion = k.key != null || k.keyFile != null;
+            message = "API key '${k.name}' must have either 'key' or 'keyFile' set.";
+          }
+        )
+        cfg.declarative.apiKeys)
+      ++ (mapAttrsToList (
+          username: user: {
+            assertion = user.password != null || user.passwordFile != null;
+            message = "User '${username}' must have either 'password' or 'passwordFile' set.";
+          }
+        )
+        cfg.declarative.users);
 
     users.users.circus = {
       isSystemUser = true;


### PR DESCRIPTION
Follows the same pattern as other similar options by allowing both a string (for development) or path to a secret (for production). It's currently running with the new option on my instance.

If this looks good, I planned to do it for the other options too. Here's the ones I found:
- `GitHubOAuthConfig` -> `client_secret` - `String`
- `NotificationsConfig` -> `*_token` - `Option<String>`
- `EmailConfig` -> `smtp_password` - `Option<String>`
- `S3CacheConfig` -> `access_key_id`/`secret_access_key` - `Option<String>`


I also ran the formatter and kept the files I changed, sorry if the diff is a little worse because of it. Maybe we can format main once it's quieter?

Also, how do you prefer such PR titles to be formatted?
