### PR TITLE
runner: fix feature-aware agent scheduling

### DIFF
--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -722,15 +722,38 @@ async fn read_required_features(drv_path: &str) -> Vec<String> {
   else {
     return Vec::new();
   };
-  let Some(drv) = parsed.as_object().and_then(|o| o.values().next()) else {
+  required_features_from_derivation_show(&parsed)
+}
+
+fn derivation_from_show(
+  parsed: &serde_json::Value,
+) -> Option<&serde_json::Map<String, serde_json::Value>> {
+  let obj = parsed.as_object()?;
+  if let Some(derivations) = obj.get("derivations").and_then(|v| v.as_object())
+  {
+    return derivations.values().next()?.as_object();
+  }
+  obj.values().next()?.as_object()
+}
+
+fn split_required_features(value: &str) -> Vec<String> {
+  value
+    .split(|c: char| c.is_whitespace() || c == ':' || c == ',')
+    .filter(|s| !s.is_empty())
+    .map(str::to_owned)
+    .collect()
+}
+
+fn required_features_from_derivation_show(
+  parsed: &serde_json::Value,
+) -> Vec<String> {
+  let Some(drv) = derivation_from_show(parsed) else {
     return Vec::new();
   };
-  let drv = drv.as_object();
 
   // 1. Top-level `requiredSystemFeatures` list (modern Nix).
-  if let Some(arr) = drv
-    .and_then(|d| d.get("requiredSystemFeatures"))
-    .and_then(|v| v.as_array())
+  if let Some(arr) =
+    drv.get("requiredSystemFeatures").and_then(|v| v.as_array())
   {
     return arr
       .iter()
@@ -738,14 +761,20 @@ async fn read_required_features(drv_path: &str) -> Vec<String> {
       .filter(|s| !s.is_empty())
       .collect();
   }
-  // 2. `env.requiredSystemFeatures`: space-separated string.
+
+  // 2. `env.requiredSystemFeatures`, a space-separated string.
+  if let Some(env_str) =
+    drv.get("requiredSystemFeatures").and_then(|v| v.as_str())
+  {
+    return split_required_features(env_str);
+  }
   if let Some(env_str) = drv
-    .and_then(|d| d.get("env"))
+    .get("env")
     .and_then(|v| v.as_object())
     .and_then(|env| env.get("requiredSystemFeatures"))
     .and_then(|v| v.as_str())
   {
-    return env_str.split_whitespace().map(str::to_owned).collect();
+    return split_required_features(env_str);
   }
   Vec::new()
 }
@@ -1025,5 +1054,47 @@ async fn discover_projects_without_jobsets(
     };
 
     sync_repo_declarative_config(pool, &repo_path, project.id).await;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json::json;
+
+  use super::*;
+
+  #[test]
+  fn required_features_read_wrapped_derivation_show() {
+    let shown = json!({
+      "derivations": {
+        "/nix/store/example.drv": {
+          "env": {
+            "requiredSystemFeatures": "kvm nixos-test uid-range"
+          }
+        }
+      },
+      "version": 3
+    });
+
+    assert_eq!(required_features_from_derivation_show(&shown), vec![
+      "kvm",
+      "nixos-test",
+      "uid-range"
+    ]);
+  }
+
+  #[test]
+  fn required_features_split_legacy_separators() {
+    let shown = json!({
+      "/nix/store/example.drv": {
+        "requiredSystemFeatures": "kvm:nixos-test,uid-range"
+      }
+    });
+
+    assert_eq!(required_features_from_derivation_show(&shown), vec![
+      "kvm",
+      "nixos-test",
+      "uid-range"
+    ]);
   }
 }

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -57,6 +57,19 @@ pub fn scheduler_capacity(
   }
 }
 
+#[must_use]
+pub(crate) fn supports_required_features(
+  required_features: &[String],
+  supported_features: &[String],
+  mandatory_features: &[String],
+) -> bool {
+  required_features
+    .iter()
+    .all(|feature| supported_features.contains(feature))
+    && mandatory_features
+      .iter()
+      .all(|feature| required_features.contains(feature))
+}
 pub struct AgentDispatch<'a> {
   pub timeout:                    Duration,
   pub extra_nix_args:             &'a [String],
@@ -144,19 +157,12 @@ async fn select_and_reserve_agent(
     });
   }
 
-  if !build.required_features.is_empty() {
-    candidates.retain(|(_, snap)| {
-      build
-        .required_features
-        .iter()
-        .all(|f| snap.supported_features.iter().any(|s| s == f))
-    });
-  }
   candidates.retain(|(_, snap)| {
-    snap
-      .mandatory_features
-      .iter()
-      .all(|f| build.required_features.iter().any(|required| required == f))
+    supports_required_features(
+      &build.required_features,
+      &snap.supported_features,
+      &snap.mandatory_features,
+    )
   });
   if candidates.is_empty() {
     return None;
@@ -314,4 +320,41 @@ async fn read_drv_outputs(drv_path: &str) -> Vec<String> {
     .map(|s| s.trim().to_owned())
     .filter(|s| !s.is_empty())
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::supports_required_features;
+
+  fn strs(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+  }
+
+  #[test]
+  fn supported_features_must_cover_build_requirements() {
+    assert!(supports_required_features(
+      &strs(&["kvm", "nixos-test"]),
+      &strs(&["benchmark", "kvm", "nixos-test"]),
+      &[],
+    ));
+    assert!(!supports_required_features(
+      &strs(&["kvm", "nixos-test", "uid-range"]),
+      &strs(&["benchmark", "kvm", "nixos-test"]),
+      &[],
+    ));
+  }
+
+  #[test]
+  fn builder_mandatory_features_must_be_required_by_build() {
+    assert!(supports_required_features(
+      &strs(&["kvm", "nixos-test"]),
+      &strs(&["kvm", "nixos-test"]),
+      &strs(&["kvm"]),
+    ));
+    assert!(!supports_required_features(
+      &strs(&["nixos-test"]),
+      &strs(&["kvm", "nixos-test"]),
+      &strs(&["kvm"]),
+    ));
+  }
 }

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -8,7 +8,7 @@ use circus_common::{
 use sqlx::PgPool;
 use tokio::sync::{Notify, RwLock};
 
-use crate::worker::WorkerPool;
+use crate::{dispatch::supports_required_features, worker::WorkerPool};
 
 /// Reset builds left in `running` from a crashed runner. Builds older
 /// than 5 minutes in `running` are assumed orphaned.
@@ -343,7 +343,6 @@ pub async fn run(
             },
           }
 
-          // A full connected agent still means the system is supported.
           if let Some(timeout) = unsupported_timeout
             && let Some(system) = &build.system
           {
@@ -354,40 +353,55 @@ pub async fn run(
             )
             .await
             {
-              Ok(builders)
-                if builders.is_empty()
-                  && !worker_pool.agent_pool().serves_system(system) =>
-              {
-                let timeout_at = build.created_at + timeout;
-                if chrono::Utc::now() > timeout_at {
-                  tracing::info!(
-                    build_id = %build.id,
-                    system = %system,
-                    timeout = ?timeout,
-                    "Aborting build: no builder available for system type"
-                  );
-
-                  if let Err(e) = repo::builds::start(&pool, build.id).await {
-                    tracing::warn!(build_id = %build.id, "Failed to start unsupported build: {e}");
-                  }
-
-                  if let Err(e) = repo::builds::complete(
-                    &pool,
-                    build.id,
-                    BuildStatus::UnsupportedSystem,
-                    None,
-                    None,
-                    Some("No builder available for system type"),
+              Ok(builders) => {
+                let has_builder = builders.iter().any(|builder| {
+                  supports_required_features(
+                    &build.required_features,
+                    &builder.supported_features,
+                    &builder.mandatory_features,
                   )
-                  .await
-                  {
-                    tracing::warn!(build_id = %build.id, "Failed to complete unsupported build: {e}");
-                  }
+                });
+                let has_agent =
+                  worker_pool.agent_pool().snapshot_all().iter().any(|agent| {
+                    agent.systems.iter().any(|s| s == system)
+                      && supports_required_features(
+                        &build.required_features,
+                        &agent.supported_features,
+                        &agent.mandatory_features,
+                      )
+                  });
+                if !has_builder && !has_agent {
+                  let timeout_at = build.created_at + timeout;
+                  if chrono::Utc::now() > timeout_at {
+                    tracing::info!(
+                      build_id = %build.id,
+                      system = %system,
+                      timeout = ?timeout,
+                      "Aborting build: no builder available for system/features"
+                    );
 
+                    if let Err(e) = repo::builds::start(&pool, build.id).await {
+                      tracing::warn!(build_id = %build.id, "Failed to start unsupported build: {e}");
+                    }
+
+                    if let Err(e) = repo::builds::complete(
+                      &pool,
+                      build.id,
+                      BuildStatus::UnsupportedSystem,
+                      None,
+                      None,
+                      Some("No builder available for system/features"),
+                    )
+                    .await
+                    {
+                      tracing::warn!(build_id = %build.id, "Failed to complete unsupported build: {e}");
+                    }
+
+                    continue;
+                  }
                   continue;
                 }
               },
-              Ok(_) => {}, // Builders available, proceed normally
               Err(e) => {
                 tracing::error!(
                   build_id = %build.id,

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -30,6 +30,8 @@ use tokio::sync::{RwLock, Semaphore};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::dispatch::supports_required_features;
+
 pub type ActiveBuilds = Arc<DashMap<Uuid, CancellationToken>>;
 
 pub struct WorkerPool {
@@ -528,20 +530,18 @@ async fn try_remote_build(
     .ok()?;
 
   for builder in &builders {
-    // Build-side required_features gate. Mirrors the agent path: every
-    // entry must appear in `supported_features`. Skipping leaves the
-    // build pending so a feature-capable builder can pick it up.
-    if !build.required_features.is_empty()
-      && !build
-        .required_features
-        .iter()
-        .all(|f| builder.supported_features.iter().any(|s| s == f))
-    {
+    // Leave the build pending for a builder with the right feature set.
+    if !supports_required_features(
+      &build.required_features,
+      &builder.supported_features,
+      &builder.mandatory_features,
+    ) {
       tracing::debug!(
         build_id = %build.id,
         builder = %builder.name,
         required = ?build.required_features,
         supported = ?builder.supported_features,
+        mandatory = ?builder.mandatory_features,
         "skipping builder: missing required_features"
       );
       continue;


### PR DESCRIPTION
This commit parses `requiredSystemFeatures` from wrapped Nix derivation
output and use one compatibility check for agents, SSH builders, and
unsupported builds.

- Fixes #58