### PR TITLE
ci: cancel in-progress PR runs on new push

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   changes:
     name: Detect Changed Files
@@ -60,4 +64,3 @@ jobs:
 
       - name: Build ${{ matrix.package }}
         run: nix build .#${{ matrix.package }} -L --no-link
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   fmt:
     name: Format
@@ -33,4 +37,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - name: Run Test Suite
-        run:  nix develop --command cargo nextest run --all
+        run: nix develop --command cargo nextest run --all

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   changes:
     name: Detect Changed Files


### PR DESCRIPTION
Currently, force-pushing a PR will leave the previous runs going, so checks
end up piling up and stalling. This commit cancels in-progress runs when
that happens.