### PR TITLE
server: restrict binary cache serving

### DIFF
--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -206,6 +206,14 @@ pub async fn serve(
     .with_context(|| format!("bind {}", cfg.bind))?;
   tracing::info!(addr = %cfg.bind, tls = cfg.tls.is_some(), "circus-rpc listening");
 
+  if cfg.presigner.is_some() && cfg.signing_key_file.is_none() {
+    tracing::warn!(
+      "[queue_runner] presigned uploads are enabled without [signing] \
+       key_file; uploaded NARs are persisted unsigned and the cache will \
+       never serve them"
+    );
+  }
+
   let cfg = Arc::new(cfg);
   let connection_permits = Arc::new(Semaphore::new(cfg.max_connections));
   #[expect(clippy::infinite_loop, reason = "intentional accept loop")]

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -654,11 +654,6 @@ impl runner::Server for RunnerImpl {
         let s = info.get_ca()?.to_str()?;
         (!s.is_empty()).then(|| s.to_owned())
       };
-      let sig_in = {
-        let s = info.get_sig()?.to_str()?;
-        (!s.is_empty()).then(|| s.to_owned())
-      };
-
       validate_store_path(&store_path)?;
       validate_hash_text("nar_hash", &nar_hash)?;
       if !file_hash.is_empty() {
@@ -710,11 +705,11 @@ impl runner::Server for RunnerImpl {
       let file_size_opt =
         (compression != "none" && file_size > 0).then_some(file_size);
 
-      // Sign the narinfo on the runner side. The fingerprint is the
-      // canonical Nix narinfo signing input:
+      // Sign the narinfo on the runner side. The fingerprint is the canonical
+      // Nix narinfo signing input:
       // `<storePath>;<narHash>;<narSize>;<references>` (refs comma-
-      // joined). When a signing key is configured we replace whatever
-      // the agent sent (typically empty) with our own signature.
+      // joined). Never persist an agent-supplied signature; only a runner-
+      // minted signature makes the uploaded NAR servable by circus-server.
       let signed_sig = if let Some(key_file) = &self_cfg.signing_key_file {
         match sign_fingerprint(
           key_file,
@@ -728,11 +723,11 @@ impl runner::Server for RunnerImpl {
           Ok(sig) => Some(sig),
           Err(e) => {
             tracing::warn!(%store_path, "narinfo signing failed: {e}");
-            sig_in
+            None
           },
         }
       } else {
-        sig_in
+        None
       };
 
       if let Err(e) = circus_common::repo::narinfo_cache::upsert(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -62,6 +62,13 @@ async fn main() -> color_eyre::Result<()> {
     &config.server.allowed_url_schemes,
   );
 
+  if config.cache.secret_key_file.is_some() {
+    tracing::warn!(
+      "[cache] secret_key_file no longer signs narinfos on the fly; configure \
+       [signing] on the queue-runner so outputs are signed at build time"
+    );
+  }
+
   let db = Database::new(config.database.clone()).await?;
 
   // Bootstrap declarative projects, jobsets, and API keys from config

--- a/crates/server/src/routes/cache.rs
+++ b/crates/server/src/routes/cache.rs
@@ -40,9 +40,10 @@ fn first_path_info_entry(
   }
 }
 
-/// Look up a store path by its nix hash, checking both `build_products` and
-/// builds tables.
-async fn find_store_path(
+/// Look up a store path by its nix hash, limited to build outputs that Circus
+/// signed at build time. This intentionally does not fall back to arbitrary
+/// `/nix/store` paths.
+async fn find_signed_store_path(
   pool: &sqlx::PgPool,
   hash: &str,
   store_dir: &str,
@@ -51,7 +52,8 @@ async fn find_store_path(
   let like_pattern = format!("{store_dir}/{hash}-%");
 
   let path: Option<String> = sqlx::query_scalar(
-    "SELECT path FROM build_products WHERE path LIKE $1 LIMIT 1",
+    "SELECT bp.path FROM build_products bp JOIN builds b ON b.id = \
+     bp.build_id WHERE bp.path LIKE $1 AND b.signed = true LIMIT 1",
   )
   .bind(&like_pattern)
   .fetch_optional(pool)
@@ -63,33 +65,21 @@ async fn find_store_path(
   }
 
   let from_builds = sqlx::query_scalar(
-    "SELECT build_output_path FROM builds WHERE build_output_path LIKE $1 \
-     LIMIT 1",
+    "SELECT build_output_path FROM builds WHERE build_output_path LIKE $1 AND \
+     signed = true LIMIT 1",
   )
   .bind(&like_pattern)
   .fetch_optional(pool)
   .await
   .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
 
-  if from_builds.is_some() {
-    return Ok(from_builds);
-  }
+  Ok(from_builds)
+}
 
-  // Otherwise serve any local store path so agents can substitute assigned
-  // drv closures.
-  //
-  // FIXME: this shells out to `nix`, and needs the nix-command feature. We
-  // should bind to the Nix C/C++ API and call it directly instead.
-  let resolved = tokio::process::Command::new("nix")
-    .args(["store", "path-from-hash-part", hash])
-    .output()
-    .await
-    .ok()
-    .filter(|o| o.status.success())
-    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-    .filter(|p| !p.is_empty());
-
-  Ok(resolved)
+fn narinfo_has_signature(
+  row: &circus_common::repo::narinfo_cache::NarInfo,
+) -> bool {
+  row.sig.as_ref().is_some_and(|sig| !sig.trim().is_empty())
 }
 
 /// Serve `NARInfo` for a store path hash.
@@ -129,16 +119,9 @@ async fn narinfo(
   if let Ok(row) =
     circus_common::repo::narinfo_cache::get_by_hash_part(&state.pool, hash)
       .await
+    && narinfo_has_signature(&row)
   {
     let body = render_narinfo_row(&row);
-    let body = if let (true, Some(key_file)) = (
-      state.config.signing.enabled,
-      state.config.signing.key_file.as_ref(),
-    ) {
-      sign_narinfo(&body, key_file).await
-    } else {
-      body
-    };
     state.narinfo_cache.insert(hash.to_owned(), body.clone());
     return Ok(
       (
@@ -152,7 +135,9 @@ async fn narinfo(
 
   let store_dir = state.config.nix.store_dir.to_string_lossy();
   let store_dir = store_dir.trim_end_matches('/');
-  let store_path = match find_store_path(&state.pool, hash, store_dir).await? {
+  let store_path = match find_signed_store_path(&state.pool, hash, store_dir)
+    .await?
+  {
     Some(p) if circus_common::validate::is_valid_store_path(&p, store_dir) => p,
     _ => return Ok(StatusCode::NOT_FOUND.into_response()),
   };
@@ -207,6 +192,15 @@ async fn narinfo(
   // Extract content-addressable hash
   let ca = entry.get("ca").and_then(|v| v.as_str());
 
+  let signatures: Vec<&str> = entry
+    .get("signatures")
+    .and_then(|v| v.as_array())
+    .map(|arr| arr.iter().filter_map(|s| s.as_str()).collect())
+    .unwrap_or_default();
+  if signatures.is_empty() {
+    return Ok(StatusCode::NOT_FOUND.into_response());
+  }
+
   let compression = &state.config.cache.compression;
   let nar_url = format!("nar/{hash}{}", compression.file_extension());
   let compression_str = compression.as_str();
@@ -240,18 +234,9 @@ async fn narinfo(
   if let Some(ca) = ca {
     let _ = writeln!(narinfo_text, "CA: {ca}");
   }
-
-  // Optionally sign if secret key is configured
-  let narinfo_text =
-    if let Some(ref key_file) = state.config.cache.secret_key_file {
-      if key_file.exists() {
-        sign_narinfo(&narinfo_text, key_file).await
-      } else {
-        narinfo_text
-      }
-    } else {
-      narinfo_text
-    };
+  for sig in signatures {
+    let _ = writeln!(narinfo_text, "Sig: {sig}");
+  }
 
   state
     .narinfo_cache
@@ -328,6 +313,9 @@ async fn redirect_uploaded_nar(
   match circus_common::repo::narinfo_cache::get_by_url(&state.pool, &url).await
   {
     Ok(row) => {
+      if !narinfo_has_signature(&row) {
+        return Ok(Some(StatusCode::NOT_FOUND.into_response()));
+      }
       let Some(presigner) = uploaded_nar_presigner(&state.config) else {
         tracing::warn!(
           url = %row.url,
@@ -347,56 +335,6 @@ async fn redirect_uploaded_nar(
     },
     Err(circus_common::CiError::NotFound(_)) => Ok(None),
     Err(e) => Err(ApiError(e)),
-  }
-}
-
-/// Sign narinfo using nix store sign command
-async fn sign_narinfo(narinfo: &str, key_file: &std::path::Path) -> String {
-  let store_path = narinfo
-    .lines()
-    .find(|l| l.starts_with("StorePath: "))
-    .and_then(|l| l.strip_prefix("StorePath: "));
-
-  let Some(store_path) = store_path else {
-    return narinfo.to_string();
-  };
-
-  let output = Command::new("nix")
-    .args([
-      "store",
-      "sign",
-      "--key-file",
-      &key_file.to_string_lossy(),
-      store_path,
-    ])
-    .output()
-    .await;
-
-  match output {
-    Ok(o) if o.status.success() => {
-      let re_output = Command::new("nix")
-        .args(["path-info", "--json", store_path])
-        .output()
-        .await;
-
-      if let Ok(o) = re_output
-        && let Ok(parsed) =
-          serde_json::from_slice::<serde_json::Value>(&o.stdout)
-        && let Some((entry, _)) = first_path_info_entry(&parsed)
-        && let Some(sigs) = entry.get("signatures").and_then(|v| v.as_array())
-      {
-        let sig_lines: Vec<String> = sigs
-          .iter()
-          .filter_map(|s| s.as_str())
-          .map(|s| format!("Sig: {s}"))
-          .collect();
-        if !sig_lines.is_empty() {
-          return format!("{narinfo}{}\n", sig_lines.join("\n"));
-        }
-      }
-      narinfo.to_string()
-    },
-    _ => narinfo.to_string(),
   }
 }
 
@@ -532,12 +470,15 @@ async fn serve_nar_combined(
 
   let store_dir = state.config.nix.store_dir.to_string_lossy();
   let store_dir = store_dir.trim_end_matches('/');
-  let store_path = match find_store_path(&state.pool, stripped, store_dir)
-    .await?
-  {
-    Some(p) if circus_common::validate::is_valid_store_path(&p, store_dir) => p,
-    _ => return Ok(StatusCode::NOT_FOUND.into_response()),
-  };
+  let store_path =
+    match find_signed_store_path(&state.pool, stripped, store_dir).await? {
+      Some(p)
+        if circus_common::validate::is_valid_store_path(&p, store_dir) =>
+      {
+        p
+      },
+      _ => return Ok(StatusCode::NOT_FOUND.into_response()),
+    };
 
   let body = if let Some((bin, args)) = compressor {
     let stdout = pipe_through_compressor(&store_path, bin, args)?;

--- a/crates/server/src/routes/cache.rs
+++ b/crates/server/src/routes/cache.rs
@@ -82,6 +82,61 @@ fn narinfo_has_signature(
   row.sig.as_ref().is_some_and(|sig| !sig.trim().is_empty())
 }
 
+/// Resolve the local store path a cache request may serve. Signed build
+/// outputs come from the DB; any other local path is only servable when
+/// content-addressed (`true` in the second tuple field), which covers the
+/// drv closures (drvs and sources) agents substitute for dispatched
+/// builds. Nix recomputes the store path from the `CA:` field on
+/// substitution, so CA paths cannot be forged and need no signature.
+///
+/// FIXME: this shells out to `nix`, and needs the nix-command feature. We
+/// should bind to the Nix C/C++ API and call it directly instead.
+async fn resolve_servable_path(
+  pool: &sqlx::PgPool,
+  hash: &str,
+  store_dir: &str,
+) -> std::result::Result<Option<(String, bool)>, ApiError> {
+  if let Some(p) = find_signed_store_path(pool, hash, store_dir).await? {
+    return Ok(
+      circus_common::validate::is_valid_store_path(&p, store_dir)
+        .then_some((p, false)),
+    );
+  }
+
+  let resolved = Command::new("nix")
+    .args(["store", "path-from-hash-part", hash])
+    .output()
+    .await
+    .ok()
+    .filter(|o| o.status.success())
+    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+    .filter(|p| circus_common::validate::is_valid_store_path(p, store_dir));
+
+  Ok(resolved.map(|p| (p, true)))
+}
+
+/// Whether the local store path is content-addressed (drvs, sources).
+async fn is_content_addressed(store_path: &str) -> bool {
+  let output = Command::new("nix")
+    .args(["path-info", "--json", store_path])
+    .output()
+    .await;
+  let Ok(output) = output else {
+    return false;
+  };
+  if !output.status.success() {
+    return false;
+  }
+  let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+  else {
+    return false;
+  };
+  first_path_info_entry(&parsed)
+    .and_then(|(entry, _)| entry.get("ca"))
+    .and_then(|v| v.as_str())
+    .is_some_and(|ca| !ca.is_empty())
+}
+
 /// Serve `NARInfo` for a store path hash.
 /// GET /nix-cache/{hash}.narinfo
 async fn narinfo(
@@ -135,11 +190,10 @@ async fn narinfo(
 
   let store_dir = state.config.nix.store_dir.to_string_lossy();
   let store_dir = store_dir.trim_end_matches('/');
-  let store_path = match find_signed_store_path(&state.pool, hash, store_dir)
-    .await?
-  {
-    Some(p) if circus_common::validate::is_valid_store_path(&p, store_dir) => p,
-    _ => return Ok(StatusCode::NOT_FOUND.into_response()),
+  let Some((store_path, require_ca)) =
+    resolve_servable_path(&state.pool, hash, store_dir).await?
+  else {
+    return Ok(StatusCode::NOT_FOUND.into_response());
   };
 
   // Get narinfo from nix path-info
@@ -197,7 +251,14 @@ async fn narinfo(
     .and_then(|v| v.as_array())
     .map(|arr| arr.iter().filter_map(|s| s.as_str()).collect())
     .unwrap_or_default();
-  if signatures.is_empty() {
+  // Outputs must carry a signature minted at build time; drv-closure
+  // paths are only trusted through their CA field.
+  let servable = if require_ca {
+    ca.is_some_and(|c| !c.is_empty())
+  } else {
+    !signatures.is_empty()
+  };
+  if !servable {
     return Ok(StatusCode::NOT_FOUND.into_response());
   }
 
@@ -470,15 +531,14 @@ async fn serve_nar_combined(
 
   let store_dir = state.config.nix.store_dir.to_string_lossy();
   let store_dir = store_dir.trim_end_matches('/');
-  let store_path =
-    match find_signed_store_path(&state.pool, stripped, store_dir).await? {
-      Some(p)
-        if circus_common::validate::is_valid_store_path(&p, store_dir) =>
-      {
-        p
-      },
-      _ => return Ok(StatusCode::NOT_FOUND.into_response()),
-    };
+  let Some((store_path, require_ca)) =
+    resolve_servable_path(&state.pool, stripped, store_dir).await?
+  else {
+    return Ok(StatusCode::NOT_FOUND.into_response());
+  };
+  if require_ca && !is_content_addressed(&store_path).await {
+    return Ok(StatusCode::NOT_FOUND.into_response());
+  }
 
   let body = if let Some((bin, args)) = compressor {
     let stdout = pipe_through_compressor(&store_path, bin, args)?;

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -352,6 +352,83 @@ async fn test_cache_invalid_hash_returns_404() {
 }
 
 #[tokio::test]
+async fn test_cache_serves_only_signed_persisted_narinfo() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let hash = uuid::Uuid::new_v4().simple().to_string();
+  let store_path = format!("/nix/store/{hash}-cache-test");
+  circus_common::repo::narinfo_cache::upsert(
+    &pool,
+    circus_common::repo::narinfo_cache::UpsertNarInfo {
+      store_path:  &store_path,
+      nar_hash:
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      nar_size:    1,
+      file_hash:   None,
+      file_size:   None,
+      compression: "none",
+      url:         &format!("nar/{hash}.nar"),
+      deriver:     None,
+      references:  &[],
+      sig:         None,
+      ca:          None,
+    },
+  )
+  .await
+  .unwrap();
+
+  let mut config = circus_common::config::Config::default();
+  config.cache.enabled = true;
+  let app = build_app_with_config(pool.clone(), config.clone());
+
+  let response = app
+    .clone()
+    .oneshot(
+      Request::builder()
+        .uri(format!("/nix-cache/{hash}.narinfo"))
+        .body(Body::empty())
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+  assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+  circus_common::repo::narinfo_cache::upsert(
+    &pool,
+    circus_common::repo::narinfo_cache::UpsertNarInfo {
+      store_path:  &store_path,
+      nar_hash:
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      nar_size:    1,
+      file_hash:   None,
+      file_size:   None,
+      compression: "none",
+      url:         &format!("nar/{hash}.nar"),
+      deriver:     None,
+      references:  &[],
+      sig:         Some("circus:test-signature"),
+      ca:          None,
+    },
+  )
+  .await
+  .unwrap();
+
+  let app = build_app_with_config(pool, config);
+  let response = app
+    .oneshot(
+      Request::builder()
+        .uri(format!("/nix-cache/{hash}.narinfo"))
+        .body(Body::empty())
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+  assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_cache_nar_invalid_hash_returns_404() {
   let Some(pool) = get_pool().await else {
     return;

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -213,7 +213,7 @@ development; `circus.toml` remains the practical reference.
 | `logs`               | `log_dir`                    | `/var/lib/circus/logs`                              | Build log storage directory                      |
 | `logs`               | `compress`                   | `false`                                             | Compress stored logs                             |
 | `cache`              | `enabled`                    | `true`                                              | Serve a Nix binary cache at `/nix-cache/`        |
-| `cache`              | `secret_key_file`            | none                                                | Signing key for binary cache                     |
+| `cache`              | `secret_key_file`            | none                                                | Deprecated; outputs are signed via `[signing]`   |
 | `cache`              | `compression`                | `zstd`                                              | NAR compression algorithm                        |
 | `cache`              | `cache_url`                  | none                                                | Public cache URL for channel manifests           |
 | `signing`            | `enabled`                    | `false`                                             | Sign build outputs                               |
@@ -273,6 +273,13 @@ development; `circus.toml` remains the practical reference.
 Set `[cache].enabled = true` on the server to expose `/nix-cache/`. For outputs
 present in the server's Nix store, Circus generates narinfo from `nix path-info`
 and streams NARs with the configured `[cache].compression`.
+
+Only two kinds of local store paths are served: build outputs the queue-runner
+signed at build time (`[signing]` with a `key_file` — unsigned outputs are
+never exposed), and content-addressed paths such as drvs and sources, which
+Nix verifies against their `CA:` field and which agents substitute when
+starting dispatched builds. Without a signing key the cache serves nothing
+beyond drv closures.
 
 Set `[cache_upload].enabled = true` and `store_uri = "s3://bucket[/prefix]"` to
 push completed outputs to S3. SSH/local runner builds use `nix copy --to`; agent

--- a/nix/tests/agent-dispatch.nix
+++ b/nix/tests/agent-dispatch.nix
@@ -110,9 +110,13 @@ testers.runNixOSTest {
             };
             gc.enabled = false;
             logs.log_dir = "/var/lib/circus/logs";
-            # Serve + sign the local store so the agent can substitute drv closures.
+            # Serve the local store so the agent can substitute drv closures
+            # (drvs and sources are content-addressed and served unsigned).
             cache.enabled = true;
-            cache.secret_key_file = "/etc/circus/cache-key.sec";
+            signing = {
+              enabled = true;
+              key_file = "/etc/circus/cache-key.sec";
+            };
             tracing = {
               level = "info";
               format = "compact";

--- a/nix/tests/basic-api.nix
+++ b/nix/tests/basic-api.nix
@@ -89,6 +89,21 @@ testers.runNixOSTest {
     with subtest("Cache returns 404 for valid but nonexistent hash"):
         machine.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3000/nix-cache/abcdefghijklmnopqrstuvwxyz012345.narinfo | grep -q 404")
 
+    with subtest("Cache serves only Circus-signed persisted narinfo"):
+        unsigned_hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        signed_hash = "cccccccccccccccccccccccccccccccc"
+        machine.succeed(
+            "setpriv --reuid=circus --regid=circus --init-groups psql -U circus -d circus -c \""
+            "INSERT INTO narinfo_cache (store_path, nar_hash, nar_size, compression, url, \\\"references\\\", sig) VALUES "
+            "('/nix/store/" + unsigned_hash + "-unsigned-cache-test', 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1, 'none', 'nar/" + unsigned_hash + ".nar', '{}', NULL), "
+            "('/nix/store/" + signed_hash + "-signed-cache-test', 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1, 'none', 'nar/" + signed_hash + ".nar', '{}', 'circus-test-cache:sig')"
+            "\""
+        )
+        machine.succeed(f"curl -s -o /dev/null -w '%{{http_code}}' http://127.0.0.1:3000/nix-cache/{unsigned_hash}.narinfo | grep -q 404")
+        signed_narinfo = machine.succeed(f"curl -sf http://127.0.0.1:3000/nix-cache/{signed_hash}.narinfo")
+        assert "StorePath: /nix/store/" + signed_hash + "-signed-cache-test" in signed_narinfo, signed_narinfo
+        assert "Sig: circus-test-cache:sig" in signed_narinfo, signed_narinfo
+
     #  NAR endpoints: invalid hash rejection
     with subtest("NAR zst rejects invalid hash"):
         machine.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3000/nix-cache/nar/INVALID.nar.zst | grep -q 404")


### PR DESCRIPTION
Changes around serving Nix store paths and narinfo files from the cache. Mainly, we now make sure only store paths and narinfo entries that were signed by Circus at build time are served, and that agent-supplied or unsigned data is never exposed. Also removes some redundant fallback logic/signature handling code that was implemented by @amaanq earlier. I meant to "improve" it but I found it to be unsalvagable, especially the nix command invocation.


Change-Id: I8cc19463bb1e2712f008e11f299f1b0e6a6a6964