### PR TITLE
server: harden `queue_bump` errors; dedup the permission predicate

### DIFF
--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -4,7 +4,7 @@
 //! `/etc/circus-agent.toml`. Environment overrides with prefix
 //! `CIRCUS_AGENT__` and `__` as a path separator.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +25,7 @@ pub struct Agent {
 
   /// Bearer token presented on `register`. Hashed and compared against
   /// `[builder].auth_tokens` on the runner.
+  #[serde(default)]
   pub auth_token: String,
 
   /// Nix systems this agent can build. Must match what the host's Nix
@@ -127,11 +128,9 @@ impl AgentConfig {
   ///
   /// # Errors
   /// Returns the underlying `config` error on missing file or parse failure.
-  pub fn load(
-    path: Option<&std::path::Path>,
-  ) -> Result<Self, config::ConfigError> {
+  pub fn load(path: Option<&Path>) -> Result<Self, config::ConfigError> {
     let chosen = path
-      .map(std::path::Path::to_path_buf)
+      .map(Path::to_path_buf)
       .or_else(|| std::env::var("CIRCUS_AGENT_CONFIG").ok().map(PathBuf::from))
       .unwrap_or_else(|| PathBuf::from("/etc/circus-agent.toml"));
 
@@ -142,6 +141,17 @@ impl AgentConfig {
       )
       .build()?;
 
-    cfg.try_deserialize()
+    let mut parsed = cfg.try_deserialize::<Self>()?;
+
+    if let Ok(token) = std::env::var("CIRCUS_AGENT_TOKEN") {
+      parsed.agent.auth_token = token;
+    }
+    if parsed.agent.auth_token.is_empty() {
+      return Err(config::ConfigError::Message(
+        "no auth token: set CIRCUS_AGENT_TOKEN or agent.auth_token".into(),
+      ));
+    }
+
+    Ok(parsed)
   }
 }

--- a/crates/agent/src/sandbox.rs
+++ b/crates/agent/src/sandbox.rs
@@ -497,13 +497,10 @@ fn setup_pivot_root(paths: &SandboxPaths) -> color_eyre::Result<()> {
   bind_if_exists("/etc/nsswitch.conf", newroot.join("etc/nsswitch.conf"))?;
   bind_if_exists("/etc/ssl/certs", newroot.join("etc/ssl/certs"))?;
 
-  mount(
-    Some("proc"),
-    newroot.join("proc").as_path(),
-    Some("proc"),
-    MsFlags::empty(),
-    None::<&str>,
-  )?;
+  // Bind the host /proc rather than mounting a fresh procfs as it needs
+  // CAP_SYS_ADMIN over the PID namespace it exposes, which this sandbox does
+  // not own.
+  bind("/proc", newroot.join("proc"))?;
 
   pivot_root(newroot, &newroot.join(".oldroot"))?;
   chdir("/")?;

--- a/crates/server/src/permissions.rs
+++ b/crates/server/src/permissions.rs
@@ -46,14 +46,15 @@ fn session_role(extensions: &Extensions) -> Option<&str> {
   extensions.get::<ApiKey>().map(|k| k.role.as_str())
 }
 
+fn role_grants(role: &str, permission: Permission) -> bool {
+  role == Permission::Admin.role_str() || role == permission.role_str()
+}
+
 /// Whether the authenticated session may exercise `permission`. Admin
 /// sessions satisfy every check; anonymous sessions satisfy none.
 #[must_use]
 pub fn check(extensions: &Extensions, permission: Permission) -> bool {
-  let Some(role) = session_role(extensions) else {
-    return false;
-  };
-  role == Permission::Admin.role_str() || role == permission.role_str()
+  session_role(extensions).is_some_and(|role| role_grants(role, permission))
 }
 
 /// Reject the request with `UNAUTHORIZED` if the session is anonymous,
@@ -66,13 +67,10 @@ pub fn require(
   extensions: &Extensions,
   permission: Permission,
 ) -> Result<(), StatusCode> {
-  let Some(role) = session_role(extensions) else {
-    return Err(StatusCode::UNAUTHORIZED);
-  };
-  if role == Permission::Admin.role_str() || role == permission.role_str() {
-    Ok(())
-  } else {
-    Err(StatusCode::FORBIDDEN)
+  match session_role(extensions) {
+    None => Err(StatusCode::UNAUTHORIZED),
+    Some(role) if role_grants(role, permission) => Ok(()),
+    Some(_) => Err(StatusCode::FORBIDDEN),
   }
 }
 

--- a/crates/server/src/routes/dashboard/admin.rs
+++ b/crates/server/src/routes/dashboard/admin.rs
@@ -655,8 +655,8 @@ pub(super) async fn queue_bump(
     circus_common::repo::builds::bump_priority(&state.pool, build_id, 10)
       .await
       .map_err(|e| {
-        tracing::warn!(build_id = %build_id, "Bump failed: {e}");
-        (StatusCode::BAD_REQUEST, format!("Bump failed: {e}")).into_response()
+        tracing::error!(build_id = %build_id, error = %e, "Bump failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "Bump failed").into_response()
       })?;
   if updated.is_none() {
     return Err(

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -510,37 +510,36 @@ details are covered in [DISTRIBUTED.md](./DISTRIBUTED.md).
 
 ### Rootless Agents
 
-`circus-agent` can run on machines where you have an unprivileged shell
-account and no Nix installation (such as unprivileged ssh access). Set
-`rootless = true` under `[agent]` and the agent executes every Nix invocation
-inside a `user+mount` namespace, with `$XDG_DATA_HOME/circus-agent` mounted
-as `/nix`, build scratch under its `tmp/`, and `proc`/`dev`/DNS/CA bind-mounts
-from the host.
+`circus-agent` can run on machines where you have an unprivileged shell account
+and no Nix installation (such as unprivileged ssh access). Set `rootless = true`
+under `[agent]` and the agent executes every Nix invocation inside a
+`user+mount` namespace, with `$XDG_DATA_HOME/circus-agent` mounted as `/nix`,
+build scratch under its `tmp/`, and `proc`/`dev`/DNS/CA bind-mounts from the
+host.
 
 Requirements:
 
-- Unprivileged user namespaces must be enabled on the host kernel.
-  You can check if they are with `unshare --user --map-root-user true` succeeding.
+- Unprivileged user namespaces must be enabled on the host kernel. You can check
+  if they are with `unshare --user --map-root-user true` succeeding.
 - `CIRCUS_AGENT_NIX` must point to a `nix` (or `nix-store`) binary **at its
   `/nix/store` path as seen inside the sandbox**, that is, the binary and its
-  closure must be seeded into `$XDG_DATA_HOME/circus-agent/store` first.
-  This can be done by unpacking a Nix release tarball there. A host
-  path like `~/.nix-profile/bin/nix` will not exist after the sandbox pivots its
-  root.
+  closure must be seeded into `$XDG_DATA_HOME/circus-agent/store` first. This
+  can be done by unpacking a Nix release tarball there. A host path like
+  `~/.nix-profile/bin/nix` will not exist after the sandbox pivots its root.
 
-The data directory can be moved with `rootless_data_dir` under `[agent]` (or
-the `CIRCUS_AGENT_DATA_DIR` environment variable) for hosts without a usable
-home directory.
+The data directory can be moved with `rootless_data_dir` under `[agent]` (or the
+`CIRCUS_AGENT_DATA_DIR` environment variable) for hosts without a usable home
+directory.
 
 The agent validates both requirements at startup and refuses to register when
-they fail. Nix settings for builds come from `etc/nix/nix.conf` in the data
-dir. By default Nix sandboxes each build in a nested user namespace inside the
+they fail. Nix settings for builds come from `etc/nix/nix.conf` in the data dir.
+By default Nix sandboxes each build in a nested user namespace inside the
 agent's, however, if the host kernel does not support this, just set
 `sandbox = false` there.
 
-Rootless mode is an isolation mechanism, not a security boundary. The
-namespace only exists to give Nix the filesystem layout it expects. Builds still
-run as your real uid with unrestricted network access. Do not rely on it to contain
+Rootless mode is an isolation mechanism, not a security boundary. The namespace
+only exists to give Nix the filesystem layout it expects. Builds still run as
+your real uid with unrestricted network access. Do not rely on it to contain
 untrusted build code.
 
 ## Authentication Bootstrapping


### PR DESCRIPTION
- A few followup changes to #79 and #80