### PR TITLE
queue-runner: build dispatched drvs on agents via the cache

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -56,6 +56,8 @@ jobs:
             check: declarative
           - name: Distributed
             check: distributed
+          - name: Agent Dispatch
+            check: agent-dispatch
           - name: GC Pinning
             check: gc-pinning
           - name: Machine Health

--- a/crates/agent/src/build.rs
+++ b/crates/agent/src/build.rs
@@ -16,11 +16,13 @@ use tokio_util::sync::CancellationToken;
 
 /// Per-build options handed down from the runner via the capnp schema.
 pub struct BuildOptions<'a> {
-  pub drv_path:        &'a str,
-  pub max_log_size:    u64,
-  pub max_silent_time: Duration,
-  pub build_timeout:   Duration,
-  pub extra_args:      Vec<String>,
+  pub drv_path:         &'a str,
+  pub max_log_size:     u64,
+  pub max_silent_time:  Duration,
+  pub build_timeout:    Duration,
+  pub extra_args:       Vec<String>,
+  pub cache_url:        String,
+  pub cache_public_key: String,
 }
 
 /// One output discovered after a successful realisation.
@@ -72,6 +74,17 @@ pub async fn run(
     "internal-json".into(),
     opts.drv_path.into(),
   ];
+  // Substitute the drv closure from the runner's cache.
+  if !opts.cache_url.is_empty() {
+    args.push("--option".into());
+    args.push("extra-substituters".into());
+    args.push(opts.cache_url.clone());
+    if !opts.cache_public_key.is_empty() {
+      args.push("--option".into());
+      args.push("extra-trusted-public-keys".into());
+      args.push(opts.cache_public_key.clone());
+    }
+  }
   args.extend(opts.extra_args.iter().cloned());
 
   let mut cmd = Command::new("nix-store");

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -408,6 +408,8 @@ impl builder::Server for BuilderImpl {
       let build_id = Uuid::parse_str(&build_id_str)
         .map_err(|e| capnp::Error::failed(format!("bad build_id: {e}")))?;
       let drv_path = job.get_drv_path()?.to_str()?.to_owned();
+      let cache_url = job.get_cache_url()?.to_str()?.to_owned();
+      let cache_public_key = job.get_cache_public_key()?.to_str()?.to_owned();
       let max_log_size = job.get_max_log_size();
       let max_silent_time = job.get_max_silent_time();
       let build_timeout = job.get_build_timeout();
@@ -468,6 +470,8 @@ impl builder::Server for BuilderImpl {
             max_silent_time: Duration::from_secs(max_silent_time.into()),
             build_timeout: Duration::from_secs(build_timeout.into()),
             extra_args: extra,
+            cache_url,
+            cache_public_key,
           },
           log,
           cancel,
@@ -528,6 +532,26 @@ impl builder::Server for BuilderImpl {
               }
             },
           }
+        }
+
+        match &outcome {
+          Ok(r) if matches!(r.outcome, circus_proto::BuildOutcome::Success) => {
+            tracing::info!(
+              %build_id,
+              build_time_ms = r.build_time_ms,
+              "build succeeded"
+            );
+          },
+          Ok(r) => {
+            tracing::warn!(
+              %build_id,
+              outcome = ?r.outcome,
+              exit_code = r.exit_code,
+              error = %r.error_message,
+              "build failed"
+            );
+          },
+          Err(e) => tracing::error!(%build_id, "build run errored: {e}"),
         }
 
         if let Err(e) = report_result(&result, outcome).await {

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -247,6 +247,14 @@ pub struct RpcConfig {
   /// agent from scheduling decisions.
   #[serde(default = "default_heartbeat_ttl_secs")]
   pub heartbeat_ttl_secs: u64,
+
+  /// Cache agents substitute drv closures from, forwarded to each agent.
+  #[serde(default)]
+  pub cache_substituter: Option<String>,
+
+  /// Public key to trust for `cache_substituter`.
+  #[serde(default)]
+  pub cache_public_key: Option<String>,
 }
 
 /// Server-side TLS material for the capnp-rpc endpoint. When `client_ca`

--- a/crates/proto/schema/circus.capnp
+++ b/crates/proto/schema/circus.capnp
@@ -122,6 +122,8 @@ struct BuildAssignment {
   # cache-upload path off; present switches the agent to upload directly to
   # the runner's configured S3 bucket via presigned URLs.
   presignedUpload @8 :PresignedUploadOpts;
+  cacheUrl        @9 :Text;       # Cache to substitute the drv closure from
+  cachePublicKey  @10 :Text;      # Key to trust for it
 }
 
 struct PresignedUploadOpts {

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -76,6 +76,10 @@ pub struct ServerConfig {
   /// `<key-name>:<base64-secret>`). When set, narinfo records are signed
   /// before persistence so cache fetchers see a trust-rooted entry.
   pub signing_key_file:   Option<std::path::PathBuf>,
+  /// Cache forwarded to agents so they can substitute drv closures.
+  pub cache_substituter:  Option<String>,
+  /// Key forwarded to agents so they can substitute drv closures.
+  pub cache_public_key:   Option<String>,
   active_uploads: Arc<parking_lot::Mutex<HashMap<UploadKey, ExpectedUpload>>>,
 }
 
@@ -141,6 +145,8 @@ impl ServerConfig {
       presign_expiry: std::time::Duration::from_secs(cfg.presign_expiry_secs),
       upload_compression: "zstd".to_owned(),
       signing_key_file: None,
+      cache_substituter: cfg.cache_substituter.clone(),
+      cache_public_key: cfg.cache_public_key.clone(),
       active_uploads: Arc::new(parking_lot::Mutex::new(HashMap::new())),
     })
   }
@@ -913,6 +919,13 @@ async fn dispatch_one(
       let build_id_str = cmd.build_id.to_string();
       job.set_build_id(build_id_str.as_str());
       job.set_drv_path(cmd.drv_path.as_str());
+      // Where the agent substitutes the drv closure from.
+      if let Some(url) = cfg.cache_substituter.as_deref() {
+        job.set_cache_url(url);
+      }
+      if let Some(key) = cfg.cache_public_key.as_deref() {
+        job.set_cache_public_key(key);
+      }
       job.set_max_log_size(cmd.max_log_size);
       job.set_max_silent_time(cmd.max_silent_time);
       job.set_build_timeout(cmd.build_timeout);

--- a/crates/server/src/routes/cache.rs
+++ b/crates/server/src/routes/cache.rs
@@ -62,14 +62,34 @@ async fn find_store_path(
     return Ok(path);
   }
 
-  sqlx::query_scalar(
+  let from_builds = sqlx::query_scalar(
     "SELECT build_output_path FROM builds WHERE build_output_path LIKE $1 \
      LIMIT 1",
   )
   .bind(&like_pattern)
   .fetch_optional(pool)
   .await
-  .map_err(|e| ApiError(circus_common::CiError::Database(e)))
+  .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
+
+  if from_builds.is_some() {
+    return Ok(from_builds);
+  }
+
+  // Otherwise serve any local store path so agents can substitute assigned
+  // drv closures.
+  //
+  // FIXME: this shells out to `nix`, and needs the nix-command feature. We
+  // should bind to the Nix C/C++ API and call it directly instead.
+  let resolved = tokio::process::Command::new("nix")
+    .args(["store", "path-from-hash-part", hash])
+    .output()
+    .await
+    .ok()
+    .filter(|o| o.status.success())
+    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+    .filter(|p| !p.is_empty());
+
+  Ok(resolved)
 }
 
 /// Serve `NARInfo` for a store path hash.

--- a/flake.nix
+++ b/flake.nix
@@ -76,10 +76,11 @@
         machine-health = callTest ./nix/tests/machine-health.nix;
         channel-tarball = callTest ./nix/tests/channel-tarball.nix;
         distributed = callTest ./nix/tests/distributed.nix;
+        agent-dispatch = callTest ./nix/tests/agent-dispatch.nix;
         s3-cache = callTest ./nix/tests/s3-cache.nix;
       };
     in {
-      inherit (vmTests) service-startup basic-api auth-rbac api-crud features webhooks e2e declarative gc-pinning machine-health channel-tarball distributed s3-cache;
+      inherit (vmTests) service-startup basic-api auth-rbac api-crud features webhooks e2e declarative gc-pinning machine-health channel-tarball distributed agent-dispatch s3-cache;
       full = pkgs.symlinkJoin {
         name = "vm-tests-full";
         paths = builtins.attrValues vmTests;

--- a/nix/modules/circus-agent.nix
+++ b/nix/modules/circus-agent.nix
@@ -119,11 +119,15 @@ in {
     };
     users.groups.circus-agent = {};
 
+    nix.settings.extra-trusted-users = ["circus-agent"];
+
     systemd.services.circus-agent = {
       description = "Circus distributed build agent";
       after = ["network-online.target" "nix-daemon.service"];
       wants = ["network-online.target"];
       wantedBy = ["multi-user.target"];
+
+      path = [config.nix.package];
 
       serviceConfig = {
         Type = "simple";

--- a/nix/tests/agent-dispatch.nix
+++ b/nix/tests/agent-dispatch.nix
@@ -1,0 +1,245 @@
+# Test the runner and an agent on a SEPARATE store. The agent has no
+# substituters or cache config of its own, so it can only build the dispatched
+# drv by substituting its closure from the cache the runner advertises.
+{
+  testers,
+  pkgs,
+  self,
+}:
+let
+  # Trivial buildable flake: a FOD fetch of an inline file.
+  testFlake = pkgs.writeText "flake.nix" ''
+    {
+      outputs = { self, ... }: {
+        packages.x86_64-linux.hello = derivation {
+          name = "circus-test-hello";
+          system = "x86_64-linux";
+          builder = "builtin:fetchurl";
+          url = "file://''${builtins.toFile "hello.txt" "hello\n"}";
+          outputHashMode = "flat";
+          outputHashAlgo = "sha256";
+          outputHash = "sha256-WJG1tSLV3whtD/CxEPvZ0hu0/HFjrzTQgoai6Eb2vgM=";
+        };
+      };
+    }
+  '';
+in
+testers.runNixOSTest {
+  name = "circus-agent-dispatch";
+
+  nodes = {
+    runner =
+      {
+        pkgs,
+        lib,
+        ...
+      }:
+      let
+        circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+      in
+      {
+        imports = [ self.nixosModules.circus ];
+        _module.args.self = self;
+
+        virtualisation = {
+          diskSize = 10 * 1000;
+          memorySize = 2048;
+          cores = 2;
+        };
+
+        programs.git.enable = true;
+        security.sudo.enable = true;
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+          openssl
+          util-linux
+        ];
+
+        # Throwaway signing key
+        environment.etc."circus/cache-key.sec" = {
+          text = "circus-test-cache-1:C7h9wunIEh7kCa2Ylpa/omVaLewO7gQTb2LEPCPeJ0G6ZsLd2SaJZyt44z6nX5RanSkkrjM4xwapqVPneHY83A==";
+          mode = "0400";
+          user = "circus";
+        };
+
+        nix.settings.experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
+        nix.settings.substituters = lib.mkForce [ ];
+
+        networking.firewall.allowedTCPPorts = [
+          3000
+          8443
+        ];
+
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = [ "circus" ];
+          ensureUsers = [
+            {
+              name = "circus";
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+
+        services.circus = {
+          enable = true;
+          package = circus-packages.circus-server;
+          evaluatorPackage = circus-packages.circus-evaluator;
+          queueRunnerPackage = circus-packages.circus-queue-runner;
+          migratePackage = circus-packages.circus-migrate-cli;
+
+          server.enable = true;
+          evaluator.enable = true;
+          queueRunner.enable = true;
+
+          settings = {
+            database.url = "postgresql:///circus?host=/run/postgresql";
+            server = {
+              host = "0.0.0.0";
+              port = 3000;
+              cors_permissive = false;
+              allowed_url_schemes = [
+                "https"
+                "http"
+                "file"
+              ];
+            };
+            gc.enabled = false;
+            logs.log_dir = "/var/lib/circus/logs";
+            # Serve + sign the local store so the agent can substitute drv closures.
+            cache.enabled = true;
+            cache.secret_key_file = "/etc/circus/cache-key.sec";
+            tracing = {
+              level = "info";
+              format = "compact";
+            };
+            queue_runner = {
+              poll_interval = 3;
+              work_dir = "/var/lib/circus/queue-runner";
+              strict_errors = false;
+              rpc = {
+                bind = "0.0.0.0:8443";
+                max_connections = 64;
+                heartbeat_ttl_secs = 30;
+                auth_tokens = [
+                  "${builtins.hashString "sha256" "demo-agent-token-please-rotate"}"
+                ];
+                # Advertised to agents in the assignment.
+                cache_substituter = "http://runner:3000/nix-cache";
+                cache_public_key = "circus-test-cache-1:umbC3dkmiWcreOM+p1+UWp0pJK4zOMcGqalT53h2PNw=";
+              };
+            };
+          };
+
+          declarative.apiKeys = [
+            {
+              name = "bootstrap-admin";
+              key = "circus_bootstrap_key";
+              role = "admin";
+            }
+          ];
+        };
+      };
+
+    agent =
+      {
+        pkgs,
+        lib,
+        ...
+      }:
+      let
+        circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+      in
+      {
+        imports = [ self.nixosModules.circus-agent ];
+        _module.args.self = self;
+
+        virtualisation = {
+          diskSize = 10 * 1000;
+          memorySize = 2048;
+          cores = 2;
+        };
+
+        environment.systemPackages = with pkgs; [
+          nix
+          curl
+          jq
+        ];
+        nix.settings.experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
+        nix.settings.substituters = lib.mkForce [ ];
+
+        environment.etc."circus-agent/token".text = "demo-agent-token-please-rotate";
+
+        services.circus-agent = {
+          enable = true;
+          package = circus-packages.circus-agent;
+          authTokenFile = "/etc/circus-agent/token";
+          settings.agent = {
+            name = "agent-01";
+            runner_url = "circus://runner:8443";
+            systems = [ pkgs.stdenv.hostPlatform.system ];
+            max_jobs = 2;
+            speed_factor = 1.0;
+            heartbeat_interval_secs = 3;
+            reconnect_delay_secs = 2;
+          };
+        };
+      };
+  };
+
+  testScript = /* py */ ''
+    start_all()
+
+    auth = "-H 'Authorization: Bearer circus_bootstrap_key'"
+    api = "http://127.0.0.1:3000/api/v1"
+
+    def psql(q):
+        return f"""setpriv --reuid=circus --regid=circus --init-groups psql -U circus -d circus -tAc "{q}" """
+
+    # Wait until a count(*) query returns exactly 1.
+    def wait_row(q):
+        runner.wait_until_succeeds(psql(f"SELECT count(*) FROM {q}") + " | grep -qE '^ *1$'", timeout=180)
+
+    with subtest("Services up, agent registered"):
+        runner.wait_for_unit("circus-server.service")
+        runner.wait_for_unit("circus-queue-runner.service")
+        runner.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=60)
+        runner.wait_for_open_port(8443)
+        agent.wait_for_unit("circus-agent.service")
+        # Register before the jobset exists, so the build dispatches to a live agent.
+        wait_row("builder_sessions WHERE name='agent-01' AND connected")
+
+    with subtest("Publish flake, create jobset"):
+        runner.succeed(
+            "mkdir -p /var/lib/circus/test-repos",
+            "git init --bare -q /var/lib/circus/test-repos/test-flake.git",
+            "git config --global --add safe.directory '*'",
+            "git init -q /tmp/wc",
+            "cp ${testFlake} /tmp/wc/flake.nix",
+            "git -C /tmp/wc add -A",
+            "git -C /tmp/wc -c user.email=circus@manic.systems -c user.name=circus commit -qm flake",
+            "git -C /tmp/wc push -q /var/lib/circus/test-repos/test-flake.git HEAD:refs/heads/master",
+            "chown -R circus:circus /var/lib/circus/test-repos",
+        )
+        project = runner.succeed(
+            f"""curl -sf -X POST {api}/projects {auth} -H 'Content-Type: application/json' """
+            """-d '{"name":"t","repository_url":"file:///var/lib/circus/test-repos/test-flake.git"}' | jq -r .id"""
+        ).strip()
+        runner.succeed(
+            f"""curl -sf -X POST {api}/projects/{project}/jobsets {auth} -H 'Content-Type: application/json' """
+            """-d '{"name":"packages","nix_expression":"packages","flake_mode":true,"enabled":true,"check_interval":10}'"""
+        )
+
+    with subtest("Build dispatches to and succeeds on the agent"):
+        # builds_succeeded only rises when the agent realises the drv via the cache, otherwise it would time out.
+        wait_row("builder_sessions WHERE name='agent-01' AND builds_succeeded >= 1")
+        assert runner.succeed(psql("SELECT builds_failed FROM builder_sessions WHERE name='agent-01'")).strip() == "0"
+  '';
+}


### PR DESCRIPTION
Agents realised a bare drv_path locally but were never given the drv, so any agent not sharing the runner's store failed every build and work fell back to local. Now, `/nix-cache` serves any local store path, the runner forwards its cache URL and key in the assignment, and the agent substitutes the closure when realising.

We've been running into this when trying to setup distributed builders, and this should fix it. cc @max-privatevoid