### PR TITLE
rpc: default client cert auth to optional

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -257,10 +257,9 @@ pub struct RpcConfig {
   pub cache_public_key: Option<String>,
 }
 
-/// Server-side TLS material for the capnp-rpc endpoint. When `client_ca`
-/// is set the server requires mTLS and pins the client certificate's CN
-/// to the registered agent name; without it the server accepts any TLS
-/// client and authentication relies on the bearer token alone.
+/// Server-side TLS material for the capnp-rpc endpoint. When `client_ca` is
+/// set, the runner verifies any client cert an agent presents. Set
+/// `require_client_cert` to make that cert mandatory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcTlsConfig {
   pub cert_file:           PathBuf,
@@ -270,8 +269,8 @@ pub struct RpcTlsConfig {
   /// Pin a presented client cert name to the registering agent name.
   #[serde(default = "default_true")]
   pub pin_cn:              bool,
-  /// Require every agent to present a cert when `client_ca` is set.
-  #[serde(default = "default_true")]
+  /// Require client certs when `client_ca` is set.
+  #[serde(default)]
   pub require_client_cert: bool,
 }
 

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -322,8 +322,8 @@ struct PeerCertIdentity {
 
 /// Extract the pinning name from the peer's verified client certificate.
 ///
-/// rustls hands us the DER-encoded certificate chain; we only need the name
-/// of the leaf. Prefer DNS SANs and fall back to the Subject CN.
+/// rustls gives us the DER-encoded certificate chain, and we only need the
+/// leaf name. Prefer DNS SANs and fall back to the Subject CN.
 fn extract_peer_cert_identity(
   stream: &tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
 ) -> PeerCertIdentity {

--- a/crates/queue-runner/src/rpc/tls.rs
+++ b/crates/queue-runner/src/rpc/tls.rs
@@ -1,9 +1,9 @@
 //! Runner-side TLS. Builds a `tokio_rustls::TlsAcceptor` from the
 //! configured server identity. When `client_ca` is set the acceptor
-//! verifies client certs against it. This is required when
-//! `require_client_cert` is set, otherwise honored only when offered. The
-//! CN-pin is checked at the application layer after the handshake so we can map
-//! it onto the agent's registered name.
+//! verifies any client cert an agent presents, and can require one when
+//! `require_client_cert` is enabled. CN pinning runs after the handshake,
+//! where it can compare the verified cert identity with the agent's registered
+//! name.
 
 use std::{io::BufReader, sync::Arc};
 

--- a/docs/DISTRIBUTED.md
+++ b/docs/DISTRIBUTED.md
@@ -149,13 +149,11 @@ The flow is as follows
    flight are marked stuck and reset to `pending` by the orphan sweeper (already
    implemented at `crates/queue-runner/src/runner_loop.rs`).
 7. `register` carries a bearer token. The runner SHA-256 hashes it and compares
-   constant-time against `[queue_runner.rpc].auth_tokens`. mTLS is optional, and
-   setting `tls.client_ca` enables client-cert verification. However, note that
-   with `tls.pin_cn = true`, the certificate's Common Name must equal the agent's
-   registered `name`. Whether a cert is mandatory is governed by
-   `tls.require_client_cert`, which is true by default. This enforces strict mTLS,
-   but setting it false to accept token-only agents that present no certificate
-   while still verifying any cert that is offered.
+   constant-time against `[queue_runner.rpc].auth_tokens`. If `tls.client_ca`
+   is set, the runner verifies any client cert an agent presents. Client certs
+   remain optional unless `tls.require_client_cert = true` is set, and with
+   `tls.pin_cn = true` the verified cert name must match the agent's registered
+   `name`.
 8. If the runner's cache upload target is S3 and explicit presigning credentials
    are configured, `BuildAssignment.presignedUpload` asks the agent to upload
    outputs directly. The agent requests PUT URLs for the active
@@ -242,7 +240,7 @@ cert_file           = "/var/lib/circus/tls/runner.crt"
 key_file            = "/var/lib/circus/tls/runner.key"
 client_ca           = "/var/lib/circus/tls/clients.ca.crt" # enables client-cert verification
 pin_cn              = true                                 # CN must equal agent.name
-require_client_cert = true                                 # false => cert optional, token-only OK
+require_client_cert = false                                # true opts into strict mTLS
 ```
 
 > [!NOTE]
@@ -300,12 +298,11 @@ matter of which service is running.
   malformed token digests. The `builder_sessions` table has an `auth_token_hash`
   column reserved for per-agent tokens but no code path consults it yet.
 - Optional mTLS via `tokio-rustls`. Cert + key live under
-  `[queue_runner.rpc].tls`; setting `client_ca` attaches a
-  `WebPkiClientVerifier`. With `require_client_cert = true`, client certs are
-  mandatory. Set it false to use `allow_unauthenticated` so an agent may
-  connect token-only while any cert it does present is still verified. With
-  `pin_cn = true` (the default when `client_ca` is set), an agent that presents
-  a certificate must have a CN equal to its registered `name`.
+  `[queue_runner.rpc].tls`, and setting `client_ca` attaches a
+  `WebPkiClientVerifier` for any client cert an agent presents. Agents may
+  still connect token-only unless `require_client_cert = true` is set. With
+  `pin_cn = true`, the verified cert name must match the registered agent
+  `name`.
 - Cap'n Proto framing is bounded by `capnp::message::ReaderOptions` defaults;
   oversized messages are rejected at decode. Circus also enforces
   application-level limits from `circus_proto::limits`: bounded registration


### PR DESCRIPTION
Follow-up to #65 to make mTLS support opt-in. `client_ca` still verifies any presented cert, while `require_client_cert = true` opts into strict mTLS.