### PR TITLE
server: fix 0 succeeded builds in jobsets

### DIFF
--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -5,6 +5,8 @@
 //! These handlers do not mutate server state; they only render templates.
 //! Mutating admin actions live in `super::admin`.
 
+use std::collections::HashMap;
+
 use askama::Template;
 use axum::{
   extract::{Path, Query, State},
@@ -322,6 +324,21 @@ pub(super) async fn jobset_page(
   .await
   .unwrap_or_default();
 
+  let eval_ids: Vec<Uuid> = evals.iter().map(|e| e.id).collect();
+  let builds = circus_common::repo::builds::list_for_jobset_evaluations(
+    &state.pool,
+    id,
+    &eval_ids,
+  )
+  .await
+  .unwrap_or_default();
+
+  let mut builds_by_eval: HashMap<Uuid, Vec<&circus_common::models::Build>> =
+    HashMap::new();
+  for b in &builds {
+    builds_by_eval.entry(b.evaluation_id).or_default().push(b);
+  }
+
   let mut summaries = Vec::new();
   for e in &evals {
     let (text, class) = eval_badge(&e.status);
@@ -330,33 +347,33 @@ pub(super) async fn jobset_page(
     } else {
       e.commit_hash.clone()
     };
-    let succeeded = circus_common::repo::builds::count_filtered(
-      &state.pool,
-      Some(e.id),
-      Some("completed"),
-      None,
-      None,
-    )
-    .await
-    .unwrap_or(0);
-    let failed = circus_common::repo::builds::count_filtered(
-      &state.pool,
-      Some(e.id),
-      Some("failed"),
-      None,
-      None,
-    )
-    .await
-    .unwrap_or(0);
-    let pending = circus_common::repo::builds::count_filtered(
-      &state.pool,
-      Some(e.id),
-      Some("pending"),
-      None,
-      None,
-    )
-    .await
-    .unwrap_or(0);
+
+    let eval_builds =
+      builds_by_eval.get(&e.id).map_or_else(|| &[], Vec::as_slice);
+    let succeeded = eval_builds
+      .iter()
+      .filter(|b| b.status == BuildStatus::Succeeded)
+      .count() as i64;
+    let failed = eval_builds
+      .iter()
+      .filter(|b| {
+        matches!(
+          b.status,
+          BuildStatus::Failed
+            | BuildStatus::DependencyFailed
+            | BuildStatus::FailedWithOutput
+            | BuildStatus::Timeout
+            | BuildStatus::CachedFailure
+            | BuildStatus::LogLimitExceeded
+            | BuildStatus::NarSizeLimitExceeded
+            | BuildStatus::NonDeterministic
+        )
+      })
+      .count() as i64;
+    let pending = eval_builds
+      .iter()
+      .filter(|b| b.status == BuildStatus::Pending)
+      .count() as i64;
 
     summaries.push(EvalSummaryView {
       id: e.id,


### PR DESCRIPTION
Same issue as #47, we tried to check for "completed" instead of "succeeded" as well as not accounting for all failure states.

Only difference is that we have to list many evals so they are  grouped them by eval id first.

Database calls reduced from 3*evals to 1 for all evaluations by using existing `builds`.

I remembered to take screenshots this time from before and after :) both are taken from `circus.example.com/jobsets/<id>` page:

<img width="1267" height="398" alt="screenshot_2026-06-03_18-24-17" src="https://github.com/user-attachments/assets/ab1086bb-0315-4efd-9e83-bc6de59942c6" />
<img width="1267" height="398" alt="screenshot_2026-06-03_18-32-09" src="https://github.com/user-attachments/assets/3505b825-8b39-465d-93ef-3a2fb30c1ede" />

