### PR TITLE
queue-runner: ssh fixes

### DIFF
--- a/crates/queue-runner/src/psi.rs
+++ b/crates/queue-runner/src/psi.rs
@@ -75,6 +75,8 @@ impl PsiCache {
 /// Returns `None` if anything goes wrong - the caller then treats the builder
 /// as unloaded rather than penalizing it for a transient connectivity blip.
 pub async fn read(ssh_uri: &str, timeout: Duration) -> Option<PsiSnapshot> {
+  // Ensure ssh-ng is ignored here.
+  let ssh_uri = ssh_uri.strip_prefix("ssh-ng://").unwrap_or(ssh_uri);
   let cmd = tokio::process::Command::new("ssh")
     .args([
       "-o",

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -835,7 +835,14 @@ async fn try_remote_build(
     }
 
     // Build remotely via --store
-    let store_uri = format!("ssh://{}", builder.ssh_uri);
+    // Allow ssh-ng but default to ssh.
+    let store_uri = if builder.ssh_uri.starts_with("ssh://")
+      || builder.ssh_uri.starts_with("ssh-ng://")
+    {
+      builder.ssh_uri.clone()
+    } else {
+      format!("ssh://{}", builder.ssh_uri)
+    };
     let result = crate::builder::run_nix_build_remote(
       drv_path,
       work_dir,

--- a/nix/modules/circus.nix
+++ b/nix/modules/circus.nix
@@ -831,6 +831,7 @@ in {
 
           path = with pkgs; [
             nix
+            openssh
           ];
 
           serviceConfig = {


### PR DESCRIPTION
Ensure the ssh string is correct for both stores and builders which fixes this error when starting a remote build. Also, we now allow `ssh-ng://` URIs but it is stripped for ssh commands.

openssh package added to the NixOS module to fix this error:
```
error: Could not find executable 'ssh'
```
