### PR TITLE
rpc: make client-cert auth optional when a client CA is configured

### DIFF
--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -81,8 +81,10 @@ pub struct Agent {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TlsConfig {
   pub ca_file:   PathBuf,
-  pub cert_file: PathBuf,
-  pub key_file:  PathBuf,
+  #[serde(default)]
+  pub cert_file: Option<PathBuf>,
+  #[serde(default)]
+  pub key_file:  Option<PathBuf>,
 }
 
 const fn default_max_jobs() -> u32 {

--- a/crates/agent/src/tls.rs
+++ b/crates/agent/src/tls.rs
@@ -5,20 +5,40 @@
 use std::{io::BufReader, sync::Arc};
 
 use color_eyre::eyre::eyre;
-use rustls::{ClientConfig, RootCertStore};
+use rustls::{ClientConfig, RootCertStore, pki_types::CertificateDer};
 use tokio_rustls::TlsConnector;
 
 use crate::config::TlsConfig;
 
-/// Build a connector that trusts `ca_file` for the server and presents
-/// `cert_file` / `key_file` as the client identity (mTLS).
+/// Build a connector that trusts `ca_file` for the server. When `cert_file`
+/// and `key_file` are both set it also presents them as the client identity
+/// for mTLS. When they're absent it connects with no client auth, relying on
+/// the bearer token alone.
 ///
 /// # Errors
+///
 /// Returns the underlying IO/rustls error on missing files, malformed
 /// PEM, or unsupported key types.
 pub fn build_client_connector(
   cfg: &TlsConfig,
 ) -> color_eyre::Result<TlsConnector> {
+  let client_identity = match (&cfg.cert_file, &cfg.key_file) {
+    (Some(cert_file), Some(key_file)) => Some((cert_file, key_file)),
+    (None, None) => None,
+    (Some(cert_file), None) => {
+      return Err(eyre!(
+        "agent TLS cert_file {} requires key_file",
+        cert_file.display()
+      ));
+    },
+    (None, Some(key_file)) => {
+      return Err(eyre!(
+        "agent TLS key_file {} requires cert_file",
+        key_file.display()
+      ));
+    },
+  };
+
   let mut roots = RootCertStore::empty();
   let ca_bytes = std::fs::read(&cfg.ca_file)?;
   for cert in rustls_pemfile::certs(&mut BufReader::new(ca_bytes.as_slice())) {
@@ -26,18 +46,51 @@ pub fn build_client_connector(
     roots.add(cert)?;
   }
 
-  let cert_bytes = std::fs::read(&cfg.cert_file)?;
-  let cert_chain: Vec<_> =
-    rustls_pemfile::certs(&mut BufReader::new(cert_bytes.as_slice()))
-      .collect::<Result<_, _>>()?;
+  let builder = ClientConfig::builder().with_root_certificates(roots);
+  let client_cfg = if let Some((cert_file, key_file)) = client_identity {
+    let cert_bytes = std::fs::read(cert_file)?;
+    let cert_chain =
+      rustls_pemfile::certs(&mut BufReader::new(cert_bytes.as_slice()))
+        .collect::<Result<Vec<CertificateDer>, _>>()?;
+    let key_bytes = std::fs::read(key_file)?;
+    let key =
+      rustls_pemfile::private_key(&mut BufReader::new(key_bytes.as_slice()))?
+        .ok_or_else(|| eyre!("no private key in {}", key_file.display()))?;
+    builder.with_client_auth_cert(cert_chain, key)?
+  } else {
+    builder.with_no_client_auth()
+  };
+  Ok(TlsConnector::from(Arc::new(client_cfg)))
+}
 
-  let key_bytes = std::fs::read(&cfg.key_file)?;
-  let key =
-    rustls_pemfile::private_key(&mut BufReader::new(key_bytes.as_slice()))?
-      .ok_or_else(|| eyre!("no private key in {}", cfg.key_file.display()))?;
+#[cfg(test)]
+#[expect(clippy::panic, reason = "it's in a test")]
+mod tests {
+  use std::path::PathBuf;
 
-  let cfg = ClientConfig::builder()
-    .with_root_certificates(roots)
-    .with_client_auth_cert(cert_chain, key)?;
-  Ok(TlsConnector::from(Arc::new(cfg)))
+  use super::*;
+
+  fn cfg(cert_file: Option<&str>, key_file: Option<&str>) -> TlsConfig {
+    TlsConfig {
+      ca_file:   PathBuf::from("missing-ca.pem"),
+      cert_file: cert_file.map(PathBuf::from),
+      key_file:  key_file.map(PathBuf::from),
+    }
+  }
+
+  #[test]
+  fn rejects_cert_without_key() {
+    let Err(err) = build_client_connector(&cfg(Some("agent.crt"), None)) else {
+      panic!("partial client identity should fail");
+    };
+    assert!(err.to_string().contains("requires key_file"));
+  }
+
+  #[test]
+  fn rejects_key_without_cert() {
+    let Err(err) = build_client_connector(&cfg(None, Some("agent.key"))) else {
+      panic!("partial client identity should fail");
+    };
+    assert!(err.to_string().contains("requires cert_file"));
+  }
 }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -263,16 +263,16 @@ pub struct RpcConfig {
 /// client and authentication relies on the bearer token alone.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcTlsConfig {
-  pub cert_file: PathBuf,
-  pub key_file:  PathBuf,
+  pub cert_file:           PathBuf,
+  pub key_file:            PathBuf,
   #[serde(default)]
-  pub client_ca: Option<PathBuf>,
-  /// When `client_ca` is set and this is true, the server requires the
-  /// client certificate's CN to equal the agent's `name`. Defaults to
-  /// true; flip to false for cluster operators using a per-tenant CA
-  /// rather than per-host certs.
+  pub client_ca:           Option<PathBuf>,
+  /// Pin a presented client cert name to the registering agent name.
   #[serde(default = "default_true")]
-  pub pin_cn:    bool,
+  pub pin_cn:              bool,
+  /// Require every agent to present a cert when `client_ca` is set.
+  #[serde(default = "default_true")]
+  pub require_client_cert: bool,
 }
 
 const fn default_max_rpc_conns() -> usize {

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -253,7 +253,7 @@ async fn serve_one(
 
   let rpc_result = if let Some(tls) = cfg.tls.as_ref() {
     let stream = tls.acceptor.clone().accept(socket).await?;
-    let pinned_cn = extract_peer_cn(&stream);
+    let peer_cert = extract_peer_cert_identity(&stream);
     let (rh, wh) = tokio::io::split(stream);
     let network = twoparty::VatNetwork::new(
       rh.compat(),
@@ -266,7 +266,7 @@ async fn serve_one(
       pool: Arc::clone(&pool),
       db_pool: db_pool.clone(),
       registered_machine: Arc::clone(&registered_machine),
-      pinned_cn,
+      peer_cert,
     };
     let runner_cap: runner::Client = capnp_rpc::new_client(runner_impl);
     let rpc = RpcSystem::new(Box::new(network), Some(runner_cap.client));
@@ -284,7 +284,7 @@ async fn serve_one(
       pool:               Arc::clone(&pool),
       db_pool:            db_pool.clone(),
       registered_machine: Arc::clone(&registered_machine),
-      pinned_cn:          None,
+      peer_cert:          PeerCertIdentity::default(),
     };
     let runner_cap: runner::Client = capnp_rpc::new_client(runner_impl);
     let rpc = RpcSystem::new(Box::new(network), Some(runner_cap.client));
@@ -314,20 +314,31 @@ async fn serve_one(
   Ok(())
 }
 
-/// Extract the Common Name from the peer's verified client certificate.
-///
-/// rustls hands us the DER-encoded certificate chain; we only need the CN
-/// of the leaf. We do a minimal X.509 walk rather than pulling in a full
-/// parser: the CN is in the Subject sequence under OID 2.5.4.3.
-fn extract_peer_cn(
-  stream: &tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
-) -> Option<String> {
-  let (_, server_conn) = stream.get_ref();
-  let peer = server_conn.peer_certificates()?.first()?;
-  parse_cn(peer.as_ref())
+#[derive(Clone, Default)]
+struct PeerCertIdentity {
+  presented: bool,
+  name:      Option<String>,
 }
 
-fn parse_cn(der: &[u8]) -> Option<String> {
+/// Extract the pinning name from the peer's verified client certificate.
+///
+/// rustls hands us the DER-encoded certificate chain; we only need the name
+/// of the leaf. Prefer DNS SANs and fall back to the Subject CN.
+fn extract_peer_cert_identity(
+  stream: &tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
+) -> PeerCertIdentity {
+  let (_, server_conn) = stream.get_ref();
+  let Some(peer) = server_conn.peer_certificates().and_then(|c| c.first())
+  else {
+    return PeerCertIdentity::default();
+  };
+  PeerCertIdentity {
+    presented: true,
+    name:      parse_cert_name(peer.as_ref()),
+  }
+}
+
+fn parse_cert_name(der: &[u8]) -> Option<String> {
   let (_, cert) =
     x509_parser::certificate::X509Certificate::from_der(der).ok()?;
   if let Ok(Some(san)) = cert.subject_alternative_name() {
@@ -352,9 +363,8 @@ struct RunnerImpl {
   pool:               Arc<AgentPool>,
   db_pool:            PgPool,
   registered_machine: Arc<parking_lot::Mutex<Option<RegisteredAgent>>>,
-  /// CN extracted from the peer certificate when mTLS is enforced; `None`
-  /// when TLS is off or `client_ca` was not set.
-  pinned_cn:          Option<String>,
+  /// Client certificate identity, if one was presented.
+  peer_cert:          PeerCertIdentity,
 }
 
 #[allow(refining_impl_trait_internal, refining_impl_trait_reachable)]
@@ -368,7 +378,7 @@ impl runner::Server for RunnerImpl {
     let pool = Arc::clone(&self.pool);
     let db_pool = self.db_pool.clone();
     let registered_slot = Arc::clone(&self.registered_machine);
-    let pinned_cn = self.pinned_cn.clone();
+    let peer_cert = self.peer_cert.clone();
     Promise::from_future(async move {
       let pr = params.get()?;
       let info = pr.get_info()?;
@@ -397,15 +407,20 @@ impl runner::Server for RunnerImpl {
         return Err(capnp::Error::failed("auth failed".into()));
       }
 
-      // CN pinning: only enforced when mTLS extracted a CN. With
-      // `pin_cn = false` operators can use a per-tenant CA where the CN
-      // is the tenant identifier rather than the agent name.
-      if let Some(cn) = pinned_cn.as_ref()
-        && cfg.tls.as_ref().is_some_and(|t| t.pin_cn)
-        && cn != &name
-      {
-        tracing::warn!(name = %name, cn = %cn, "cert CN does not match agent name");
-        return Err(capnp::Error::failed("CN/name mismatch".into()));
+      if cfg.tls.as_ref().is_some_and(|t| t.pin_cn) && peer_cert.presented {
+        match peer_cert.name.as_deref() {
+          Some(cert_name) if cert_name == name => {},
+          Some(cert_name) => {
+            tracing::warn!(name = %name, cert_name, "cert name does not match agent name");
+            return Err(capnp::Error::failed("cert/name mismatch".into()));
+          },
+          None => {
+            tracing::warn!(name = %name, "client cert has no name to pin");
+            return Err(capnp::Error::failed(
+              "client cert has no pinned name".into(),
+            ));
+          },
+        }
       }
 
       validate_text_len("agent.name", &name, 1, limits::MAX_AGENT_NAME_LEN)?;

--- a/crates/queue-runner/src/rpc/tls.rs
+++ b/crates/queue-runner/src/rpc/tls.rs
@@ -1,7 +1,9 @@
 //! Runner-side TLS. Builds a `tokio_rustls::TlsAcceptor` from the
 //! configured server identity. When `client_ca` is set the acceptor
-//! enforces mTLS; the CN-pin is checked at the application layer after
-//! the handshake so we can map it onto the agent's registered name.
+//! verifies client certs against it. This is required when
+//! `require_client_cert` is set, otherwise honored only when offered. The
+//! CN-pin is checked at the application layer after the handshake so we can map
+//! it onto the agent's registered name.
 
 use std::{io::BufReader, sync::Arc};
 
@@ -36,7 +38,12 @@ pub fn build_acceptor(cfg: &RpcTlsConfig) -> color_eyre::Result<TlsAcceptor> {
     {
       roots.add(cert?)?;
     }
-    let verifier = WebPkiClientVerifier::builder(Arc::new(roots)).build()?;
+    let builder = WebPkiClientVerifier::builder(Arc::new(roots));
+    let verifier = if cfg.require_client_cert {
+      builder.build()?
+    } else {
+      builder.allow_unauthenticated().build()?
+    };
     ServerConfig::builder()
       .with_client_cert_verifier(verifier)
       .with_single_cert(cert_chain, key)?

--- a/crates/server/src/routes/dashboard/auth.rs
+++ b/crates/server/src/routes/dashboard/auth.rs
@@ -235,13 +235,11 @@ pub(super) async fn logout_action(
       } else {
         None
       }
-    })
-      && let Err(e) =
-        circus_common::repo::users::delete_session(&state.pool, &session_id)
-          .await
-      {
-        tracing::warn!("failed to delete user session during logout: {e}");
-      }
+    }) && let Err(e) =
+      circus_common::repo::users::delete_session(&state.pool, &session_id).await
+    {
+      tracing::warn!("failed to delete user session during logout: {e}");
+    }
 
     // Check for legacy API key session
     if let Some(session_id) = cookie_header.split(';').find_map(|pair| {

--- a/docs/DISTRIBUTED.md
+++ b/docs/DISTRIBUTED.md
@@ -149,15 +149,17 @@ The flow is as follows
    flight are marked stuck and reset to `pending` by the orphan sweeper (already
    implemented at `crates/queue-runner/src/runner_loop.rs`).
 7. `register` carries a bearer token. The runner SHA-256 hashes it and compares
-   constant-time against `[queue_runner.rpc].auth_tokens` (hex digests). mTLS is
-   optional; when the server config sets `tls.client_ca` and
-   `tls.pin_cn = true`, the client certificate's Common Name must also equal the
-   agent's registered `name`.
+   constant-time against `[queue_runner.rpc].auth_tokens`. mTLS is optional, and
+   setting `tls.client_ca` enables client-cert verification. However, note that
+   with `tls.pin_cn = true`, the certificate's Common Name must equal the agent's
+   registered `name`. Whether a cert is mandatory is governed by
+   `tls.require_client_cert`, which is true by default. This enforces strict mTLS,
+   but setting it false to accept token-only agents that present no certificate
+   while still verifying any cert that is offered.
 8. If the runner's cache upload target is S3 and explicit presigning credentials
    are configured, `BuildAssignment.presignedUpload` asks the agent to upload
    outputs directly. The agent requests PUT URLs for the active
-   `(machineId,
-   buildId)` pair, streams each compressed NAR to S3, then calls
+   `(machineId, buildId)` pair, streams each compressed NAR to S3, then calls
    `notifyUploadComplete`. The runner verifies the upload was presigned for that
    live build/path before persisting narinfo and clears the expected-upload
    state when the build completes or disconnects.
@@ -234,11 +236,13 @@ prefix            = "nix-cache" # objects are written below root/nix-cache/
 access_key_id     = "..."
 secret_access_key = "..."
 
-[queue_runner.rpc.tls]                           # optional; omit for plain TCP
-cert_file = "/var/lib/circus/tls/runner.crt"
-key_file  = "/var/lib/circus/tls/runner.key"
-client_ca = "/var/lib/circus/tls/clients.ca.crt" # presence => mTLS required
-pin_cn    = true                                 # CN must equal agent.name
+# optional, this can be omitted for plain TCP
+[queue_runner.rpc.tls]
+cert_file           = "/var/lib/circus/tls/runner.crt"
+key_file            = "/var/lib/circus/tls/runner.key"
+client_ca           = "/var/lib/circus/tls/clients.ca.crt" # enables client-cert verification
+pin_cn              = true                                 # CN must equal agent.name
+require_client_cert = true                                 # false => cert optional, token-only OK
 ```
 
 > [!NOTE]
@@ -263,9 +267,9 @@ work_dir                = "/var/lib/circus-agent"
 
 # required for circus+tls://
 [agent.tls]
-ca_file   = "/etc/circus/tls/runner.ca.crt"
-cert_file = "/etc/circus/tls/build-01.crt"
-key_file  = "/etc/circus/tls/build-01.key"
+ca_file   = "/etc/circus/tls/runner.ca.crt" # required: trusts the runner cert
+cert_file = "/etc/circus/tls/build-01.crt"  # optional: client identity (mTLS)
+key_file  = "/etc/circus/tls/build-01.key"  # omit cert_file + key_file for token-only
 ```
 
 The agent runs as a Systemd service. A NixOS module is provided at
@@ -296,10 +300,12 @@ matter of which service is running.
   malformed token digests. The `builder_sessions` table has an `auth_token_hash`
   column reserved for per-agent tokens but no code path consults it yet.
 - Optional mTLS via `tokio-rustls`. Cert + key live under
-  `[queue_runner.rpc].tls`; setting `client_ca` switches the acceptor to
-  `WebPkiClientVerifier` so client certs are required. With `pin_cn = true` (the
-  default when `client_ca` is set), the registering agent's `name` must equal
-  the CN extracted from the verified client certificate.
+  `[queue_runner.rpc].tls`; setting `client_ca` attaches a
+  `WebPkiClientVerifier`. With `require_client_cert = true`, client certs are
+  mandatory. Set it false to use `allow_unauthenticated` so an agent may
+  connect token-only while any cert it does present is still verified. With
+  `pin_cn = true` (the default when `client_ca` is set), an agent that presents
+  a certificate must have a CN equal to its registered `name`.
 - Cap'n Proto framing is bounded by `capnp::message::ReaderOptions` defaults;
   oversized messages are rejected at decode. Circus also enforces
   application-level limits from `circus_proto::limits`: bounded registration


### PR DESCRIPTION
Setting `tls.client_ca` forced every agent to present a client certificate at the handshake, even though the bearer token already authenticates each register call and the CN-pin is an additional binding on top.

This commit gates the verifier on a new require_client_cert field, which when false the acceptor uses `allow_unauthenticated`, so a presented cert is still verified and pinned while a missing one falls through to token auth.