### PR TITLE
agent: batch log forwarding and freeze the outcome at child exit

### DIFF
--- a/crates/agent/src/build.rs
+++ b/crates/agent/src/build.rs
@@ -2,7 +2,8 @@
 //! and stderr through a `LogSink`, and assembles a `BuildResult` at exit.
 use std::{
   collections::{BTreeMap, VecDeque},
-  process::Stdio,
+  io,
+  process::{ExitStatus, Stdio},
   time::{Duration, Instant},
 };
 
@@ -13,6 +14,30 @@ use tokio::{
   time::timeout,
 };
 use tokio_util::sync::CancellationToken;
+
+/// Keep log writes below the 1MiB wire cap without sending one RPC per line.
+const MAX_LOG_BATCH_BYTES: usize = 256 * 1024;
+const MAX_LOG_BATCH_LINES: usize = 4096;
+
+/// Backpressure the child pipe instead of buffering logs without bound.
+const LOG_CHANNEL_CAPACITY: usize = 1024;
+
+#[derive(Clone, Copy)]
+pub struct Tunables {
+  pub drain_grace:   Duration,
+  pub write_timeout: Duration,
+  pub reap_timeout:  Duration,
+}
+
+impl Default for Tunables {
+  fn default() -> Self {
+    Self {
+      drain_grace:   Duration::from_mins(5),
+      write_timeout: Duration::from_mins(1),
+      reap_timeout:  Duration::from_secs(30),
+    }
+  }
+}
 
 /// Per-build options handed down from the runner via the capnp schema.
 pub struct BuildOptions<'a> {
@@ -46,12 +71,11 @@ pub struct LocalResult {
 /// Spawn the child, stream its log through `log_sink`, and wait for it.
 ///
 /// `log_sink` is a Cap'n Proto client capability the runner created and
-/// passed in via `Builder.assign`. We call `write(chunk)` for each log
-/// line and `close()` at the end. Failures on the sink are logged at the
-/// agent and ignored otherwise; the build still completes.
+/// passed in via `Builder.assign`. We coalesce buffered log lines into
+/// `write(chunk)` batches and call `close()` at the end.
 ///
 /// `cancel` is signalled by [`crate::session::BuilderImpl::abort`]. When
-/// it fires, the child is SIGTERM'd and the function returns an aborted
+/// it fires, the child is killed and the function returns an aborted
 /// outcome.
 ///
 /// # Errors
@@ -68,6 +92,11 @@ pub async fn run(
     clippy::future_not_send,
     reason = "capnp futures are not Send; agent uses a single-threaded runtime"
   )]
+  let cmd = build_command(&opts);
+  run_command(cmd, &opts, Tunables::default(), log_sink, cancel).await
+}
+
+fn build_command(opts: &BuildOptions<'_>) -> Command {
   let mut args: Vec<String> = vec![
     "--realise".into(),
     "--log-format".into(),
@@ -93,7 +122,46 @@ pub async fn run(
     .stdout(Stdio::piped())
     .stderr(Stdio::piped())
     .kill_on_drop(true);
+  cmd
+}
 
+enum Event {
+  Line(Option<Result<String, String>>),
+  ChildExited(io::Result<ExitStatus>),
+  SilentTimeout,
+  DeadlineTimeout,
+  Cancelled,
+}
+
+/// Preserve a real child exit when it races log or deadline handling.
+fn observe_exit(
+  child: &mut tokio::process::Child,
+  child_status: &mut Option<ExitStatus>,
+  drain_deadline: &mut Option<Instant>,
+  grace: Duration,
+) -> bool {
+  if child_status.is_none()
+    && let Ok(Some(s)) = child.try_wait()
+  {
+    *drain_deadline = Some(Instant::now() + grace);
+    *child_status = Some(s);
+  }
+  child_status.is_some()
+}
+
+#[expect(
+  clippy::too_many_lines,
+  clippy::future_not_send,
+  reason = "one supervision loop with !Send capnp futures on a \
+            single-threaded runtime"
+)]
+async fn run_command(
+  mut cmd: Command,
+  opts: &BuildOptions<'_>,
+  tun: Tunables,
+  log_sink: log_sink::Client,
+  cancel: CancellationToken,
+) -> color_eyre::Result<LocalResult> {
   let started = Instant::now();
   let mut child = cmd.spawn()?;
   let stdout = child
@@ -109,7 +177,7 @@ pub async fn run(
   // stream does not cause lines buffered in the other to be discarded.
   // Both tasks forward lines (or IO errors) through a shared channel.
   let (line_tx, mut line_rx) =
-    tokio::sync::mpsc::unbounded_channel::<Result<String, String>>();
+    tokio::sync::mpsc::channel::<Result<String, String>>(LOG_CHANNEL_CAPACITY);
   {
     let tx = line_tx.clone();
     let mut reader = BufReader::new(stdout).lines();
@@ -117,13 +185,13 @@ pub async fn run(
       loop {
         match reader.next_line().await {
           Ok(Some(line)) => {
-            if tx.send(Ok(line)).is_err() {
+            if tx.send(Ok(line)).await.is_err() {
               break;
             }
           },
           Ok(None) => break,
           Err(e) => {
-            let _ = tx.send(Err(format!("stdout read: {e}")));
+            let _ = tx.send(Err(format!("stdout read: {e}"))).await;
             break;
           },
         }
@@ -137,13 +205,13 @@ pub async fn run(
       loop {
         match reader.next_line().await {
           Ok(Some(line)) => {
-            if tx.send(Ok(line)).is_err() {
+            if tx.send(Ok(line)).await.is_err() {
               break;
             }
           },
           Ok(None) => break,
           Err(e) => {
-            let _ = tx.send(Err(format!("stderr read: {e}")));
+            let _ = tx.send(Err(format!("stderr read: {e}"))).await;
             break;
           },
         }
@@ -156,8 +224,13 @@ pub async fn run(
   let mut bytes_sent: u64 = 0;
   let mut error_message = String::new();
   let mut log_size_exceeded = false;
+  let mut sink_failed = false;
+  let mut log_truncated = false;
   let mut aborted = false;
   let mut timed_out = false;
+  let mut killed = false;
+  let mut child_status = Option::<ExitStatus>::None;
+  let mut drain_deadline = Option::<Instant>::None;
 
   let overall_deadline = if opts.build_timeout.is_zero() {
     None
@@ -168,105 +241,303 @@ pub async fn run(
   let mut recent_msgs = VecDeque::<String>::with_capacity(32);
 
   loop {
-    let read_timeout = remaining_silent(&opts.max_silent_time, last_output);
-    let build_deadline_timeout = overall_deadline
+    let pre_exit = child_status.is_none();
+    let read_timeout = if pre_exit {
+      remaining_silent(&opts.max_silent_time, last_output)
+    } else {
+      None
+    };
+    let phase_deadline = if pre_exit {
+      overall_deadline
+    } else {
+      drain_deadline
+    };
+    let deadline_timeout = phase_deadline
       .map(|deadline| deadline.saturating_duration_since(Instant::now()))
       .map(|remaining| remaining.max(Duration::from_millis(1)));
-    let msg: Option<Result<String, String>> = tokio::select! {
-      r = line_rx.recv() => r,
-      () = sleep_opt(read_timeout) => {
+
+    let ev = tokio::select! {
+      r = line_rx.recv() => Event::Line(r),
+      s = child.wait(), if pre_exit => Event::ChildExited(s),
+      () = sleep_opt(read_timeout) => Event::SilentTimeout,
+      () = sleep_opt(deadline_timeout) => Event::DeadlineTimeout,
+      () = cancel.cancelled() => Event::Cancelled,
+    };
+
+    let first = match ev {
+      Event::ChildExited(s) => {
+        let status = s?;
+        if child_status.is_none() {
+          drain_deadline = Some(Instant::now() + tun.drain_grace);
+          child_status = Some(status);
+        }
+        continue;
+      },
+      Event::SilentTimeout => {
+        if observe_exit(
+          &mut child,
+          &mut child_status,
+          &mut drain_deadline,
+          tun.drain_grace,
+        ) {
+          continue;
+        }
         error_message = "max-silent-time exceeded".into();
         let _ = child.start_kill();
+        killed = true;
         break;
-      }
-      () = sleep_opt(build_deadline_timeout) => {
-        timed_out = true;
-        error_message = "build-timeout exceeded".into();
-        let _ = child.start_kill();
+      },
+      Event::DeadlineTimeout => {
+        if pre_exit
+          && observe_exit(
+            &mut child,
+            &mut child_status,
+            &mut drain_deadline,
+            tun.drain_grace,
+          )
+        {
+          continue;
+        }
+        if child_status.is_none() {
+          timed_out = true;
+          error_message = "build-timeout exceeded".into();
+          let _ = child.start_kill();
+          killed = true;
+        } else {
+          log_truncated = true;
+        }
         break;
-      }
-      () = cancel.cancelled() => {
+      },
+      Event::Cancelled => {
+        if observe_exit(
+          &mut child,
+          &mut child_status,
+          &mut drain_deadline,
+          tun.drain_grace,
+        ) {
+          log_truncated = true;
+          break;
+        }
         aborted = true;
         error_message = "aborted by runner".into();
         let _ = child.start_kill();
+        killed = true;
         break;
-      }
-    };
-
-    let line = match msg {
-      None => break,
-      Some(Err(e)) => {
+      },
+      Event::Line(None) => break,
+      Event::Line(Some(Err(e))) => {
         error_message = e;
         break;
       },
-      Some(Ok(l)) => l,
+      Event::Line(Some(Ok(l))) => l,
     };
     last_output = Instant::now();
-    if let Some(nix_log::LogLine::Message { text, .. }) =
-      nix_log::parse_line(&line)
-    {
-      if recent_msgs.len() == 32 {
-        recent_msgs.pop_front();
+
+    let mut batch = Vec::<u8>::new();
+    let mut batch_lines = 0usize;
+    let mut pending_read_err = Option::<String>::None;
+    let mut next = Some(first);
+    while let Some(line) = next.take() {
+      if let Some(nix_log::LogLine::Message { text, .. }) =
+        nix_log::parse_line(&line)
+      {
+        if recent_msgs.len() == 32 {
+          recent_msgs.pop_front();
+        }
+        recent_msgs.push_back(text);
       }
-      recent_msgs.push_back(text);
+
+      if !log_size_exceeded && !log_truncated && !sink_failed {
+        if bytes_sent.saturating_add(line.len() as u64 + 1) > opts.max_log_size
+        {
+          if child_status.is_none() {
+            log_size_exceeded = true;
+            error_message = "max-log-size exceeded".into();
+            let _ = child.start_kill();
+            killed = true;
+          } else {
+            log_truncated = true;
+          }
+        } else {
+          bytes_sent = bytes_sent.saturating_add(line.len() as u64 + 1);
+          if !batch.is_empty() {
+            batch.push(b'\n');
+          }
+          batch.extend_from_slice(line.as_bytes());
+          batch_lines += 1;
+        }
+      }
+
+      if batch.len() >= MAX_LOG_BATCH_BYTES
+        || batch_lines >= MAX_LOG_BATCH_LINES
+      {
+        break;
+      }
+      match line_rx.try_recv() {
+        Ok(Ok(l)) => next = Some(l),
+        Ok(Err(e)) => {
+          pending_read_err = Some(e);
+          break;
+        },
+        Err(_) => break,
+      }
     }
 
-    if log_size_exceeded {
-      continue;
-    }
-    if bytes_sent.saturating_add(line.len() as u64) > opts.max_log_size {
-      log_size_exceeded = true;
-      error_message = "max-log-size exceeded".into();
-      let _ = child.start_kill();
-      continue;
-    }
-    bytes_sent = bytes_sent.saturating_add(line.len() as u64 + 1);
-    if let Err(e) = forward_chunk(&log_sink, line.as_bytes()).await {
-      tracing::warn!(error = ?e, "log sink write failed; killing child");
-      log_size_exceeded = true;
-      let _ = child.start_kill();
+    if !batch.is_empty() {
+      // Bound each write so a wedged sink cannot stall every deadline
+      let write_cap = phase_deadline
+        .map_or(tun.write_timeout, |deadline| {
+          deadline
+            .saturating_duration_since(Instant::now())
+            .min(tun.write_timeout)
+        })
+        .max(Duration::from_millis(1));
+      let write_result = tokio::select! {
+        r = timeout(write_cap, forward_chunk(&log_sink, &batch)) => match r {
+          Ok(Ok(())) => Ok(()),
+          Ok(Err(e)) => Err(format!("log sink write failed: {e}")),
+          Err(_) => Err("log sink write timed out".into()),
+        },
+        () = cancel.cancelled(), if child_status.is_none() => {
+          if observe_exit(
+            &mut child,
+            &mut child_status,
+            &mut drain_deadline,
+            tun.drain_grace,
+          ) {
+            log_truncated = true;
+            break;
+          }
+          aborted = true;
+          error_message = "aborted by runner".into();
+          let _ = child.start_kill();
+          killed = true;
+          break;
+        }
+      };
+      if let Err(e) = write_result {
+        if observe_exit(
+          &mut child,
+          &mut child_status,
+          &mut drain_deadline,
+          tun.drain_grace,
+        ) {
+          log_truncated = true;
+          break;
+        }
+        tracing::warn!(error = %e, "log sink write failed; killing child");
+        sink_failed = true;
+        let _ = child.start_kill();
+        killed = true;
+      }
     }
 
-    if let Some(deadline) = overall_deadline
+    if let Some(e) = pending_read_err {
+      error_message = e;
+      break;
+    }
+    let deadline = if child_status.is_none() {
+      overall_deadline
+    } else {
+      drain_deadline
+    };
+    if let Some(deadline) = deadline
       && Instant::now() >= deadline
     {
-      timed_out = true;
-      error_message = "build-timeout exceeded".into();
-      let _ = child.start_kill();
+      let was_pre_exit = child_status.is_none();
+      if was_pre_exit
+        && observe_exit(
+          &mut child,
+          &mut child_status,
+          &mut drain_deadline,
+          tun.drain_grace,
+        )
+        && drain_deadline.is_some_and(|d| Instant::now() < d)
+      {
+        continue;
+      }
+      if child_status.is_none() {
+        timed_out = true;
+        error_message = "build-timeout exceeded".into();
+        let _ = child.start_kill();
+        killed = true;
+      } else {
+        log_truncated = true;
+      }
       break;
     }
   }
 
-  let status = match overall_deadline {
-    Some(deadline) => {
-      if let Ok(s) = timeout(
-        deadline.saturating_duration_since(Instant::now()),
-        child.wait(),
-      )
-      .await
-      {
-        s?
+  let status = match child_status {
+    Some(s) => Some(s),
+    None if killed => {
+      if let Ok(s) = timeout(tun.reap_timeout, child.wait()).await {
+        Some(s?)
       } else {
         let _ = child.kill().await;
-        let _ = close_log(&log_sink).await;
-        return Ok(LocalResult {
-          outcome:        circus_proto::BuildOutcome::TimedOut,
-          exit_code:      -1,
-          build_time_ms:  started.elapsed().as_millis() as u64,
-          upload_time_ms: 0,
-          outputs:        Vec::new(),
-          error_message:  "build-timeout exceeded".into(),
-        });
+        None
       }
     },
-    None => child.wait().await?,
+    // EOF with a live child still waits on the build deadline.
+    None => {
+      match overall_deadline {
+        Some(deadline) => {
+          if let Ok(s) = timeout(
+            deadline.saturating_duration_since(Instant::now()),
+            child.wait(),
+          )
+          .await
+          {
+            Some(s?)
+          } else {
+            timed_out = true;
+            error_message = "build-timeout exceeded".into();
+            let _ = child.kill().await;
+            None
+          }
+        },
+        None => Some(child.wait().await?),
+      }
+    },
   };
 
-  let _ = close_log(&log_sink).await;
+  if log_truncated {
+    let _ = timeout(
+      tun.write_timeout,
+      forward_chunk(&log_sink, b"[circus-agent] log truncated"),
+    )
+    .await;
+    if !error_message.is_empty() {
+      error_message.push('\n');
+    }
+    error_message
+      .push_str("log drain timed out after child exit; log truncated");
+  }
+  let _ = timeout(tun.write_timeout, close_log(&log_sink)).await;
+
+  let Some(status) = status else {
+    return Ok(LocalResult {
+      outcome: if timed_out {
+        circus_proto::BuildOutcome::TimedOut
+      } else if aborted {
+        circus_proto::BuildOutcome::Aborted
+      } else {
+        circus_proto::BuildOutcome::BuildFailure
+      },
+      exit_code: -1,
+      build_time_ms: started.elapsed().as_millis() as u64,
+      upload_time_ms: 0,
+      outputs: Vec::new(),
+      error_message,
+    });
+  };
 
   let exit_code = status.code().unwrap_or(-1);
-  let success =
-    status.success() && !log_size_exceeded && !aborted && !timed_out;
+  let success = status.success()
+    && !log_size_exceeded
+    && !sink_failed
+    && !aborted
+    && !timed_out;
   if !success && error_message.is_empty() {
     error_message = summarize_failure(&recent_msgs);
   }
@@ -426,4 +697,200 @@ async fn close_log(sink: &log_sink::Client) -> Result<(), capnp::Error> {
   )]
   sink.close_request().send().promise.await?;
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{cell::RefCell, future::Future, rc::Rc};
+
+  use capnp::capability::Promise;
+  use circus_proto::log_sink;
+
+  use super::*;
+
+  struct TestSink {
+    chunks:     Rc<RefCell<Vec<Vec<u8>>>>,
+    hang_after: Option<usize>,
+  }
+
+  #[allow(refining_impl_trait_internal)]
+  impl log_sink::Server for TestSink {
+    fn write(
+      self: capnp::capability::Rc<Self>,
+      params: log_sink::WriteParams,
+      _results: log_sink::WriteResults,
+    ) -> Promise<(), capnp::Error> {
+      let chunks = Rc::clone(&self.chunks);
+      let hang_after = self.hang_after;
+      Promise::from_future(async move {
+        let n = {
+          let mut g = chunks.borrow_mut();
+          g.push(params.get()?.get_chunk()?.to_vec());
+          g.len()
+        };
+        if hang_after.is_some_and(|h| n > h) {
+          std::future::pending::<()>().await;
+        }
+        Ok(())
+      })
+    }
+
+    fn close(
+      self: capnp::capability::Rc<Self>,
+      _params: log_sink::CloseParams,
+      _results: log_sink::CloseResults,
+    ) -> Promise<(), capnp::Error> {
+      Promise::ok(())
+    }
+  }
+
+  struct Harness {
+    chunks: Rc<RefCell<Vec<Vec<u8>>>>,
+    sink:   log_sink::Client,
+  }
+
+  fn harness(hang_after: Option<usize>) -> Harness {
+    let chunks = Rc::new(RefCell::new(Vec::new()));
+    let sink = capnp_rpc::new_client(TestSink {
+      chunks: Rc::clone(&chunks),
+      hang_after,
+    });
+    Harness { chunks, sink }
+  }
+
+  fn sh(script: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd
+      .args(["-c", script])
+      .stdout(Stdio::piped())
+      .stderr(Stdio::piped())
+      .kill_on_drop(true);
+    cmd
+  }
+
+  fn opts(max_log_size: u64, build_timeout: Duration) -> BuildOptions<'static> {
+    BuildOptions {
+      drv_path: "/nix/store/00000000000000000000000000000000-test.drv",
+      max_log_size,
+      max_silent_time: Duration::ZERO,
+      build_timeout,
+      extra_args: Vec::new(),
+      cache_substituter: String::new(),
+      cache_public_key: String::new(),
+    }
+  }
+
+  fn fast_tunables() -> Tunables {
+    Tunables {
+      drain_grace:   Duration::from_secs(10),
+      write_timeout: Duration::from_millis(200),
+      reap_timeout:  Duration::from_secs(5),
+    }
+  }
+
+  fn run_local<F: Future>(f: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .expect("runtime");
+    let local = tokio::task::LocalSet::new();
+    rt.block_on(local.run_until(f))
+  }
+
+  #[test]
+  fn chatty_log_is_batched_and_intact() {
+    run_local(async {
+      let h = harness(None);
+      let result = run_command(
+        sh("seq 20000"),
+        &opts(u64::MAX, Duration::from_mins(1)),
+        fast_tunables(),
+        h.sink,
+        CancellationToken::new(),
+      )
+      .await
+      .expect("run_command");
+
+      assert_eq!(result.outcome, circus_proto::BuildOutcome::Success);
+      assert_eq!(result.exit_code, 0);
+      let chunks = h.chunks.borrow();
+      // The exact batch count depends on Tokio's cooperative scheduling.
+      assert!(
+        chunks.len() < 1000,
+        "expected batching, got {}",
+        chunks.len()
+      );
+      let joined = chunks
+        .iter()
+        .map(|c| String::from_utf8(c.clone()).expect("utf8"))
+        .collect::<Vec<_>>()
+        .join("\n");
+      let want = (1..=20000).map(|i| i.to_string()).collect::<Vec<_>>();
+      assert_eq!(joined.lines().collect::<Vec<_>>(), want);
+    });
+  }
+
+  #[test]
+  fn finished_build_survives_wedged_sink() {
+    run_local(async {
+      // This exits before the first write wedges.
+      let h = harness(Some(0));
+      let result = run_command(
+        sh("seq 100"),
+        &opts(u64::MAX, Duration::from_mins(1)),
+        fast_tunables(),
+        h.sink,
+        CancellationToken::new(),
+      )
+      .await
+      .expect("run_command");
+
+      assert_eq!(result.outcome, circus_proto::BuildOutcome::Success);
+      assert_eq!(result.exit_code, 0);
+      assert!(
+        result.error_message.contains("log truncated"),
+        "missing truncation note: {:?}",
+        result.error_message
+      );
+    });
+  }
+
+  #[test]
+  fn build_timeout_kills_hung_child() {
+    run_local(async {
+      let h = harness(None);
+      let result = run_command(
+        sh("sleep 30"),
+        &opts(u64::MAX, Duration::from_millis(300)),
+        fast_tunables(),
+        h.sink,
+        CancellationToken::new(),
+      )
+      .await
+      .expect("run_command");
+
+      assert_eq!(result.outcome, circus_proto::BuildOutcome::TimedOut);
+      assert_eq!(result.exit_code, -1);
+      assert!(result.error_message.contains("build-timeout"));
+    });
+  }
+
+  #[test]
+  fn max_log_size_fails_running_build() {
+    run_local(async {
+      let h = harness(None);
+      let result = run_command(
+        sh("seq 10000; sleep 30"),
+        &opts(64, Duration::from_mins(1)),
+        fast_tunables(),
+        h.sink,
+        CancellationToken::new(),
+      )
+      .await
+      .expect("run_command");
+
+      assert_eq!(result.outcome, circus_proto::BuildOutcome::BuildFailure);
+      assert!(result.error_message.contains("max-log-size exceeded"));
+    });
+  }
 }

--- a/crates/agent/src/build.rs
+++ b/crates/agent/src/build.rs
@@ -259,7 +259,7 @@ async fn run_command(
     let ev = tokio::select! {
       r = line_rx.recv() => Event::Line(r),
       s = child.wait(), if pre_exit => Event::ChildExited(s),
-      () = sleep_opt(read_timeout) => Event::SilentTimeout,
+      () = sleep_opt(read_timeout), if pre_exit => Event::SilentTimeout,
       () = sleep_opt(deadline_timeout) => Event::DeadlineTimeout,
       () = cancel.cancelled() => Event::Cancelled,
     };

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -168,6 +168,10 @@ pub struct QueueRunnerConfig {
   pub build_timeout: u64,
   pub work_dir:      PathBuf,
 
+  /// Agent build silence timeout in seconds. `0` disables it.
+  #[serde(default)]
+  pub max_silent_time: u64,
+
   /// When true, abort on the first runner loop error instead of logging and
   /// retrying.
   #[serde(default)]
@@ -900,6 +904,7 @@ impl Default for QueueRunnerConfig {
       workers:              4,
       poll_interval:        5,
       build_timeout:        3600,
+      max_silent_time:      0,
       work_dir:             PathBuf::from("/tmp/circus-queue-runner"),
       strict_errors:        false,
       failed_paths_cache:   true,
@@ -966,6 +971,7 @@ pub enum BuilderSchedulingStrategy {
 pub struct HotConfig {
   pub poll_interval:        std::time::Duration,
   pub build_timeout:        std::time::Duration,
+  pub max_silent_time:      std::time::Duration,
   pub notifications_config: NotificationsConfig,
   pub failed_paths_ttl:     u64,
   pub scheduling_strategy:  BuilderSchedulingStrategy,
@@ -984,6 +990,9 @@ impl HotConfig {
       ),
       build_timeout:        std::time::Duration::from_secs(
         config.queue_runner.build_timeout,
+      ),
+      max_silent_time:      std::time::Duration::from_secs(
+        config.queue_runner.max_silent_time,
       ),
       notifications_config: config.notifications.clone(),
       failed_paths_ttl:     config.queue_runner.failed_paths_ttl,

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -72,6 +72,7 @@ pub(crate) fn supports_required_features(
 }
 pub struct AgentDispatch<'a> {
   pub timeout:                    Duration,
+  pub max_silent_time:            Duration,
   pub extra_nix_args:             &'a [String],
   pub cache_upload_enabled_s3:    bool,
   pub cache_upload_compression:   &'a str,
@@ -243,7 +244,11 @@ pub async fn run_on_agent(
     build_id: build.id,
     drv_path: drv_path.to_owned(),
     max_log_size: 100 * 1024 * 1024,
-    max_silent_time: 0,
+    max_silent_time: opts
+      .max_silent_time
+      .as_secs()
+      .try_into()
+      .unwrap_or(u32::MAX),
     build_timeout: opts.timeout.as_secs().try_into().unwrap_or(u32::MAX),
     extra_args: opts.extra_nix_args.to_vec(),
     log_path: live_log_path.to_path_buf(),

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -166,6 +166,7 @@ impl WorkerPool {
       let result = async {
         let (
           timeout,
+          max_silent_time,
           notifications_config,
           scheduling_strategy,
           psi_threshold,
@@ -175,6 +176,7 @@ impl WorkerPool {
           let hot = hot_config.read().await;
           (
             hot.build_timeout,
+            hot.max_silent_time,
             hot.notifications_config.clone(),
             hot.scheduling_strategy.clone(),
             hot.psi_threshold,
@@ -189,6 +191,7 @@ impl WorkerPool {
           &work_dir,
           &nix_store_dir,
           timeout,
+          max_silent_time,
           &log_config,
           &gc_config,
           &notifications_config,
@@ -751,6 +754,7 @@ async fn run_build(
   work_dir: &std::path::Path,
   nix_store_dir: &std::path::Path,
   timeout: Duration,
+  max_silent_time: Duration,
   log_config: &LogConfig,
   gc_config: &GcConfig,
   notifications_config: &NotificationsConfig,
@@ -867,6 +871,7 @@ async fn run_build(
     crate::dispatch::ExecutionReservation::Agent { meta, snap, slot } => {
       let opts = crate::dispatch::AgentDispatch {
         timeout,
+        max_silent_time,
         extra_nix_args: &build_extra_nix_args,
         cache_upload_enabled_s3,
         cache_upload_compression: &cache_upload_config.compression,

--- a/crates/queue-runner/tests/runner_tests.rs
+++ b/crates/queue-runner/tests/runner_tests.rs
@@ -86,6 +86,7 @@ async fn test_worker_pool_drain_stops_dispatch() {
     circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
+      max_silent_time:      std::time::Duration::ZERO,
       notifications_config: circus_common::config::NotificationsConfig::default(
       ),
       failed_paths_ttl:     0,
@@ -210,6 +211,7 @@ async fn test_worker_pool_active_builds_cancel() {
     circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
+      max_silent_time:      std::time::Duration::ZERO,
       notifications_config: circus_common::config::NotificationsConfig::default(
       ),
       failed_paths_ttl:     0,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -191,6 +191,7 @@ development; `circus.toml` remains the practical reference.
 | `queue_runner`       | `workers`                    | `4`                                                 | Concurrent build slots                           |
 | `queue_runner`       | `poll_interval`              | `5`                                                 | Seconds between build queue polls                |
 | `queue_runner`       | `build_timeout`              | `3600`                                              | Per-build timeout (seconds)                      |
+| `queue_runner`       | `max_silent_time`            | `0`                                                 | Fail agent builds silent for `N` seconds         |
 | `queue_runner`       | `work_dir`                   | `/tmp/circus-queue-runner`                          | Working directory for builds                     |
 | `queue_runner`       | `strict_errors`              | `false`                                             | Abort on first runner loop error                 |
 | `queue_runner`       | `failed_paths_cache`         | `true`                                              | Cache failed derivation paths                    |


### PR DESCRIPTION
Batch log lines before sending them over RPC and treat child exit as
the final build outcome.

Also forward `queue_runner.max_silent_time` through agent dispatch. The default
of 0 keeps the previous no-silence-timeout behavior.