### PR TITLE
nix: drop perl from the agent build and token rendering

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,14 +44,26 @@
         buildInputs = with pkgs; [openssl];
       };
 
+      # agent doesn't need openssl
+      agentArgs = commonArgs // {buildInputs = [];};
+
       cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+      agentArtifacts = craneLib.buildDepsOnly (agentArgs
+        // {
+          pname = "circus-agent";
+          cargoExtraArgs = "--package circus-agent";
+        });
+
       callCratePackage = path: pkgs.callPackage path {inherit craneLib commonArgs cargoArtifacts;};
     in {
       demo-vm = pkgs.callPackage ./nix/demo-vm.nix {inherit self;};
 
       # circus Packages
       circus-admin = callCratePackage ./nix/packages/circus-admin.nix;
-      circus-agent = callCratePackage ./nix/packages/circus-agent.nix;
+      circus-agent = (callCratePackage ./nix/packages/circus-agent.nix).override {
+        commonArgs = agentArgs;
+        cargoArtifacts = agentArtifacts;
+      };
       circus-evaluator = callCratePackage ./nix/packages/circus-evaluator.nix;
       circus-migrate-cli = callCratePackage ./nix/packages/circus-migrate-cli.nix;
       circus-queue-runner = callCratePackage ./nix/packages/circus-queue-runner.nix;

--- a/nix/modules/circus-agent.nix
+++ b/nix/modules/circus-agent.nix
@@ -143,11 +143,10 @@ in {
         ExecStartPre = pkgs.writeShellScript "circus-agent-render-config" ''
           set -eu
           token="$(cat "$CREDENTIALS_DIRECTORY/auth_token")"
-          token_json="$(printf '%s' "$token" | ${pkgs.jq}/bin/jq -Rs .)"
-          install -m 0600 ${configFile} "$RUNTIME_DIRECTORY/circus-agent.toml"
-          TOKEN_JSON="$token_json" ${pkgs.perl}/bin/perl -0pi -e \
-            's/"\@CIRCUS_AGENT_AUTH_TOKEN\@"/$ENV{TOKEN_JSON}/g' \
-            "$RUNTIME_DIRECTORY/circus-agent.toml"
+          install -m 0600 /dev/null "$RUNTIME_DIRECTORY/circus-agent.toml"
+          ${pkgs.jq}/bin/jq -Rrs --arg tok "$token" \
+            '($tok | @json) as $j | gsub("\"@CIRCUS_AGENT_AUTH_TOKEN@\""; $j)' \
+            ${configFile} > "$RUNTIME_DIRECTORY/circus-agent.toml"
         '';
         RuntimeDirectory = "circus-agent";
         RuntimeDirectoryMode = "0700";


### PR DESCRIPTION
I don't want to build perl from source on my powerpc machines