### PR TITLE
nix: make server unit `requires` conditional for split deployments

### DIFF
--- a/nix/modules/circus.nix
+++ b/nix/modules/circus.nix
@@ -786,8 +786,13 @@ in {
         circus-evaluator = mkIf cfg.evaluator.enable {
           description = "circus Evaluator";
           wantedBy = ["multi-user.target"];
-          after = ["network.target" "circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
-          requires = ["circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          after =
+            ["network.target"]
+            ++ optional cfg.server.enable "circus-server.service"
+            ++ optional cfg.database.createLocally "postgresql.target";
+          requires =
+            optional cfg.server.enable "circus-server.service"
+            ++ optional cfg.database.createLocally "postgresql.target";
 
           path = with pkgs; [
             nix
@@ -826,8 +831,13 @@ in {
         circus-queue-runner = mkIf cfg.queueRunner.enable {
           description = "circus Queue Runner";
           wantedBy = ["multi-user.target"];
-          after = ["network.target" "circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
-          requires = ["circus-server.service"] ++ optional cfg.database.createLocally "postgresql.target";
+          after =
+            ["network.target"]
+            ++ optional cfg.server.enable "circus-server.service"
+            ++ optional cfg.database.createLocally "postgresql.target";
+          requires =
+            optional cfg.server.enable "circus-server.service"
+            ++ optional cfg.database.createLocally "postgresql.target";
 
           path = with pkgs; [
             nix


### PR DESCRIPTION
For running components on different hosts. Otherwise, it's necessary to enable the server on each to satisfy the systemd `requires`/`after`.