### PR TITLE
Add push-forward control and centralize role-based authorization

### DIFF
--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -248,6 +248,58 @@ pub async fn complete(
   .ok_or_else(|| CiError::NotFound(format!("Build {id} not found")))
 }
 
+/// List pending builds in scheduler order: highest priority first, then
+/// oldest first. Mirrors the ordering the queue runner uses (minus the
+/// share-deficit factor, which depends on live worker counts) so the
+/// dashboard queue page can show builds in the order they will be picked.
+///
+/// # Errors
+///
+/// Returns error if database query fails.
+pub async fn list_pending_in_scheduler_order(
+  pool: &PgPool,
+  limit: i64,
+  offset: i64,
+) -> Result<Vec<Build>> {
+  sqlx::query_as::<_, Build>(
+    "SELECT * FROM builds WHERE status = 'pending' ORDER BY priority DESC, \
+     created_at ASC LIMIT $1 OFFSET $2",
+  )
+  .bind(limit)
+  .bind(offset)
+  .fetch_all(pool)
+  .await
+  .map_err(CiError::Database)
+}
+
+/// Atomically increment a pending build's priority by `delta`. The row is
+/// only updated if the build is still in the pending state, so a build
+/// the scheduler has already claimed is left alone.
+///
+/// # Returns
+///
+/// The updated `Build` row, or `None` if the build does not exist or is
+/// no longer pending.
+///
+/// # Errors
+///
+/// Returns error if database update fails.
+pub async fn bump_priority(
+  pool: &PgPool,
+  id: Uuid,
+  delta: i32,
+) -> Result<Option<Build>> {
+  sqlx::query_as::<_, Build>(
+    "UPDATE builds SET priority = priority + $2 WHERE id = $1 AND status = \
+     'pending' RETURNING *",
+  )
+  .bind(id)
+  .bind(delta)
+  .fetch_optional(pool)
+  .await
+  .map_err(CiError::Database)
+}
+
 /// List recent builds ordered by creation time.
 ///
 /// # Errors

--- a/crates/server/src/auth_middleware.rs
+++ b/crates/server/src/auth_middleware.rs
@@ -189,51 +189,6 @@ impl FromRequestParts<AppState> for RequireAdmin {
   }
 }
 
-/// Extractor that requires one of the specified roles (admin always passes).
-/// Use as: `RequireRoles::check(&extensions, &["cancel-build",
-/// "restart-jobs"])`
-pub struct RequireRoles;
-
-impl RequireRoles {
-  /// Check if the session has one of the allowed roles. Admin always passes.
-  ///
-  /// # Errors
-  ///
-  /// Returns unauthorized or forbidden status if authentication fails or role
-  /// is insufficient.
-  pub fn check(
-    extensions: &axum::http::Extensions,
-    allowed: &[&str],
-  ) -> Result<ApiKey, StatusCode> {
-    // Check for user first
-    if let Some(user) = extensions.get::<User>()
-      && (user.role == "admin" || allowed.contains(&user.role.as_str()))
-    {
-      return Ok(ApiKey {
-        id:           user.id,
-        name:         user.username.clone(),
-        key_hash:     String::new(),
-        role:         user.role.clone(),
-        created_at:   user.created_at,
-        last_used_at: user.last_login_at,
-        user_id:      Some(user.id),
-      });
-    }
-
-    // Fall back to API key
-    let key = extensions
-      .get::<ApiKey>()
-      .cloned()
-      .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    if key.role == "admin" || allowed.contains(&key.role.as_str()) {
-      Ok(key)
-    } else {
-      Err(StatusCode::FORBIDDEN)
-    }
-  }
-}
-
 /// Session extraction middleware for dashboard routes.
 /// Reads `circus_user_session` or `circus_session` cookie, or Bearer token (API
 /// key), and inserts User/ApiKey into extensions if valid.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod audit;
 pub mod auth_middleware;
 pub mod error;
+pub mod permissions;
 pub mod routes;
 pub mod state;

--- a/crates/server/src/permissions.rs
+++ b/crates/server/src/permissions.rs
@@ -1,0 +1,131 @@
+//! Capability-based authorisation. Every gateable action in the server
+//! maps to one [`Permission`] variant, and every check - API handler,
+//! dashboard mutation, template gating - flows through this module. The
+//! role string a permission resolves to (the value stored in
+//! `User.role` and `ApiKey.role`) lives only in [`Permission::role_str`],
+//! so a typo in a role string is a compile error and the server-side
+//! enforcement and the UI's button-gating cannot drift apart.
+
+use axum::http::{Extensions, StatusCode};
+use circus_common::models::{ApiKey, User};
+
+use crate::error::ApiError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Permission {
+  Admin,
+  BumpToFront,
+  CancelBuild,
+  RestartJobs,
+  CreateProjects,
+  EvalJobset,
+}
+
+impl Permission {
+  /// Role string stored on `User.role` / `ApiKey.role` for this
+  /// capability. Anyone whose session role matches this string (or who
+  /// holds the `admin` role, which satisfies every check) may exercise
+  /// the capability.
+  #[must_use]
+  pub const fn role_str(self) -> &'static str {
+    match self {
+      Self::Admin => "admin",
+      Self::BumpToFront => "bump-to-front",
+      Self::CancelBuild => "cancel-build",
+      Self::RestartJobs => "restart-jobs",
+      Self::CreateProjects => "create-projects",
+      Self::EvalJobset => "eval-jobset",
+    }
+  }
+}
+
+fn session_role(extensions: &Extensions) -> Option<&str> {
+  if let Some(user) = extensions.get::<User>() {
+    return Some(user.role.as_str());
+  }
+  extensions.get::<ApiKey>().map(|k| k.role.as_str())
+}
+
+/// Whether the authenticated session may exercise `permission`. Admin
+/// sessions satisfy every check; anonymous sessions satisfy none.
+#[must_use]
+pub fn check(extensions: &Extensions, permission: Permission) -> bool {
+  let Some(role) = session_role(extensions) else {
+    return false;
+  };
+  role == Permission::Admin.role_str() || role == permission.role_str()
+}
+
+/// Reject the request with `UNAUTHORIZED` if the session is anonymous,
+/// or `FORBIDDEN` if it is authenticated but lacks `permission`.
+///
+/// # Errors
+///
+/// Returns `UNAUTHORIZED` or `FORBIDDEN` per the rules above.
+pub fn require(
+  extensions: &Extensions,
+  permission: Permission,
+) -> Result<(), StatusCode> {
+  let Some(role) = session_role(extensions) else {
+    return Err(StatusCode::UNAUTHORIZED);
+  };
+  if role == Permission::Admin.role_str() || role == permission.role_str() {
+    Ok(())
+  } else {
+    Err(StatusCode::FORBIDDEN)
+  }
+}
+
+/// [`require`] wrapped in the JSON API's error shape so callers in
+/// `routes/*` can `?` it directly from a handler returning
+/// `Result<_, ApiError>`.
+///
+/// # Errors
+///
+/// See [`require`].
+pub fn require_api(
+  extensions: &Extensions,
+  permission: Permission,
+) -> Result<(), ApiError> {
+  require(extensions, permission).map_err(|s| {
+    ApiError(if s == StatusCode::FORBIDDEN {
+      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
+    } else {
+      circus_common::CiError::Unauthorized(
+        "Authentication required".to_string(),
+      )
+    })
+  })
+}
+
+/// Snapshot of every dashboard-visible capability for the current
+/// session. Computed once per request and threaded into the template so
+/// each page carries a single `permissions` field instead of accumulating
+/// one `can_X: bool` per gateable action.
+#[expect(
+  clippy::struct_excessive_bools,
+  reason = "one bool per Permission variant is the point of this snapshot; \
+            templates read these fields directly"
+)]
+pub struct UiPermissions {
+  pub admin:           bool,
+  pub bump_to_front:   bool,
+  pub cancel_build:    bool,
+  pub restart_jobs:    bool,
+  pub create_projects: bool,
+  pub eval_jobset:     bool,
+}
+
+impl UiPermissions {
+  #[must_use]
+  pub fn from_extensions(extensions: &Extensions) -> Self {
+    Self {
+      admin:           check(extensions, Permission::Admin),
+      bump_to_front:   check(extensions, Permission::BumpToFront),
+      cancel_build:    check(extensions, Permission::CancelBuild),
+      restart_jobs:    check(extensions, Permission::RestartJobs),
+      create_projects: check(extensions, Permission::CreateProjects),
+      eval_jobset:     check(extensions, Permission::EvalJobset),
+    }
+  }
+}

--- a/crates/server/src/routes/builds.rs
+++ b/crates/server/src/routes/builds.rs
@@ -217,19 +217,14 @@ async fn bump_build(
   Path(id): Path<Uuid>,
 ) -> Result<Json<Build>, ApiError> {
   check_role(&extensions, &["bump-to-front"])?;
-  let build = sqlx::query_as::<_, Build>(
-    "UPDATE builds SET priority = priority + 10 WHERE id = $1 AND status = \
-     'pending' RETURNING *",
-  )
-  .bind(id)
-  .fetch_optional(&state.pool)
-  .await
-  .map_err(|e| ApiError(circus_common::CiError::Database(e)))?
-  .ok_or_else(|| {
-    ApiError(circus_common::CiError::Validation(
-      "Build not found or not in pending state".to_string(),
-    ))
-  })?;
+  let build = circus_common::repo::builds::bump_priority(&state.pool, id, 10)
+    .await
+    .map_err(ApiError)?
+    .ok_or_else(|| {
+      ApiError(circus_common::CiError::Validation(
+        "Build not found or not in pending state".to_string(),
+      ))
+    })?;
 
   Ok(Json(build))
 }

--- a/crates/server/src/routes/builds.rs
+++ b/crates/server/src/routes/builds.rs
@@ -207,7 +207,7 @@ async fn bump_build(
     .map_err(ApiError)?
     .ok_or_else(|| {
       ApiError(circus_common::CiError::Validation(
-        "Build not found or not in pending state".to_string(),
+        "Build not found or no longer pending".to_string(),
       ))
     })?;
 

--- a/crates/server/src/routes/builds.rs
+++ b/crates/server/src/routes/builds.rs
@@ -17,26 +17,11 @@ use circus_common::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::{auth_middleware::RequireRoles, error::ApiError, state::AppState};
-
-fn check_role(
-  extensions: &Extensions,
-  allowed: &[&str],
-) -> Result<(), ApiError> {
-  RequireRoles::check(extensions, allowed)
-    .map(|_| ())
-    .map_err(|s| {
-      ApiError(if s == StatusCode::FORBIDDEN {
-        circus_common::CiError::Forbidden(
-          "Insufficient permissions".to_string(),
-        )
-      } else {
-        circus_common::CiError::Unauthorized(
-          "Authentication required".to_string(),
-        )
-      })
-    })
-}
+use crate::{
+  error::ApiError,
+  permissions::{self, Permission},
+  state::AppState,
+};
 
 #[derive(Debug, Deserialize)]
 struct ListBuildsParams {
@@ -104,7 +89,7 @@ async fn cancel_build(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Build>>, ApiError> {
-  check_role(&extensions, &["cancel-build"])?;
+  permissions::require_api(&extensions, Permission::CancelBuild)?;
   let cancelled = circus_common::repo::builds::cancel_cascade(&state.pool, id)
     .await
     .map_err(ApiError)?;
@@ -197,7 +182,7 @@ async fn restart_build(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Build>, ApiError> {
-  check_role(&extensions, &["restart-jobs"])?;
+  permissions::require_api(&extensions, Permission::RestartJobs)?;
   let build = circus_common::repo::builds::restart(&state.pool, id)
     .await
     .map_err(ApiError)?;
@@ -216,7 +201,7 @@ async fn bump_build(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
 ) -> Result<Json<Build>, ApiError> {
-  check_role(&extensions, &["bump-to-front"])?;
+  permissions::require_api(&extensions, Permission::BumpToFront)?;
   let build = circus_common::repo::builds::bump_priority(&state.pool, id, 10)
     .await
     .map_err(ApiError)?

--- a/crates/server/src/routes/dashboard/admin.rs
+++ b/crates/server/src/routes/dashboard/admin.rs
@@ -23,6 +23,7 @@ use super::{
     DashboardPage,
     UserView,
     auth_name,
+    can_bump_to_front,
     enforce_page_access,
     is_admin,
   },
@@ -632,4 +633,42 @@ pub(super) async fn notifications_delete(
   Ok(Redirect::to(&format!(
     "/project/{project_id}/notifications"
   )))
+}
+
+/// Push a pending build forward in the queue. Mirrors the JSON
+/// `/builds/{id}/bump` API but accepts a session-authenticated form post
+/// and redirects back to the queue page so the new ordering is visible.
+pub(super) async fn queue_bump(
+  State(state): State<AppState>,
+  Path(build_id): Path<Uuid>,
+  extensions: Extensions,
+  Form(form): Form<CsrfOnlyForm>,
+) -> Result<Redirect, Response> {
+  if !can_bump_to_front(&extensions) {
+    return Err(
+      (
+        StatusCode::FORBIDDEN,
+        "Insufficient permissions to push build forward",
+      )
+        .into_response(),
+    );
+  }
+  check_csrf(&extensions, &form.csrf_token)?;
+  let updated =
+    circus_common::repo::builds::bump_priority(&state.pool, build_id, 10)
+      .await
+      .map_err(|e| {
+        tracing::warn!(build_id = %build_id, "Bump failed: {e}");
+        (StatusCode::BAD_REQUEST, format!("Bump failed: {e}")).into_response()
+      })?;
+  if updated.is_none() {
+    return Err(
+      (
+        StatusCode::NOT_FOUND,
+        "Build not found or no longer pending",
+      )
+        .into_response(),
+    );
+  }
+  Ok(Redirect::to("/queue"))
 }

--- a/crates/server/src/routes/dashboard/admin.rs
+++ b/crates/server/src/routes/dashboard/admin.rs
@@ -23,7 +23,6 @@ use super::{
     DashboardPage,
     UserView,
     auth_name,
-    can_bump_to_front,
     enforce_page_access,
     is_admin,
   },
@@ -38,10 +37,14 @@ use super::{
     UsersTemplate,
   },
 };
-use crate::state::AppState;
+use crate::{
+  permissions::{self, Permission},
+  state::AppState,
+};
 
-// ---------- Admin overview ----------
-
+/// Render the admin overview at `/admin`: system status counters, builder
+/// load and last-activity, API keys, queued notification tasks, pinned
+/// build outputs, and the on-disk config editor when writes are enabled.
 pub(super) async fn admin_page(
   State(state): State<AppState>,
   extensions: Extensions,
@@ -275,8 +278,8 @@ pub(super) async fn admin_page(
   ))
 }
 
-// ---------- Users page ----------
-
+/// Render the user-management page at `/users`. Admin-only because the
+/// listing exposes emails and other account metadata.
 pub(super) async fn users_page(
   State(state): State<AppState>,
   Query(params): Query<PageParams>,
@@ -344,8 +347,8 @@ pub(super) async fn users_page(
   ))
 }
 
-// ---------- News ----------
-
+/// Render the news page at `/news`: list of recent announcements plus,
+/// for admins, the form to publish a new one.
 pub(super) async fn news_page(
   State(state): State<AppState>,
   extensions: Extensions,
@@ -422,8 +425,9 @@ pub(super) async fn news_delete(
   Redirect::to("/news").into_response()
 }
 
-// ---------- Project-scoped notification configs ----------
-
+/// Form payload for `POST /project/{id}/notifications`: the kind of
+/// notification (webhook, email, ...) and a JSON blob holding the
+/// kind-specific configuration.
 #[derive(serde::Deserialize)]
 pub struct NotificationCreateForm {
   pub notification_type: String,
@@ -644,15 +648,8 @@ pub(super) async fn queue_bump(
   extensions: Extensions,
   Form(form): Form<CsrfOnlyForm>,
 ) -> Result<Redirect, Response> {
-  if !can_bump_to_front(&extensions) {
-    return Err(
-      (
-        StatusCode::FORBIDDEN,
-        "Insufficient permissions to push build forward",
-      )
-        .into_response(),
-    );
-  }
+  permissions::require(&extensions, Permission::BumpToFront)
+    .map_err(|s| (s, "Insufficient permissions").into_response())?;
   check_csrf(&extensions, &form.csrf_token)?;
   let updated =
     circus_common::repo::builds::bump_priority(&state.pool, build_id, 10)

--- a/crates/server/src/routes/dashboard/mod.rs
+++ b/crates/server/src/routes/dashboard/mod.rs
@@ -11,7 +11,10 @@
 //!
 //! The public surface is just [`router`].
 
-use axum::{Router, routing::get};
+use axum::{
+  Router,
+  routing::{get, post},
+};
 
 use crate::state::AppState;
 
@@ -25,7 +28,7 @@ mod templates;
 pub fn router() -> Router<AppState> {
   Router::new()
     .route("/login", get(auth::login_page).post(auth::login_action))
-    .route("/logout", axum::routing::post(auth::logout_action))
+    .route("/logout", post(auth::logout_action))
     .route("/", get(pages::home))
     .route("/projects", get(pages::projects_page))
     .route("/projects/new", get(pages::project_setup_page))
@@ -36,28 +39,26 @@ pub fn router() -> Router<AppState> {
     )
     .route(
       "/project/{id}/notifications/{config_id}/delete",
-      axum::routing::post(admin::notifications_delete),
+      post(admin::notifications_delete),
     )
     .route("/jobset/{id}", get(pages::jobset_page))
     .route("/jobset/{id}/jobs", get(pages::jobset_jobs_page))
-    .route(
-      "/jobset/{id}/delete",
-      axum::routing::post(admin::jobset_delete),
-    )
+    .route("/jobset/{id}/delete", post(admin::jobset_delete))
     .route("/evaluations", get(pages::evaluations_page))
     .route("/evaluation/{id}", get(pages::evaluation_page))
     .route(
       "/evaluation/{id}/visibility",
-      axum::routing::post(admin::evaluation_visibility),
+      post(admin::evaluation_visibility),
     )
     .route("/builds", get(pages::builds_page))
     .route("/build/{id}", get(pages::build_page))
     .route("/build/{id}/log", get(pages::build_log))
     .route("/queue", get(pages::queue_page))
+    .route("/build/{id}/bump", post(admin::queue_bump))
     .route("/channels", get(pages::channels_page))
     .route("/channel/{id}", get(pages::channel_page))
     .route("/news", get(admin::news_page).post(admin::news_create))
-    .route("/news/{id}/delete", axum::routing::post(admin::news_delete))
+    .route("/news/{id}/delete", post(admin::news_delete))
     .route("/admin", get(admin::admin_page))
     .route("/users", get(admin::users_page))
     .route("/starred", get(pages::starred_page))

--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -30,6 +30,7 @@ use super::{
     build_view,
     build_view_with_context,
     decode_build_log,
+    can_bump_to_front,
     enforce_page_access,
     eval_badge,
     eval_view,
@@ -959,12 +960,12 @@ pub(super) async fn queue_page(
   )
   .await
   .unwrap_or_default();
-  let pending = circus_common::repo::builds::list_filtered(
+  // Order pending by the same key the queue runner uses (priority DESC,
+  // created_at ASC) so the displayed queue position matches what the
+  // scheduler will pick next, and a "Push forward" bump visibly moves
+  // the build up the list.
+  let pending = circus_common::repo::builds::list_pending_in_scheduler_order(
     &state.pool,
-    None,
-    Some("pending"),
-    None,
-    None,
     100,
     0,
   )
@@ -1099,6 +1100,8 @@ pub(super) async fn queue_page(
     running_builds,
     pending_count,
     running_count,
+    can_bump: can_bump_to_front(&extensions),
+    csrf_token: super::csrf::csrf_from(&extensions),
     is_admin: is_admin(&extensions),
     auth_name: auth_name(&extensions),
   };

--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -30,7 +30,6 @@ use super::{
     build_view,
     build_view_with_context,
     decode_build_log,
-    can_bump_to_front,
     enforce_page_access,
     eval_badge,
     eval_view,
@@ -56,7 +55,7 @@ use super::{
     StarredTemplate,
   },
 };
-use crate::state::AppState;
+use crate::{permissions::UiPermissions, state::AppState};
 
 #[derive(serde::Deserialize)]
 pub(super) struct PageParams {
@@ -97,8 +96,9 @@ pub(super) fn format_elapsed(secs: i64) -> String {
   }
 }
 
-// ---------- Home ----------
-
+/// Render the dashboard landing page at `/`: aggregate build stats,
+/// recent builds and evaluations, project summaries with last-eval
+/// status, and announcements.
 pub(super) async fn home(
   State(state): State<AppState>,
   extensions: Extensions,
@@ -197,8 +197,7 @@ pub(super) async fn home(
   ))
 }
 
-// ---------- Projects / Project ----------
-
+/// Render the paginated project list at `/projects`.
 pub(super) async fn projects_page(
   State(state): State<AppState>,
   Query(params): Query<PageParams>,
@@ -528,8 +527,9 @@ pub(super) async fn jobset_jobs_page(
   ))
 }
 
-// ---------- Evaluations / Evaluation ----------
-
+/// Render the paginated evaluation list at `/evaluations`, enriched with
+/// the owning project and jobset names. Hidden evaluations are included
+/// only for admins.
 pub(super) async fn evaluations_page(
   State(state): State<AppState>,
   Query(params): Query<PageParams>,
@@ -696,8 +696,9 @@ pub(super) async fn evaluation_page(
   ))
 }
 
-// ---------- Builds / Build ----------
-
+/// Render the filterable build listing at `/builds`. Each row is
+/// enriched with its owning project and jobset; the filter form drives
+/// pagination via `BuildFilterParams`.
 pub(super) async fn builds_page(
   State(state): State<AppState>,
   Query(params): Query<BuildFilterParams>,
@@ -942,8 +943,10 @@ pub(super) async fn build_log(
   )
 }
 
-// ---------- Queue ----------
-
+/// Render the build queue at `/queue`: running builds with live elapsed
+/// timers, and pending builds in scheduler order. Each row carries its
+/// project and jobset, and pending rows expose a "push forward" form
+/// when the session's [`UiPermissions`] allow it.
 pub(super) async fn queue_page(
   State(state): State<AppState>,
   extensions: Extensions,
@@ -1100,7 +1103,7 @@ pub(super) async fn queue_page(
     running_builds,
     pending_count,
     running_count,
-    can_bump: can_bump_to_front(&extensions),
+    permissions: UiPermissions::from_extensions(&extensions),
     csrf_token: super::csrf::csrf_from(&extensions),
     is_admin: is_admin(&extensions),
     auth_name: auth_name(&extensions),
@@ -1112,8 +1115,7 @@ pub(super) async fn queue_page(
   ))
 }
 
-// ---------- Channels ----------
-
+/// Render the list of all release channels at `/channels`.
 pub(super) async fn channels_page(
   State(state): State<AppState>,
   extensions: Extensions,
@@ -1200,8 +1202,8 @@ pub(super) async fn channel_page(
   ))
 }
 
-// ---------- Starred / Metrics / Setup wizard ----------
-
+/// Render `/starred`: the signed-in user's starred jobs with the latest
+/// build status for each. Anonymous visitors see an empty page.
 pub(super) async fn starred_page(
   State(state): State<AppState>,
   extensions: Extensions,

--- a/crates/server/src/routes/dashboard/shared.rs
+++ b/crates/server/src/routes/dashboard/shared.rs
@@ -464,6 +464,21 @@ pub(super) fn is_admin(extensions: &Extensions) -> bool {
     .is_some_and(|k| k.role == "admin")
 }
 
+/// True when the authenticated session may bump pending builds to the
+/// front of the queue. Admins always qualify; non-admin sessions need the
+/// `bump-to-front` role.
+pub(super) fn can_bump_to_front(extensions: &Extensions) -> bool {
+  if is_admin(extensions) {
+    return true;
+  }
+  if let Some(user) = extensions.get::<User>() {
+    return user.role == "bump-to-front";
+  }
+  extensions
+    .get::<ApiKey>()
+    .is_some_and(|k| k.role == "bump-to-front")
+}
+
 pub(super) fn is_authenticated(extensions: &Extensions) -> bool {
   extensions.get::<User>().is_some() || extensions.get::<ApiKey>().is_some()
 }

--- a/crates/server/src/routes/dashboard/shared.rs
+++ b/crates/server/src/routes/dashboard/shared.rs
@@ -14,6 +14,8 @@ use circus_common::{
 use circus_proto::nix_log::{self, LogLine};
 use uuid::Uuid;
 
+use crate::permissions::{self, Permission};
+
 // View models (pre-formatted for templates)
 
 pub(super) struct BuildView {
@@ -456,27 +458,7 @@ pub(super) fn eval_badge(s: &EvaluationStatus) -> (String, String) {
 }
 
 pub(super) fn is_admin(extensions: &Extensions) -> bool {
-  if let Some(user) = extensions.get::<User>() {
-    return user.role == "admin";
-  }
-  extensions
-    .get::<ApiKey>()
-    .is_some_and(|k| k.role == "admin")
-}
-
-/// True when the authenticated session may bump pending builds to the
-/// front of the queue. Admins always qualify; non-admin sessions need the
-/// `bump-to-front` role.
-pub(super) fn can_bump_to_front(extensions: &Extensions) -> bool {
-  if is_admin(extensions) {
-    return true;
-  }
-  if let Some(user) = extensions.get::<User>() {
-    return user.role == "bump-to-front";
-  }
-  extensions
-    .get::<ApiKey>()
-    .is_some_and(|k| k.role == "bump-to-front")
+  permissions::check(extensions, Permission::Admin)
 }
 
 pub(super) fn is_authenticated(extensions: &Extensions) -> bool {

--- a/crates/server/src/routes/dashboard/templates.rs
+++ b/crates/server/src/routes/dashboard/templates.rs
@@ -31,6 +31,7 @@ use super::shared::{
   StarredJobView,
   UserView,
 };
+use crate::permissions::UiPermissions;
 
 #[derive(Template)]
 #[template(path = "home.html")]
@@ -176,7 +177,7 @@ pub(super) struct QueueTemplate {
   pub(super) running_builds: Vec<QueueBuildView>,
   pub(super) pending_count:  i64,
   pub(super) running_count:  i64,
-  pub(super) can_bump:       bool,
+  pub(super) permissions:    UiPermissions,
   pub(super) csrf_token:     String,
   pub(super) is_admin:       bool,
   pub(super) auth_name:      String,

--- a/crates/server/src/routes/dashboard/templates.rs
+++ b/crates/server/src/routes/dashboard/templates.rs
@@ -176,6 +176,8 @@ pub(super) struct QueueTemplate {
   pub(super) running_builds: Vec<QueueBuildView>,
   pub(super) pending_count:  i64,
   pub(super) running_count:  i64,
+  pub(super) can_bump:       bool,
+  pub(super) csrf_token:     String,
   pub(super) is_admin:       bool,
   pub(super) auth_name:      String,
 }

--- a/crates/server/src/routes/evaluations.rs
+++ b/crates/server/src/routes/evaluations.rs
@@ -19,16 +19,11 @@ use circus_common::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{auth_middleware::RequireRoles, error::ApiError, state::AppState};
-
-fn extensions_is_admin(extensions: &Extensions) -> bool {
-  if let Some(user) = extensions.get::<circus_common::models::User>() {
-    return user.role == "admin";
-  }
-  extensions
-    .get::<circus_common::models::ApiKey>()
-    .is_some_and(|key| key.role == "admin")
-}
+use crate::{
+  error::ApiError,
+  permissions::{self, Permission},
+  state::AppState,
+};
 
 #[derive(Debug, Deserialize)]
 struct ListEvaluationsParams {
@@ -43,7 +38,7 @@ async fn list_evaluations(
   Query(params): Query<ListEvaluationsParams>,
   extensions: Extensions,
 ) -> Result<Json<PaginatedResponse<Evaluation>>, ApiError> {
-  let include_hidden = extensions_is_admin(&extensions);
+  let include_hidden = permissions::check(&extensions, Permission::Admin);
   let pagination = PaginationParams {
     limit:  params.limit,
     offset: params.offset,
@@ -84,7 +79,7 @@ async fn get_evaluation(
   let evaluation = circus_common::repo::evaluations::get_visible(
     &state.pool,
     id,
-    extensions_is_admin(&extensions),
+    permissions::check(&extensions, Permission::Admin),
   )
   .await
   .map_err(ApiError)?;
@@ -96,15 +91,7 @@ async fn trigger_evaluation(
   State(state): State<AppState>,
   Json(input): Json<CreateEvaluation>,
 ) -> Result<Json<Evaluation>, ApiError> {
-  RequireRoles::check(&extensions, &["eval-jobset"]).map_err(|s| {
-    ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
-    } else {
-      circus_common::CiError::Unauthorized(
-        "Authentication required".to_string(),
-      )
-    })
-  })?;
+  permissions::require_api(&extensions, Permission::EvalJobset)?;
   input
     .validate()
     .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -22,8 +22,9 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
-  auth_middleware::{RequireAdmin, RequireRoles},
+  auth_middleware::RequireAdmin,
   error::ApiError,
+  permissions::{self, Permission},
   state::AppState,
 };
 
@@ -52,15 +53,7 @@ async fn create_project(
   State(state): State<AppState>,
   Json(input): Json<CreateProject>,
 ) -> Result<Json<Project>, ApiError> {
-  RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
-    ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
-    } else {
-      circus_common::CiError::Unauthorized(
-        "Authentication required".to_string(),
-      )
-    })
-  })?;
+  permissions::require_api(&extensions, Permission::CreateProjects)?;
   input
     .validate()
     .map_err(|msg| ApiError(circus_common::CiError::Validation(msg)))?;
@@ -180,15 +173,7 @@ async fn create_project_jobset(
   Path(project_id): Path<Uuid>,
   Json(body): Json<CreateJobsetBody>,
 ) -> Result<Json<Jobset>, ApiError> {
-  RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
-    ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
-    } else {
-      circus_common::CiError::Unauthorized(
-        "Authentication required".to_string(),
-      )
-    })
-  })?;
+  permissions::require_api(&extensions, Permission::CreateProjects)?;
   let input = CreateJobset {
     project_id,
     name: body.name,
@@ -253,15 +238,7 @@ async fn setup_project(
   State(state): State<AppState>,
   Json(body): Json<SetupProjectRequest>,
 ) -> Result<Json<SetupProjectResponse>, ApiError> {
-  RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
-    ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
-    } else {
-      circus_common::CiError::Unauthorized(
-        "Authentication required".to_string(),
-      )
-    })
-  })?;
+  permissions::require_api(&extensions, Permission::CreateProjects)?;
 
   let create_project = CreateProject {
     name:           body.name,
@@ -334,15 +311,7 @@ async fn create_project_webhook(
   Path(project_id): Path<Uuid>,
   Json(body): Json<CreateWebhookBody>,
 ) -> Result<Json<WebhookConfig>, ApiError> {
-  RequireRoles::check(&extensions, &["create-projects"]).map_err(|s| {
-    ApiError(if s == axum::http::StatusCode::FORBIDDEN {
-      circus_common::CiError::Forbidden("Insufficient permissions".to_string())
-    } else {
-      circus_common::CiError::Unauthorized(
-        "Authentication required".to_string(),
-      )
-    })
-  })?;
+  permissions::require_api(&extensions, Permission::CreateProjects)?;
 
   // Validate forge type
   let valid_forges = ["github", "gitlab", "gitea", "forgejo"];

--- a/crates/server/static/style.css
+++ b/crates/server/static/style.css
@@ -800,6 +800,42 @@ th.job-history-name {
   opacity: 0.9;
 }
 
+/* Inline single-action forms inside table rows (e.g. queue push-forward) */
+.row-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+.inline-form {
+  display: inline-block;
+  margin: 0;
+}
+.bump-button {
+  height: 1.75rem;
+  padding: 0 0.625rem;
+  background: var(--surface);
+  color: var(--fg-secondary, var(--fg));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-family: inherit;
+  line-height: 1;
+  transition:
+    border-color 0.1s,
+    color 0.1s,
+    background 0.1s;
+}
+.bump-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+.bump-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 /* Pagination */
 .pagination {
   display: flex;

--- a/crates/server/templates/queue.html
+++ b/crates/server/templates/queue.html
@@ -56,7 +56,7 @@
 <div class="table-wrap">
 <table>
   <thead>
-    <tr><th>#</th><th>Project</th><th>Jobset</th><th>Job</th><th>System</th><th>Priority</th><th>Created</th>{% if can_bump %}<th></th>{% endif %}</tr>
+    <tr><th>#</th><th>Project</th><th>Jobset</th><th>Job</th><th>System</th><th>Priority</th><th>Created</th>{% if permissions.bump_to_front %}<th></th>{% endif %}</tr>
   </thead>
   <tbody>
     {% for b in pending_builds %}
@@ -68,7 +68,7 @@
       <td>{{ b.system }}</td>
       <td>{{ b.priority }}</td>
       <td>{{ b.created_at }}</td>
-      {% if can_bump %}
+      {% if permissions.bump_to_front %}
       <td class="row-actions">
         <form method="POST" action="/build/{{ b.id }}/bump" class="inline-form">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}">

--- a/crates/server/templates/queue.html
+++ b/crates/server/templates/queue.html
@@ -56,7 +56,7 @@
 <div class="table-wrap">
 <table>
   <thead>
-    <tr><th>#</th><th>Project</th><th>Jobset</th><th>Job</th><th>System</th><th>Priority</th><th>Created</th></tr>
+    <tr><th>#</th><th>Project</th><th>Jobset</th><th>Job</th><th>System</th><th>Priority</th><th>Created</th>{% if can_bump %}<th></th>{% endif %}</tr>
   </thead>
   <tbody>
     {% for b in pending_builds %}
@@ -68,6 +68,14 @@
       <td>{{ b.system }}</td>
       <td>{{ b.priority }}</td>
       <td>{{ b.created_at }}</td>
+      {% if can_bump %}
+      <td class="row-actions">
+        <form method="POST" action="/build/{{ b.id }}/bump" class="inline-form">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button type="submit" class="bump-button" title="Increase this build's priority so the scheduler picks it sooner">&uarr; Push forward</button>
+        </form>
+      </td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
Fixes #40 and adds a new, unified capability-based permissions system for the server. This replaces the previous role-string checks with a strongly-typed `Permission` enum. All authorization logic for API endpoints and dashboard actions now flow through this system, which is mildly better for consistent and less-error-prone permission checks Also on this note the PR improves the queue logic; the dashboard now displays pending builds in scheduler order, and the "push forward" (bump) action uses a new atomic method,l route handlers and templates are updated to use the new permissions and queue logic. Clean code etc.