### PR TITLE
server: fix 0 succeeded/failed builds in evaluations

### DIFF
--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -626,42 +626,34 @@ pub(super) async fn evaluation_page(
   .await
   .unwrap_or_default();
 
-  let succeeded = circus_common::repo::builds::count_filtered(
-    &state.pool,
-    Some(id),
-    Some("completed"),
-    None,
-    None,
-  )
-  .await
-  .unwrap_or(0);
-  let failed = circus_common::repo::builds::count_filtered(
-    &state.pool,
-    Some(id),
-    Some("failed"),
-    None,
-    None,
-  )
-  .await
-  .unwrap_or(0);
-  let running = circus_common::repo::builds::count_filtered(
-    &state.pool,
-    Some(id),
-    Some("running"),
-    None,
-    None,
-  )
-  .await
-  .unwrap_or(0);
-  let pending = circus_common::repo::builds::count_filtered(
-    &state.pool,
-    Some(id),
-    Some("pending"),
-    None,
-    None,
-  )
-  .await
-  .unwrap_or(0);
+  let succeeded = builds
+    .iter()
+    .filter(|b| b.status == BuildStatus::Succeeded)
+    .count() as i64;
+  let failed = builds
+    .iter()
+    .filter(|b| {
+      matches!(
+        b.status,
+        BuildStatus::Failed
+          | BuildStatus::DependencyFailed
+          | BuildStatus::FailedWithOutput
+          | BuildStatus::Timeout
+          | BuildStatus::CachedFailure
+          | BuildStatus::LogLimitExceeded
+          | BuildStatus::NarSizeLimitExceeded
+          | BuildStatus::NonDeterministic
+      )
+    })
+    .count() as i64;
+  let running = builds
+    .iter()
+    .filter(|b| b.status == BuildStatus::Running)
+    .count() as i64;
+  let pending = builds
+    .iter()
+    .filter(|b| b.status == BuildStatus::Pending)
+    .count() as i64;
 
   let tmpl = EvaluationTemplate {
     eval:            eval_view(&eval),


### PR DESCRIPTION
Dashboard didn't display successful/failed build counts (stuck at 0).

- use "succeeded" status not "completed" for successful builds
- "failed" only matched exact failures, not all other non-successes
- use already fetched `builds` instead of querying database