### PR TITLE
queue-runner: bound agent builds by agent slots, not local workers

### DIFF
--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -126,15 +126,17 @@ pub async fn list_for_jobset_evaluations(
 }
 
 /// List pending builds, prioritizing non-aggregate jobs.
-/// Returns up to `limit * worker_count` builds.
+///
+/// `schedulable_capacity` is the fair-share denominator, so it needs to
+/// include agent slots as well as local workers.
 ///
 /// # Errors
 ///
-/// Returns error if database query fails.
+/// Returns an error if the database query fails.
 pub async fn list_pending(
   pool: &PgPool,
   limit: i64,
-  worker_count: i32,
+  schedulable_capacity: i32,
 ) -> Result<Vec<Build>> {
   sqlx::query_as::<_, Build>(
     "WITH running_counts AS ( SELECT e.jobset_id, COUNT(*) AS running FROM \
@@ -153,7 +155,7 @@ pub async fn list_pending(
      DESC, b.created_at ASC LIMIT $1",
   )
   .bind(limit)
-  .bind(worker_count)
+  .bind(schedulable_capacity)
   .fetch_all(pool)
   .await
   .map_err(CiError::Database)
@@ -196,11 +198,32 @@ pub async fn mark_started_notified(pool: &PgPool, id: Uuid) -> Result<bool> {
   Ok(claimed.is_some())
 }
 
+/// Return a running build to the pending queue without counting a retry.
+///
+/// Use this for infrastructure loss rather than build failure. The status
+/// guard protects builds that finished or were cancelled meanwhile.
+///
+/// # Errors
+///
+/// Returns an error if the database update fails.
+pub async fn requeue(pool: &PgPool, id: Uuid) -> Result<Option<Build>> {
+  sqlx::query_as::<_, Build>(
+    "WITH bumped AS ( UPDATE builds SET status = 'pending', started_at = \
+     NULL, completed_at = NULL WHERE id = $1 AND status = 'running' RETURNING \
+     * ), cleared AS ( DELETE FROM build_steps WHERE build_id = $1 AND EXISTS \
+     (SELECT 1 FROM bumped) ) SELECT * FROM bumped",
+  )
+  .bind(id)
+  .fetch_optional(pool)
+  .await
+  .map_err(CiError::Database)
+}
+
 /// Mark a build as completed with final status and outputs.
 ///
 /// # Errors
 ///
-/// Returns error if database update fails or build not found.
+/// Returns an error if the database update fails or the build was not found.
 pub async fn complete(
   pool: &PgPool,
   id: Uuid,

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -1,0 +1,317 @@
+//! The running state should mean a build already holds execution capacity.
+
+use std::{
+  path::Path,
+  sync::Arc,
+  time::{Duration, Instant},
+};
+
+use circus_common::{config::BuilderSchedulingStrategy, models::Build, repo};
+use sqlx::PgPool;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
+
+use crate::{
+  builder::BuildResult,
+  rpc::{
+    AgentPool,
+    AgentSnapshot,
+    pool::{
+      AgentMeta,
+      DispatchCommand,
+      DispatchResult,
+      PresignedUpload,
+      SlotGuard,
+    },
+  },
+};
+
+pub enum ExecutionReservation {
+  Agent {
+    meta: Arc<AgentMeta>,
+    snap: AgentSnapshot,
+    slot: SlotGuard,
+  },
+  Runner(OwnedSemaphorePermit),
+}
+
+/// `list_pending` gets one capacity value for the whole fleet. This is only a
+/// fairness estimate, while reservations decide what can actually run.
+pub struct SchedulerCapacity {
+  pub fetch_limit:          i64,
+  pub schedulable_capacity: i32,
+}
+
+#[must_use]
+pub fn scheduler_capacity(
+  agent_pool: &AgentPool,
+  worker_count: usize,
+) -> SchedulerCapacity {
+  let workers = worker_count as i64;
+  SchedulerCapacity {
+    fetch_limit:          workers
+      .saturating_add(i64::from(agent_pool.total_free_slots()))
+      .clamp(10, 512),
+    schedulable_capacity: workers
+      .saturating_add(i64::from(agent_pool.total_slots()))
+      .clamp(1, i64::from(i32::MAX)) as i32,
+  }
+}
+
+pub struct AgentDispatch<'a> {
+  pub timeout:                    Duration,
+  pub extra_nix_args:             &'a [String],
+  pub cache_upload_enabled_s3:    bool,
+  pub cache_upload_compression:   &'a str,
+  pub fail_build_on_upload_error: bool,
+}
+
+/// Reserve capacity before the build is claimed as running.
+///
+/// # Panics
+///
+/// Only if the worker semaphore has been closed, which never happens during
+/// normal operation.
+pub async fn reserve_venue(
+  agent_pool: &Arc<AgentPool>,
+  pool: &PgPool,
+  build: &Build,
+  system: Option<&str>,
+  psi_threshold: Option<f64>,
+  heartbeat_ttl: Duration,
+  strategy: &BuilderSchedulingStrategy,
+  worker_semaphore: &Arc<Semaphore>,
+) -> ExecutionReservation {
+  if let Some(system) = system
+    && let Some((meta, snap, slot)) = select_and_reserve_agent(
+      agent_pool,
+      pool,
+      build,
+      system,
+      psi_threshold,
+      heartbeat_ttl,
+      strategy,
+    )
+    .await
+  {
+    return ExecutionReservation::Agent { meta, snap, slot };
+  }
+
+  #[expect(
+    clippy::expect_used,
+    reason = "the worker semaphore is never closed, so acquire never errors"
+  )]
+  let permit = Arc::clone(worker_semaphore)
+    .acquire_owned()
+    .await
+    .expect("worker semaphore is never closed");
+  ExecutionReservation::Runner(permit)
+}
+
+async fn select_and_reserve_agent(
+  agent_pool: &Arc<AgentPool>,
+  pool: &PgPool,
+  build: &Build,
+  system: &str,
+  psi_threshold: Option<f64>,
+  heartbeat_ttl: Duration,
+  strategy: &BuilderSchedulingStrategy,
+) -> Option<(Arc<AgentMeta>, AgentSnapshot, SlotGuard)> {
+  use BuilderSchedulingStrategy::{
+    CpuCoreCountWithSpeedFactor,
+    Dynamic,
+    SpeedFactorOnly,
+  };
+
+  let mut candidates = agent_pool.candidates_for(system);
+  if candidates.is_empty() {
+    return None;
+  }
+
+  // Missing or stale heartbeats are treated as unknown to match the SSH path.
+  let cutoff = Instant::now().checked_sub(heartbeat_ttl);
+  if let Some(t) = psi_threshold {
+    let t = t as f32;
+    candidates.retain(|(_, snap)| {
+      let hb = snap.heartbeat;
+      let fresh = match (hb.last_seen, cutoff) {
+        (Some(seen), Some(cut)) => seen >= cut,
+        _ => true,
+      };
+      if !fresh {
+        return true;
+      }
+      hb.cpu_psi_avg10 <= t && hb.mem_psi_avg10 <= t && hb.io_psi_avg10 <= t
+    });
+  }
+
+  if !build.required_features.is_empty() {
+    candidates.retain(|(_, snap)| {
+      build
+        .required_features
+        .iter()
+        .all(|f| snap.supported_features.iter().any(|s| s == f))
+    });
+  }
+  candidates.retain(|(_, snap)| {
+    snap
+      .mandatory_features
+      .iter()
+      .all(|f| build.required_features.iter().any(|required| required == f))
+  });
+  if candidates.is_empty() {
+    return None;
+  }
+
+  let mut eligible = Vec::with_capacity(candidates.len());
+  for candidate in candidates {
+    match repo::builder_sessions::is_schedulable(pool, candidate.0.machine_id)
+      .await
+    {
+      Ok(true) => eligible.push(candidate),
+      Ok(false) => {
+        tracing::debug!(
+          machine_id = %candidate.0.machine_id,
+          name = %candidate.1.name,
+          "skipping agent disabled by failure backoff"
+        );
+      },
+      Err(e) => {
+        tracing::warn!(
+          machine_id = %candidate.0.machine_id,
+          name = %candidate.1.name,
+          "failed to read agent backoff state: {e}"
+        );
+      },
+    }
+  }
+
+  eligible.sort_by(|a, b| {
+    match strategy {
+      SpeedFactorOnly => {
+        b.1
+          .speed_factor
+          .partial_cmp(&a.1.speed_factor)
+          .unwrap_or(std::cmp::Ordering::Equal)
+      },
+      CpuCoreCountWithSpeedFactor => {
+        let av = a.1.cpu_count as f32 * a.1.speed_factor;
+        let bv = b.1.cpu_count as f32 * b.1.speed_factor;
+        bv.partial_cmp(&av).unwrap_or(std::cmp::Ordering::Equal)
+      },
+      Dynamic => {
+        let free = |s: &AgentSnapshot| -> f32 {
+          s.max_jobs.saturating_sub(s.current_jobs) as f32 * s.speed_factor
+        };
+        free(&b.1)
+          .partial_cmp(&free(&a.1))
+          .unwrap_or(std::cmp::Ordering::Equal)
+      },
+    }
+  });
+
+  eligible.into_iter().find_map(|(meta, snap)| {
+    meta.try_acquire_slot().map(|slot| (meta, snap, slot))
+  })
+}
+
+/// Return [`None`] when the agent disappears before reporting a result.
+pub async fn run_on_agent(
+  meta: &Arc<AgentMeta>,
+  snap: &AgentSnapshot,
+  slot: SlotGuard,
+  pool: &PgPool,
+  build: &Build,
+  drv_path: &str,
+  live_log_path: &Path,
+  opts: &AgentDispatch<'_>,
+) -> Option<BuildResult> {
+  let (tx, rx) = oneshot::channel();
+  let presigned_upload = opts.cache_upload_enabled_s3.then(|| {
+    PresignedUpload {
+      compression:                opts.cache_upload_compression.to_owned(),
+      fail_build_on_upload_error: opts.fail_build_on_upload_error,
+    }
+  });
+
+  let cmd = DispatchCommand {
+    build_id: build.id,
+    drv_path: drv_path.to_owned(),
+    max_log_size: 100 * 1024 * 1024,
+    max_silent_time: 0,
+    build_timeout: opts.timeout.as_secs().try_into().unwrap_or(u32::MAX),
+    extra_args: opts.extra_nix_args.to_vec(),
+    log_path: live_log_path.to_path_buf(),
+    presigned_upload,
+    reservation: slot,
+    completion: tx,
+  };
+  if meta.tx.send(cmd).is_err() {
+    tracing::warn!(name = %snap.name, "agent channel closed, falling back");
+    return None;
+  }
+
+  if let Err(e) = sqlx::query(
+    "UPDATE builder_sessions SET updated_at = NOW() WHERE machine_id = $1",
+  )
+  .bind(meta.machine_id)
+  .execute(pool)
+  .await
+  {
+    tracing::debug!(name = %snap.name, "builder_sessions touch failed: {e}");
+  }
+  if let Err(e) = repo::builds::set_agent(pool, build.id, meta.machine_id).await
+  {
+    tracing::warn!(build_id = %build.id, name = %snap.name, "Failed to set agent_machine_id: {e}");
+  }
+  tracing::info!(build_id = %build.id, agent = %snap.name, "dispatched to agent");
+
+  let result = |success, exit_code, stderr: String, output_paths| {
+    BuildResult {
+      success,
+      exit_code: Some(exit_code),
+      stdout: String::new(),
+      stderr,
+      output_paths,
+      sub_steps: Vec::new(),
+      cache_upload_handled: opts.cache_upload_enabled_s3,
+    }
+  };
+
+  match rx.await {
+    Ok(DispatchResult::Succeeded) => {
+      let outputs = read_drv_outputs(drv_path).await;
+      Some(result(true, 0, String::new(), outputs))
+    },
+    Ok(DispatchResult::Failed(error_message)) => {
+      Some(result(false, 1, error_message, Vec::new()))
+    },
+    Ok(DispatchResult::TimedOut) => {
+      Some(result(false, 124, "build timed out".into(), Vec::new()))
+    },
+    Ok(DispatchResult::Aborted) => {
+      Some(result(false, 130, "build aborted".into(), Vec::new()))
+    },
+    Ok(DispatchResult::Disconnected) | Err(_) => {
+      tracing::warn!(name = %snap.name, "agent disconnected mid-build; falling back");
+      None
+    },
+  }
+}
+
+async fn read_drv_outputs(drv_path: &str) -> Vec<String> {
+  let Ok(out) = tokio::process::Command::new("nix-store")
+    .args(["--query", "--outputs", drv_path])
+    .output()
+    .await
+  else {
+    return Vec::new();
+  };
+  if !out.status.success() {
+    return Vec::new();
+  }
+  String::from_utf8_lossy(&out.stdout)
+    .lines()
+    .map(|s| s.trim().to_owned())
+    .filter(|s| !s.is_empty())
+    .collect()
+}

--- a/crates/queue-runner/src/lib.rs
+++ b/crates/queue-runner/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod dispatch;
 pub mod psi;
 pub mod rpc;
 pub mod runner_loop;

--- a/crates/queue-runner/src/rpc/pool.rs
+++ b/crates/queue-runner/src/rpc/pool.rs
@@ -26,6 +26,9 @@ use parking_lot::RwLock;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+/// Upper bound on an agent's advertised `max_jobs`.
+pub const MAX_AGENT_MAX_JOBS: u32 = 670;
+
 /// One command queued from the scheduler to a connected agent.
 pub struct DispatchCommand {
   pub build_id:         Uuid,
@@ -41,6 +44,9 @@ pub struct DispatchCommand {
   /// runner's own `nix copy --to s3://...` post-build path stays in
   /// charge.
   pub presigned_upload: Option<PresignedUpload>,
+  /// Keep the agent slot reservation with the command so failed handoff and
+  /// connection-task cleanup use the same release path.
+  pub reservation:      SlotGuard,
   /// Completion signal: the per-connection task sends the outcome here
   /// after the agent reports via `ResultSink`. Some scheduler errors are
   /// also surfaced here (queue full, connection closed mid-dispatch).
@@ -65,8 +71,8 @@ pub enum DispatchResult {
   Disconnected,
 }
 
-/// Metadata side of an agent. Held in `AgentPool` and shared with the
-/// scheduler. Send + Sync.
+/// The metadata side of an agent. This is held in an [`AgentPool`] and shared
+/// with the scheduler.
 pub struct AgentMeta {
   pub machine_id:         Uuid,
   pub connection_id:      Uuid,
@@ -79,7 +85,7 @@ pub struct AgentMeta {
   pub cpu_count:          u32,
   pub max_jobs:           u32,
 
-  pub current_jobs:  Arc<AtomicU32>,
+  current_jobs:      Arc<AtomicU32>,
   pub active_builds: RwLock<HashSet<Uuid>>,
 
   pub heartbeat:     RwLock<HeartbeatSnapshot>,
@@ -87,6 +93,86 @@ pub struct AgentMeta {
 
   /// Hand-off into the connection task.
   pub tx: mpsc::UnboundedSender<DispatchCommand>,
+}
+
+impl AgentMeta {
+  /// Build agent metadata from registration data. `current_jobs` starts at
+  /// zero and is thereafter mutated only via [`Self::try_acquire_slot`].
+  #[must_use]
+  #[expect(
+    clippy::too_many_arguments,
+    reason = "fields come straight from the agent's registration record"
+  )]
+  pub fn new(
+    machine_id: Uuid,
+    connection_id: Uuid,
+    name: String,
+    hostname: String,
+    systems: Vec<String>,
+    supported_features: Vec<String>,
+    mandatory_features: Vec<String>,
+    speed_factor: f32,
+    cpu_count: u32,
+    max_jobs: u32,
+    tx: mpsc::UnboundedSender<DispatchCommand>,
+  ) -> Self {
+    Self {
+      machine_id,
+      connection_id,
+      name,
+      hostname,
+      systems,
+      supported_features,
+      mandatory_features,
+      speed_factor,
+      cpu_count,
+      max_jobs,
+      current_jobs: Arc::new(AtomicU32::new(0)),
+      active_builds: RwLock::new(HashSet::new()),
+      heartbeat: RwLock::new(HeartbeatSnapshot::default()),
+      registered_at: Instant::now(),
+      tx,
+    }
+  }
+
+  /// Returns [`None`] when the agent is already at
+  /// [`max_jobs`][`Self::max_jobs`].
+  ///
+  /// The guard moves into [`DispatchCommand`], keeping the slot held until
+  /// the send fails or the connection task finishes the build.
+  #[must_use]
+  pub fn try_acquire_slot(self: &Arc<Self>) -> Option<SlotGuard> {
+    let mut cur = self.current_jobs.load(Ordering::Relaxed);
+    loop {
+      if cur >= self.max_jobs {
+        return None;
+      }
+      match self.current_jobs.compare_exchange_weak(
+        cur,
+        cur + 1,
+        Ordering::AcqRel,
+        Ordering::Relaxed,
+      ) {
+        Ok(_) => {
+          return Some(SlotGuard {
+            meta: Arc::clone(self),
+          });
+        },
+        Err(actual) => cur = actual,
+      }
+    }
+  }
+}
+
+/// Releases one agent build slot when dropped.
+pub struct SlotGuard {
+  meta: Arc<AgentMeta>,
+}
+
+impl Drop for SlotGuard {
+  fn drop(&mut self) {
+    self.meta.current_jobs.fetch_sub(1, Ordering::AcqRel);
+  }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -211,6 +297,43 @@ impl AgentPool {
       .collect()
   }
 
+  /// Free build slots across connected agents. The scheduler uses this as the
+  /// per-cycle cap when fetching pending builds.
+  #[must_use]
+  pub fn total_free_slots(&self) -> u32 {
+    self
+      .inner
+      .read()
+      .values()
+      .map(|m| {
+        m.max_jobs
+          .saturating_sub(m.current_jobs.load(Ordering::Relaxed))
+      })
+      .fold(0u32, u32::saturating_add)
+  }
+
+  /// Whether any connected agent advertises `system`, regardless of current
+  /// load.
+  #[must_use]
+  pub fn serves_system(&self, system: &str) -> bool {
+    self
+      .inner
+      .read()
+      .values()
+      .any(|m| m.systems.iter().any(|s| s == system))
+  }
+
+  /// Total advertised build slots across connected agents.
+  #[must_use]
+  pub fn total_slots(&self) -> u32 {
+    self
+      .inner
+      .read()
+      .values()
+      .map(|m| m.max_jobs)
+      .fold(0u32, u32::saturating_add)
+  }
+
   #[must_use]
   pub fn len(&self) -> usize {
     self.inner.read().len()
@@ -242,25 +365,80 @@ fn snapshot(m: &AgentMeta, current_jobs: u32) -> AgentSnapshot {
 mod tests {
   use super::*;
 
-  fn meta(machine_id: Uuid, connection_id: Uuid) -> Arc<AgentMeta> {
+  fn meta_with(
+    machine_id: Uuid,
+    connection_id: Uuid,
+    max_jobs: u32,
+  ) -> Arc<AgentMeta> {
     let (tx, _rx) = mpsc::unbounded_channel();
-    Arc::new(AgentMeta {
+    Arc::new(AgentMeta::new(
       machine_id,
       connection_id,
-      name: "agent".into(),
-      hostname: "host".into(),
-      systems: vec!["x86_64-linux".into()],
-      supported_features: Vec::new(),
-      mandatory_features: Vec::new(),
-      speed_factor: 1.0,
-      cpu_count: 1,
-      max_jobs: 1,
-      current_jobs: Arc::new(AtomicU32::new(0)),
-      active_builds: RwLock::new(HashSet::new()),
-      heartbeat: RwLock::new(HeartbeatSnapshot::default()),
-      registered_at: Instant::now(),
+      format!("agent-{machine_id}"),
+      "host".into(),
+      vec!["x86_64-linux".into()],
+      Vec::new(),
+      Vec::new(),
+      1.0,
+      1,
+      max_jobs,
       tx,
-    })
+    ))
+  }
+
+  fn meta(machine_id: Uuid, connection_id: Uuid) -> Arc<AgentMeta> {
+    meta_with(machine_id, connection_id, 1)
+  }
+
+  #[test]
+  fn try_acquire_slot_respects_max_jobs() {
+    let m = meta_with(Uuid::new_v4(), Uuid::new_v4(), 3);
+    let g1 = m.try_acquire_slot();
+    let g2 = m.try_acquire_slot();
+    let g3 = m.try_acquire_slot();
+    assert!(g1.is_some() && g2.is_some() && g3.is_some());
+    assert!(m.try_acquire_slot().is_none(), "must not exceed max_jobs");
+    drop(g1);
+    let g4 = m.try_acquire_slot();
+    assert!(g4.is_some(), "dropping a guard frees exactly one slot");
+    assert!(m.try_acquire_slot().is_none());
+  }
+
+  #[test]
+  fn try_acquire_slot_no_oversubscribe_under_contention() {
+    let m = meta_with(Uuid::new_v4(), Uuid::new_v4(), 4);
+    let succeeded = std::sync::atomic::AtomicU32::new(0);
+
+    // Every thread holds its reservation until all have tried, so the count
+    // reflects the true concurrent maximum rather than churn.
+    let barrier = std::sync::Barrier::new(32);
+    std::thread::scope(|s| {
+      for _ in 0..32 {
+        s.spawn(|| {
+          let guard = m.try_acquire_slot();
+          if guard.is_some() {
+            succeeded.fetch_add(1, Ordering::Relaxed);
+          }
+          barrier.wait();
+        });
+      }
+    });
+    assert_eq!(succeeded.load(Ordering::Relaxed), 4);
+    assert_eq!(m.current_jobs.load(Ordering::Relaxed), 0);
+  }
+
+  #[test]
+  fn total_free_slots_sums_across_agents() {
+    let pool = AgentPool::default();
+    let a = meta_with(Uuid::new_v4(), Uuid::new_v4(), 4);
+    let b = meta_with(Uuid::new_v4(), Uuid::new_v4(), 2);
+    pool.insert(Arc::clone(&a));
+    pool.insert(Arc::clone(&b));
+    assert_eq!(pool.total_free_slots(), 6);
+    let ga = a.try_acquire_slot();
+    let gb = b.try_acquire_slot();
+    assert!(ga.is_some() && gb.is_some());
+    assert_eq!(pool.total_free_slots(), 4);
   }
 
   #[test]

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -9,13 +9,9 @@
 //! [`super::pool::AgentMeta`].
 
 use std::{
-  collections::{HashMap, HashSet},
+  collections::HashMap,
   net::SocketAddr,
-  sync::{
-    Arc,
-    atomic::{AtomicU32, Ordering},
-  },
-  time::Instant,
+  sync::{Arc, Weak},
 };
 
 use capnp::capability::Promise;
@@ -30,7 +26,6 @@ use circus_proto::{
   runner,
 };
 use color_eyre::eyre::{Context as _, eyre};
-use parking_lot::RwLock;
 use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;
 use subtle::ConstantTimeEq as _;
@@ -49,10 +44,11 @@ use x509_parser::prelude::FromDer;
 use super::{
   AgentPool,
   log_sink::LogSinkImpl,
-  pool::{AgentMeta, DispatchCommand, DispatchResult, HeartbeatSnapshot},
+  pool::{AgentMeta, DispatchCommand, DispatchResult},
   result_sink::{BuildOutcomeKind, ResultSinkImpl},
   session::SessionImpl,
 };
+use crate::rpc::pool::MAX_AGENT_MAX_JOBS;
 
 #[derive(Clone)]
 pub struct ServerConfig {
@@ -479,23 +475,19 @@ impl runner::Server for RunnerImpl {
       }
 
       let (tx, rx) = mpsc::unbounded_channel::<DispatchCommand>();
-      let meta = Arc::new(AgentMeta {
+      let meta = Arc::new(AgentMeta::new(
         machine_id,
         connection_id,
-        name: name.clone(),
+        name.clone(),
         hostname,
         systems,
-        supported_features: supported,
-        mandatory_features: mandatory,
-        speed_factor: speed,
-        cpu_count: cpu,
-        max_jobs: maxj,
-        current_jobs: Arc::new(AtomicU32::new(0)),
-        active_builds: RwLock::new(HashSet::new()),
-        heartbeat: RwLock::new(HeartbeatSnapshot::default()),
-        registered_at: Instant::now(),
+        supported,
+        mandatory,
+        speed,
+        cpu,
+        maxj,
         tx,
-      });
+      ));
       if let Some(previous) = pool.insert(Arc::clone(&meta)) {
         tracing::warn!(
           name = %name,
@@ -509,7 +501,7 @@ impl runner::Server for RunnerImpl {
 
       tokio::task::spawn_local(run_dispatch_pump(
         builder_cap,
-        Arc::clone(&meta),
+        Arc::downgrade(&meta),
         Arc::clone(&cfg),
         db_pool.clone(),
         rx,
@@ -862,23 +854,23 @@ fn sanitise_key_segment(value: &str) -> String {
     .collect()
 }
 
-/// Pull from the dispatch channel forever, sending each command through
-/// the held builder capability.
+/// The meta is [`Weak`] so that removing the agent drops the sender for `rx`.
 #[expect(clippy::future_not_send, reason = "capnp future")]
 async fn run_dispatch_pump(
   builder_cap: builder::Client,
-  meta: Arc<AgentMeta>,
+  meta: Weak<AgentMeta>,
   cfg: Arc<ServerConfig>,
   db_pool: PgPool,
   mut rx: mpsc::UnboundedReceiver<DispatchCommand>,
 ) {
   while let Some(cmd) = rx.recv().await {
-    meta.current_jobs.fetch_add(1, Ordering::Relaxed);
+    let Some(meta) = meta.upgrade() else {
+      break;
+    };
     let machine_id = meta.machine_id;
     let pool = db_pool.clone();
     let cfg = Arc::clone(&cfg);
     let builder_cap = builder_cap.clone();
-    let current_jobs_counter = Arc::clone(&meta.current_jobs);
     let meta_for_task = Arc::clone(&meta);
 
     tokio::task::spawn_local(async move {
@@ -891,9 +883,10 @@ async fn run_dispatch_pump(
         &meta_for_task,
       )
       .await;
-      current_jobs_counter.fetch_sub(1, Ordering::Relaxed);
+      let build_id = cmd.build_id;
       let _ = cmd.completion.send(outcome);
-      tracing::debug!(%machine_id, build_id = %cmd.build_id, "dispatch finished");
+      drop(cmd.reservation);
+      tracing::debug!(%machine_id, %build_id, "dispatch finished");
     });
   }
 }
@@ -1029,6 +1022,11 @@ fn validate_agent_capacity(
     return Err(capnp::Error::failed(
       "agent max_jobs must be greater than 0".into(),
     ));
+  }
+  if max_jobs > MAX_AGENT_MAX_JOBS {
+    return Err(capnp::Error::failed(format!(
+      "agent max_jobs {max_jobs} exceeds cap {MAX_AGENT_MAX_JOBS}",
+    )));
   }
   Ok(())
 }

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -114,7 +114,10 @@ pub async fn run(
       )
     };
 
-    let wc = worker_pool.worker_count() as i32;
+    let capacity = crate::dispatch::scheduler_capacity(
+      worker_pool.agent_pool(),
+      worker_pool.worker_count(),
+    );
     // Cache `nix-store --query` results within a single cycle so we
     // don't shell out twice for the same FOD drv path across multiple
     // pending rows that share it.
@@ -122,7 +125,13 @@ pub async fn run(
       String,
       Option<String>,
     > = std::collections::HashMap::new();
-    match repo::builds::list_pending(&pool, 10, wc).await {
+    match repo::builds::list_pending(
+      &pool,
+      capacity.fetch_limit,
+      capacity.schedulable_capacity,
+    )
+    .await
+    {
       Ok(builds) => {
         if !builds.is_empty() {
           tracing::info!("Found {} pending builds", builds.len());
@@ -334,7 +343,7 @@ pub async fn run(
             },
           }
 
-          // Unsupported system timeout: abort builds with no available builders
+          // A full connected agent still means the system is supported.
           if let Some(timeout) = unsupported_timeout
             && let Some(system) = &build.system
           {
@@ -345,7 +354,10 @@ pub async fn run(
             )
             .await
             {
-              Ok(builders) if builders.is_empty() => {
+              Ok(builders)
+                if builders.is_empty()
+                  && !worker_pool.agent_pool().serves_system(system) =>
+              {
                 let timeout_at = build.created_at + timeout;
                 if chrono::Utc::now() > timeout_at {
                   tracing::info!(

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -103,18 +103,15 @@ impl WorkerPool {
     self.drain_token.cancel();
   }
 
-  /// Wait until all in-flight builds complete (semaphore fully available).
+  /// Wait until all active builds finish. Agent builds are included even
+  /// though they do not hold worker permits.
   pub async fn wait_for_drain(&self) {
-    // Acquire all permits = all workers idle
-    let workers = self.worker_count;
     let build_timeout = self.hot_config.read().await.build_timeout;
     let _ = tokio::time::timeout(
       Duration::from_secs(build_timeout.as_secs() + 60),
       async {
-        for _ in 0..workers {
-          if let Ok(permit) = self.semaphore.acquire().await {
-            permit.forget(); // don't release back
-          }
+        while !self.active_builds.is_empty() {
+          tokio::time::sleep(Duration::from_millis(100)).await;
         }
       },
     )
@@ -124,6 +121,11 @@ impl WorkerPool {
   #[must_use]
   pub const fn worker_count(&self) -> usize {
     self.worker_count
+  }
+
+  #[must_use]
+  pub const fn agent_pool(&self) -> &Arc<crate::rpc::AgentPool> {
+    &self.agent_pool
   }
 
   #[must_use]
@@ -160,10 +162,6 @@ impl WorkerPool {
 
     tokio::spawn(async move {
       let result = async {
-        let Ok(_permit) = semaphore.acquire().await else {
-          return;
-        };
-
         let (
           timeout,
           notifications_config,
@@ -196,6 +194,7 @@ impl WorkerPool {
           &cache_upload_config,
           &alert_manager,
           Arc::clone(&upload_semaphore),
+          Arc::clone(&semaphore),
           scheduling_strategy,
           psi_threshold,
           psi_check_timeout,
@@ -502,269 +501,6 @@ fn presigned_s3_upload_available(config: &CacheUploadConfig) -> bool {
   circus_common::s3::Presigner::from_config(store_uri, s3_config).is_some()
 }
 
-/// Dispatch the build to a connected agent if one matches. Returns
-/// `Some(BuildResult)` on definitive completion (succeeded *or* failed),
-/// `None` when no agent is eligible or the connection dropped before the
-/// result arrived. The caller falls through to SSH or local.
-#[expect(
-  clippy::too_many_arguments,
-  reason = "dispatch decision needs build metadata, live scheduler state, and \
-            cache policy"
-)]
-async fn try_agent_dispatch(
-  agent_pool: &Arc<crate::rpc::AgentPool>,
-  pool: &PgPool,
-  build: &Build,
-  system: &str,
-  drv_path: &str,
-  live_log_path: &std::path::Path,
-  timeout: Duration,
-  psi_threshold: Option<f64>,
-  heartbeat_ttl: Duration,
-  strategy: &circus_common::config::BuilderSchedulingStrategy,
-  extra_nix_args: &[String],
-  cache_upload_enabled_s3: bool,
-  cache_upload_compression: &str,
-  fail_build_on_upload_error: bool,
-) -> Option<crate::builder::BuildResult> {
-  use std::time::Instant;
-
-  use circus_common::config::BuilderSchedulingStrategy::{
-    CpuCoreCountWithSpeedFactor,
-    Dynamic,
-    SpeedFactorOnly,
-  };
-
-  let mut candidates = agent_pool.candidates_for(system);
-  if candidates.is_empty() {
-    return None;
-  }
-
-  // PSI gating from the most recent heartbeat. Missing or stale
-  // heartbeats are treated as "unknown" (do not penalise), matching the
-  // SSH-path semantics.
-  let now = Instant::now();
-  let cutoff = now.checked_sub(heartbeat_ttl);
-  if let Some(t) = psi_threshold {
-    let t = t as f32;
-    candidates.retain(|(_, snap)| {
-      let hb = snap.heartbeat;
-      let fresh = match (hb.last_seen, cutoff) {
-        (Some(seen), Some(cut)) => seen >= cut,
-        _ => true,
-      };
-      if !fresh {
-        return true;
-      }
-      hb.cpu_psi_avg10 <= t && hb.mem_psi_avg10 <= t && hb.io_psi_avg10 <= t
-    });
-  }
-  if candidates.is_empty() {
-    return None;
-  }
-
-  // Required-features gating. The drv declares
-  // `requiredSystemFeatures`; the evaluator persists them on the build
-  // row. An agent is eligible only if every required feature is in its
-  // `supported_features`. This is the build-side counterpart to the SSH
-  // path's `remote_builders.mandatory_features` gate.
-  if !build.required_features.is_empty() {
-    candidates.retain(|(_, snap)| {
-      build
-        .required_features
-        .iter()
-        .all(|f| snap.supported_features.iter().any(|s| s == f))
-    });
-    if candidates.is_empty() {
-      return None;
-    }
-  }
-  candidates.retain(|(_, snap)| {
-    snap
-      .mandatory_features
-      .iter()
-      .all(|f| build.required_features.iter().any(|required| required == f))
-  });
-  if candidates.is_empty() {
-    return None;
-  }
-
-  let mut eligible = Vec::with_capacity(candidates.len());
-  for candidate in candidates {
-    match repo::builder_sessions::is_schedulable(pool, candidate.0.machine_id)
-      .await
-    {
-      Ok(true) => eligible.push(candidate),
-      Ok(false) => {
-        tracing::debug!(
-          machine_id = %candidate.0.machine_id,
-          name = %candidate.1.name,
-          "skipping agent disabled by failure backoff"
-        );
-      },
-      Err(e) => {
-        tracing::warn!(
-          machine_id = %candidate.0.machine_id,
-          name = %candidate.1.name,
-          "failed to read agent backoff state: {e}"
-        );
-      },
-    }
-  }
-  let mut candidates = eligible;
-  if candidates.is_empty() {
-    return None;
-  }
-
-  // Ordering.
-  candidates.sort_by(|a, b| {
-    match strategy {
-      SpeedFactorOnly => {
-        b.1
-          .speed_factor
-          .partial_cmp(&a.1.speed_factor)
-          .unwrap_or(std::cmp::Ordering::Equal)
-      },
-      CpuCoreCountWithSpeedFactor => {
-        let av = a.1.cpu_count as f32 * a.1.speed_factor;
-        let bv = b.1.cpu_count as f32 * b.1.speed_factor;
-        bv.partial_cmp(&av).unwrap_or(std::cmp::Ordering::Equal)
-      },
-      Dynamic => {
-        // Weight by free slots so an idle agent wins over a partially
-        // loaded faster one. Falls back to speed_factor on a tie.
-        let free = |s: &crate::rpc::AgentSnapshot| -> f32 {
-          let slack = s.max_jobs.saturating_sub(s.current_jobs) as f32;
-          slack * s.speed_factor
-        };
-        free(&b.1)
-          .partial_cmp(&free(&a.1))
-          .unwrap_or(std::cmp::Ordering::Equal)
-      },
-    }
-  });
-
-  for (meta, snap) in candidates {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    // Honour the runner's cache-upload config: only a fully presignable S3
-    // store flips the agent into the presigned-upload path post-build. Other
-    // store types, or S3 configs without explicit signing credentials, continue
-    // to use the existing post-build `nix copy --to ...` flow.
-    let presigned_upload = cache_upload_enabled_s3.then(|| {
-      crate::rpc::pool::PresignedUpload {
-        compression: cache_upload_compression.to_owned(),
-        fail_build_on_upload_error,
-      }
-    });
-
-    let cmd = crate::rpc::pool::DispatchCommand {
-      build_id: build.id,
-      drv_path: drv_path.to_owned(),
-      max_log_size: 100 * 1024 * 1024,
-      max_silent_time: 0,
-      build_timeout: timeout.as_secs().try_into().unwrap_or(u32::MAX),
-      extra_args: extra_nix_args.to_vec(),
-      log_path: live_log_path.to_path_buf(),
-      presigned_upload,
-      completion: tx,
-    };
-    if meta.tx.send(cmd).is_err() {
-      tracing::warn!(name = %snap.name, "agent channel closed; falling through");
-      continue;
-    }
-    // Record the dispatch attempt against the builder_sessions row so
-    // the operator can see which agent ran which build without
-    // round-tripping the AgentPool. Failure here is non-fatal; the
-    // dispatch already happened.
-    if let Err(e) = sqlx::query(
-      "UPDATE builder_sessions SET updated_at = NOW() WHERE machine_id = $1",
-    )
-    .bind(meta.machine_id)
-    .execute(pool)
-    .await
-    {
-      tracing::debug!(name = %snap.name, "builder_sessions touch failed: {e}");
-    }
-
-    if let Err(e) =
-      repo::builds::set_agent(pool, build.id, meta.machine_id).await
-    {
-      tracing::warn!(build_id = %build.id, name = %snap.name, "Failed to set agent_machine_id: {e}");
-    }
-    tracing::info!(build_id = %build.id, agent = %snap.name, "dispatched to agent");
-
-    match rx.await {
-      Ok(crate::rpc::pool::DispatchResult::Succeeded) => {
-        let outputs = read_drv_outputs(drv_path).await;
-        return Some(crate::builder::BuildResult {
-          success:              true,
-          exit_code:            Some(0),
-          stdout:               String::new(),
-          stderr:               String::new(),
-          output_paths:         outputs,
-          sub_steps:            Vec::new(),
-          cache_upload_handled: cache_upload_enabled_s3,
-        });
-      },
-      Ok(crate::rpc::pool::DispatchResult::Failed(error_message)) => {
-        return Some(crate::builder::BuildResult {
-          success:              false,
-          exit_code:            Some(1),
-          stdout:               String::new(),
-          stderr:               error_message,
-          output_paths:         Vec::new(),
-          sub_steps:            Vec::new(),
-          cache_upload_handled: cache_upload_enabled_s3,
-        });
-      },
-      Ok(crate::rpc::pool::DispatchResult::TimedOut) => {
-        return Some(crate::builder::BuildResult {
-          success:              false,
-          exit_code:            Some(124),
-          stdout:               String::new(),
-          stderr:               "build timed out".into(),
-          output_paths:         Vec::new(),
-          sub_steps:            Vec::new(),
-          cache_upload_handled: cache_upload_enabled_s3,
-        });
-      },
-      Ok(crate::rpc::pool::DispatchResult::Aborted) => {
-        return Some(crate::builder::BuildResult {
-          success:              false,
-          exit_code:            Some(130),
-          stdout:               String::new(),
-          stderr:               "build aborted".into(),
-          output_paths:         Vec::new(),
-          sub_steps:            Vec::new(),
-          cache_upload_handled: cache_upload_enabled_s3,
-        });
-      },
-      Ok(crate::rpc::pool::DispatchResult::Disconnected) | Err(_) => {
-        tracing::warn!(name = %snap.name, "agent disconnected mid-build; trying next");
-      },
-    }
-  }
-  None
-}
-
-async fn read_drv_outputs(drv_path: &str) -> Vec<String> {
-  let Ok(out) = tokio::process::Command::new("nix-store")
-    .args(["--query", "--outputs", drv_path])
-    .output()
-    .await
-  else {
-    return Vec::new();
-  };
-  if !out.status.success() {
-    return Vec::new();
-  }
-  String::from_utf8_lossy(&out.stdout)
-    .lines()
-    .map(|s| s.trim().to_owned())
-    .filter(|s| !s.is_empty())
-    .collect()
-}
-
 /// Try to run the build on a remote builder if one is available for the build's
 /// system.
 #[expect(
@@ -947,7 +683,61 @@ async fn collect_metrics_and_alert(
   }
 }
 
+/// Runs with a worker permit, trying configured SSH builders before local
+/// execution.
+#[expect(
+  clippy::too_many_arguments,
+  reason = "on-runner execution needs the full SSH/local scheduling context"
+)]
+async fn run_on_runner(
+  permit: tokio::sync::OwnedSemaphorePermit,
+  pool: &PgPool,
+  build: &Build,
+  drv_path: &str,
+  work_dir: &std::path::Path,
+  timeout: Duration,
+  live_log_path: &std::path::Path,
+  scheduling_strategy: &circus_common::config::BuilderSchedulingStrategy,
+  psi_threshold: Option<f64>,
+  psi_check_timeout: Duration,
+  psi_cache: &Arc<crate::psi::PsiCache>,
+  extra_nix_args: &[String],
+) -> circus_common::error::Result<crate::builder::BuildResult> {
+  let _permit = permit;
+  if build.system.is_some()
+    && let Some(r) = try_remote_build(
+      pool,
+      build,
+      drv_path,
+      work_dir,
+      timeout,
+      Some(live_log_path),
+      scheduling_strategy,
+      psi_threshold,
+      psi_check_timeout,
+      psi_cache,
+      extra_nix_args,
+    )
+    .await
+  {
+    return Ok(r);
+  }
+  crate::builder::run_nix_build(
+    drv_path,
+    work_dir,
+    timeout,
+    Some(live_log_path),
+    extra_nix_args,
+  )
+  .await
+}
+
 #[tracing::instrument(skip(pool, build, work_dir, nix_store_dir, log_config, gc_config, notifications_config, signing_config, cache_upload_config, upload_semaphore, scheduling_strategy), fields(build_id = %build.id, job = %build.job_name))]
+#[expect(
+  clippy::significant_drop_tightening,
+  reason = "the execution reservation is held deliberately from before the DB \
+            claim until the build completes"
+)]
 #[expect(
   clippy::too_many_arguments,
   reason = "build execution coordinates database state, config, \
@@ -968,6 +758,7 @@ async fn run_build(
   cache_upload_config: &CacheUploadConfig,
   alert_manager: &Option<AlertManager>,
   upload_semaphore: Arc<Semaphore>,
+  worker_semaphore: Arc<Semaphore>,
   scheduling_strategy: circus_common::config::BuilderSchedulingStrategy,
   psi_threshold: Option<f64>,
   psi_check_timeout: Duration,
@@ -976,15 +767,24 @@ async fn run_build(
   agent_pool: Arc<crate::rpc::AgentPool>,
   heartbeat_ttl: Duration,
 ) -> color_eyre::Result<()> {
-  // Atomically claim the build
-  let claimed = repo::builds::start(pool, build.id).await?;
-  if claimed.is_none() {
+  // Reserve capacity before claiming the build so `running` means execution
+  // can start immediately.
+  let venue = crate::dispatch::reserve_venue(
+    &agent_pool,
+    pool,
+    build,
+    build.system.as_deref(),
+    psi_threshold,
+    heartbeat_ttl,
+    &scheduling_strategy,
+    &worker_semaphore,
+  )
+  .await;
+
+  let Some(claimed_build) = repo::builds::start(pool, build.id).await? else {
     tracing::debug!(build_id = %build.id, "Build already claimed, skipping");
     return Ok(());
-  }
-
-  #[expect(clippy::expect_used, reason = "checked is_some() above")]
-  let claimed_build = claimed.expect("checked is_some() above");
+  };
 
   // Normalize drv_path: nix-eval-jobs always emits absolute store paths,
   // but manually-inserted or migrated rows may have bare filenames. Without
@@ -1060,67 +860,87 @@ async fn run_build(
     log_config.log_dir.join(format!("{}.active.log", build.id));
   let _ = tokio::fs::create_dir_all(&log_config.log_dir).await;
 
-  // Dispatch precedence: persistent agent -> SSH remote builder -> local.
-  // The agent path is preferred because heartbeats give the runner live
-  // load + PSI; the SSH path is a fallback for hosts that do not run
-  // `circus-agent`.
   let cache_upload_enabled_s3 =
     presigned_s3_upload_available(cache_upload_config);
-  let result = if let Some(system) = build.system.as_deref() {
-    if let Some(r) = try_agent_dispatch(
-      &agent_pool,
-      pool,
-      build,
-      system,
-      drv_path,
-      &live_log_path,
-      timeout,
-      psi_threshold,
-      heartbeat_ttl,
-      &scheduling_strategy,
-      &build_extra_nix_args,
-      cache_upload_enabled_s3,
-      &cache_upload_config.compression,
-      cache_upload_config.fail_build_on_upload_error,
-    )
-    .await
-    {
-      Ok(r)
-    } else if let Some(r) = try_remote_build(
-      pool,
-      build,
-      drv_path,
-      work_dir,
-      timeout,
-      Some(&live_log_path),
-      &scheduling_strategy,
-      psi_threshold,
-      psi_check_timeout,
-      &psi_cache,
-      &build_extra_nix_args,
-    )
-    .await
-    {
-      Ok(r)
-    } else {
-      crate::builder::run_nix_build(
+
+  let result = match venue {
+    crate::dispatch::ExecutionReservation::Agent { meta, snap, slot } => {
+      let opts = crate::dispatch::AgentDispatch {
+        timeout,
+        extra_nix_args: &build_extra_nix_args,
+        cache_upload_enabled_s3,
+        cache_upload_compression: &cache_upload_config.compression,
+        fail_build_on_upload_error: cache_upload_config
+          .fail_build_on_upload_error,
+      };
+      if let Some(r) = crate::dispatch::run_on_agent(
+        &meta,
+        &snap,
+        slot,
+        pool,
+        build,
+        drv_path,
+        &live_log_path,
+        &opts,
+      )
+      .await
+      {
+        Ok(r)
+      } else if let Ok(permit) =
+        Arc::clone(&worker_semaphore).try_acquire_owned()
+      {
+        run_on_runner(
+          permit,
+          pool,
+          build,
+          drv_path,
+          work_dir,
+          timeout,
+          &live_log_path,
+          &scheduling_strategy,
+          psi_threshold,
+          psi_check_timeout,
+          &psi_cache,
+          &build_extra_nix_args,
+        )
+        .await
+      } else {
+        // Only remove the live log when requeue succeeds. Cancelled or
+        // completed builds may still need it.
+        match repo::builds::requeue(pool, build.id).await {
+          Ok(Some(_)) => {
+            let _ = tokio::fs::remove_file(&live_log_path).await;
+          },
+          Ok(None) => {
+            tracing::debug!(
+              build_id = %build.id,
+              "build no longer running at requeue (cancelled or completed elsewhere)"
+            );
+          },
+          Err(e) => {
+            tracing::warn!(build_id = %build.id, "Failed to requeue after agent loss: {e}");
+          },
+        }
+        return Ok(());
+      }
+    },
+    crate::dispatch::ExecutionReservation::Runner(permit) => {
+      run_on_runner(
+        permit,
+        pool,
+        build,
         drv_path,
         work_dir,
         timeout,
-        Some(&live_log_path),
+        &live_log_path,
+        &scheduling_strategy,
+        psi_threshold,
+        psi_check_timeout,
+        &psi_cache,
         &build_extra_nix_args,
       )
       .await
-    }
-  } else {
-    crate::builder::run_nix_build(
-      drv_path,
-      work_dir,
-      timeout,
-      Some(&live_log_path),
-      &build_extra_nix_args,
-    )
-    .await
+    },
   };
 
   // Initialize log storage


### PR DESCRIPTION
Agent builds used to keep a local worker permit while the work ran on
a connected agent, which made agent capacity irrelevant once the local
worker limit was full.

This commit reserves capacity before claiming the build instead. Agent
work takes an agent slot, while SSH and local work take worker permits.
Pending fetches and drain now use that same view of active work.


@max-privatevoid and I observed this issue in practice when trying to add
distributed builders that could run more jobs than the machine the central
instance is on.