### PR TITLE
queue-runner: capability-preserving builder selection

### DIFF
--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -270,6 +272,30 @@ pub async fn list_pending_in_scheduler_order(
   .fetch_all(pool)
   .await
   .map_err(CiError::Database)
+}
+
+/// The set of system features any pending build for `system` requires.
+///
+/// This is used by capability-preserving scheduling to decide which builder
+/// capabilities are currently contended, so a versatile builder is not handed
+/// fungible work while a build that needs one of its scarce features is queued.
+///
+/// # Errors
+///
+/// Returns error if the database query fails.
+pub async fn pending_feature_demand(
+  pool: &PgPool,
+  system: &str,
+) -> Result<HashSet<String>> {
+  let rows = sqlx::query_as(
+    "SELECT DISTINCT unnest(required_features) FROM builds WHERE status = \
+     'pending' AND system = $1",
+  )
+  .bind(system)
+  .fetch_all(pool)
+  .await
+  .map_err(CiError::Database)?;
+  Ok(rows.into_iter().map(|(feature,)| feature).collect())
 }
 
 /// Atomically increment a pending build's priority by `delta`. The row is
@@ -602,9 +628,7 @@ pub async fn get_completed_by_drv_paths(
 /// # Errors
 ///
 /// Returns error if database query fails.
-pub async fn list_pinned_ids(
-  pool: &PgPool,
-) -> Result<std::collections::HashSet<Uuid>> {
+pub async fn list_pinned_ids(pool: &PgPool) -> Result<HashSet<Uuid>> {
   let rows: Vec<(Uuid,)> =
     sqlx::query_as("SELECT id FROM builds WHERE keep = true")
       .fetch_all(pool)

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -1,11 +1,18 @@
 //! The running state should mean a build already holds execution capacity.
 
 use std::{
+  cmp::Ordering,
+  collections::HashSet,
   path::Path,
   sync::Arc,
   time::{Duration, Instant},
 };
 
+use BuilderSchedulingStrategy::{
+  CpuCoreCountWithSpeedFactor,
+  Dynamic,
+  SpeedFactorOnly,
+};
 use circus_common::{config::BuilderSchedulingStrategy, models::Build, repo};
 use sqlx::PgPool;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
@@ -70,6 +77,52 @@ pub(crate) fn supports_required_features(
       .iter()
       .all(|feature| required_features.contains(feature))
 }
+
+/// Count of the builder's features that some other pending build needs
+/// (`demand`) but this build does not. Scoping to `demand` keeps the score 0
+/// when nothing is contended, leaving the load strategy in charge.
+#[must_use]
+pub(crate) fn contended_surplus(
+  supported_features: &[String],
+  required_features: &[String],
+  demand: &HashSet<String>,
+) -> usize {
+  supported_features
+    .iter()
+    .filter(|feature| {
+      demand.contains(*feature) && !required_features.contains(*feature)
+    })
+    .count()
+}
+
+/// Load-based ordering for the configured strategy, used as the tie-break once
+/// builders are ranked by contended surplus.
+///
+/// Returns [`Ordering::Less`] when `a` is the better choice.
+fn strategy_order(
+  strategy: &BuilderSchedulingStrategy,
+  a: &AgentSnapshot,
+  b: &AgentSnapshot,
+) -> Ordering {
+  match strategy {
+    SpeedFactorOnly => {
+      b.speed_factor
+        .partial_cmp(&a.speed_factor)
+        .unwrap_or(Ordering::Equal)
+    },
+    CpuCoreCountWithSpeedFactor => {
+      let av = a.cpu_count as f32 * a.speed_factor;
+      let bv = b.cpu_count as f32 * b.speed_factor;
+      bv.partial_cmp(&av).unwrap_or(Ordering::Equal)
+    },
+    Dynamic => {
+      let free = |s: &AgentSnapshot| -> f32 {
+        s.max_jobs.saturating_sub(s.current_jobs) as f32 * s.speed_factor
+      };
+      free(b).partial_cmp(&free(a)).unwrap_or(Ordering::Equal)
+    },
+  }
+}
 pub struct AgentDispatch<'a> {
   pub timeout:                    Duration,
   pub max_silent_time:            Duration,
@@ -130,12 +183,6 @@ async fn select_and_reserve_agent(
   heartbeat_ttl: Duration,
   strategy: &BuilderSchedulingStrategy,
 ) -> Option<(Arc<AgentMeta>, AgentSnapshot, SlotGuard)> {
-  use BuilderSchedulingStrategy::{
-    CpuCoreCountWithSpeedFactor,
-    Dynamic,
-    SpeedFactorOnly,
-  };
-
   let mut candidates = agent_pool.candidates_for(system);
   if candidates.is_empty() {
     return None;
@@ -192,28 +239,26 @@ async fn select_and_reserve_agent(
     }
   }
 
+  // Capability-preserving order: prefer builders that waste the fewest
+  // currently-contended capabilities on this build, so a versatile builder is
+  // kept free for the queued work that actually needs it.
+  let demand = repo::builds::pending_feature_demand(pool, system)
+    .await
+    .unwrap_or_default();
+
   eligible.sort_by(|a, b| {
-    match strategy {
-      SpeedFactorOnly => {
-        b.1
-          .speed_factor
-          .partial_cmp(&a.1.speed_factor)
-          .unwrap_or(std::cmp::Ordering::Equal)
-      },
-      CpuCoreCountWithSpeedFactor => {
-        let av = a.1.cpu_count as f32 * a.1.speed_factor;
-        let bv = b.1.cpu_count as f32 * b.1.speed_factor;
-        bv.partial_cmp(&av).unwrap_or(std::cmp::Ordering::Equal)
-      },
-      Dynamic => {
-        let free = |s: &AgentSnapshot| -> f32 {
-          s.max_jobs.saturating_sub(s.current_jobs) as f32 * s.speed_factor
-        };
-        free(&b.1)
-          .partial_cmp(&free(&a.1))
-          .unwrap_or(std::cmp::Ordering::Equal)
-      },
-    }
+    let sa = contended_surplus(
+      &a.1.supported_features,
+      &build.required_features,
+      &demand,
+    );
+    let sb = contended_surplus(
+      &b.1.supported_features,
+      &build.required_features,
+      &demand,
+    );
+    sa.cmp(&sb)
+      .then_with(|| strategy_order(strategy, &a.1, &b.1))
   });
 
   eligible.into_iter().find_map(|(meta, snap)| {
@@ -329,10 +374,59 @@ async fn read_drv_outputs(drv_path: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-  use super::supports_required_features;
+  use std::collections::HashSet;
+
+  use super::{contended_surplus, supports_required_features};
 
   fn strs(values: &[&str]) -> Vec<String> {
     values.iter().map(|value| (*value).to_owned()).collect()
+  }
+
+  fn demand(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+  }
+
+  #[test]
+  fn no_contention_scores_zero_for_every_builder() {
+    // Nothing queued demands a feature, so ordering must fall back entirely to
+    // the load strategy (every builder scores 0).
+    let empty = demand(&[]);
+    assert_eq!(
+      contended_surplus(&strs(&["kvm", "big-parallel"]), &strs(&[]), &empty),
+      0
+    );
+    assert_eq!(contended_surplus(&strs(&[]), &strs(&[]), &empty), 0);
+  }
+
+  #[test]
+  fn fungible_build_is_penalised_on_a_contended_builder() {
+    // A plain build, while a kvm build is queued
+    let d = demand(&["kvm"]);
+    assert_eq!(contended_surplus(&strs(&["kvm"]), &strs(&[]), &d), 1);
+    assert_eq!(contended_surplus(&strs(&[]), &strs(&[]), &d), 0);
+  }
+
+  #[test]
+  fn a_builds_own_required_feature_is_never_surplus() {
+    // The kvm build itself belongs on the kvm builder, so kvm must not count
+    // against it even though kvm is in demand.
+    let d = demand(&["kvm"]);
+    assert_eq!(contended_surplus(&strs(&["kvm"]), &strs(&["kvm"]), &d), 0);
+  }
+
+  #[test]
+  fn only_demanded_features_count_not_noise() {
+    // `benchmark` is advertised but nothing demands it, so it must not inflate
+    // surplus, only the demanded `uid-range` does.
+    let d = demand(&["uid-range"]);
+    assert_eq!(
+      contended_surplus(
+        &strs(&["benchmark", "big-parallel", "uid-range"]),
+        &strs(&[]),
+        &d,
+      ),
+      1
+    );
   }
 
   #[test]

--- a/flake.nix
+++ b/flake.nix
@@ -102,16 +102,18 @@
         channel-tarball = callTest ./nix/tests/channel-tarball.nix;
         distributed = callTest ./nix/tests/distributed.nix;
         agent-dispatch = callTest ./nix/tests/agent-dispatch.nix;
+        capability-scheduling = callTest ./nix/tests/capability-scheduling.nix;
         s3-cache = callTest ./nix/tests/s3-cache.nix;
       };
-    in {
-      inherit (vmTests) service-startup basic-api auth-rbac api-crud features webhooks e2e declarative gc-pinning machine-health channel-tarball distributed agent-dispatch s3-cache;
-      inherit formatting;
-      full = pkgs.symlinkJoin {
-        name = "vm-tests-full";
-        paths = builtins.attrValues vmTests;
-      };
-    });
+    in
+      vmTests
+      // {
+        inherit formatting;
+        full = pkgs.symlinkJoin {
+          name = "vm-tests-full";
+          paths = builtins.attrValues vmTests;
+        };
+      });
 
     devShells = forAllSystems (system: let
       pkgs = pkgsFor system;

--- a/nix/tests/capability-scheduling.nix
+++ b/nix/tests/capability-scheduling.nix
@@ -1,0 +1,276 @@
+# A kvm-capable builder should be reserved for kvm work, not win fungible builds on load.
+{
+  testers,
+  pkgs,
+  self,
+}: let
+  testFlake =
+    pkgs.writeText "flake.nix"
+    /*
+    nix
+    */
+    ''
+      {
+        outputs = { self, ... }: {
+          packages.x86_64-linux.fungible = derivation {
+            name = "circus-test-fungible";
+            system = "x86_64-linux";
+            builder = "builtin:fetchurl";
+            url = "file://${builtins.toFile "fungible.txt" "fungible\n"}";
+            outputHashMode = "flat";
+            outputHashAlgo = "sha256";
+            outputHash = "sha256-9oWaD6E7O4521XC87GceZdWST/u9e+QFYSpMRRpFq6U=";
+          };
+          packages.x86_64-linux.kvmonly = derivation {
+            name = "circus-test-kvmonly";
+            system = "x86_64-linux";
+            builder = "builtin:fetchurl";
+            url = "file://${builtins.toFile "kvmonly.txt" "kvmonly\n"}";
+            outputHashMode = "flat";
+            outputHashAlgo = "sha256";
+            outputHash = "sha256-0pYYEKsxj4yuHDGPHknsT7d9BX86+g9xDOalDHiFoOw=";
+            requiredSystemFeatures = [ "kvm" ];
+          };
+        };
+      }
+    '';
+
+  mkAgent = {
+    name,
+    features,
+    speed,
+  }: {
+    pkgs,
+    lib,
+    ...
+  }: let
+    circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+  in {
+    imports = [self.nixosModules.circus-agent];
+    _module.args.self = self;
+
+    environment.systemPackages = with pkgs; [
+      nix
+      curl
+      jq
+    ];
+    nix.settings.experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+    nix.settings.substituters = lib.mkForce [];
+    nix.settings.system-features = lib.mkForce (
+      [
+        "nixos-test"
+        "benchmark"
+        "big-parallel"
+      ]
+      ++ features
+    );
+
+    environment.etc."circus-agent/token".text = "demo-agent-token-please-rotate";
+
+    services.circus-agent = {
+      enable = true;
+      package = circus-packages.circus-agent;
+      authTokenFile = "/etc/circus-agent/token";
+      settings.agent = {
+        inherit name;
+        runner_url = "circus://runner:8443";
+        systems = [pkgs.stdenv.hostPlatform.system];
+        supported_features = features;
+        max_jobs = 1;
+        speed_factor = speed;
+        heartbeat_interval_secs = 3;
+        reconnect_delay_secs = 2;
+      };
+    };
+  };
+in
+  testers.runNixOSTest {
+    name = "circus-capability-scheduling";
+
+    containers = {
+      runner = {
+        pkgs,
+        lib,
+        ...
+      }: let
+        circus-packages = self.packages.${pkgs.stdenv.hostPlatform.system};
+      in {
+        imports = [self.nixosModules.circus];
+        _module.args.self = self;
+
+        programs.git.enable = true;
+        security.sudo.enable = true;
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+          openssl
+          util-linux
+        ];
+
+        environment.etc."circus/cache-key.sec" = {
+          text = "circus-test-cache-1:C7h9wunIEh7kCa2Ylpa/omVaLewO7gQTb2LEPCPeJ0G6ZsLd2SaJZyt44z6nX5RanSkkrjM4xwapqVPneHY83A==";
+          mode = "0400";
+          user = "circus";
+        };
+
+        nix.settings.experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
+        nix.settings.substituters = lib.mkForce [];
+        networking.firewall.allowedTCPPorts = [
+          3000
+          8443
+        ];
+
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = ["circus"];
+          ensureUsers = [
+            {
+              name = "circus";
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+
+        services.circus = {
+          enable = true;
+          package = circus-packages.circus-server;
+          evaluatorPackage = circus-packages.circus-evaluator;
+          queueRunnerPackage = circus-packages.circus-queue-runner;
+          migratePackage = circus-packages.circus-migrate-cli;
+
+          server.enable = true;
+          evaluator.enable = true;
+          queueRunner.enable = true;
+
+          settings = {
+            database.url = "postgresql:///circus?host=/run/postgresql";
+            server = {
+              host = "0.0.0.0";
+              port = 3000;
+              cors_permissive = false;
+              allowed_url_schemes = [
+                "https"
+                "http"
+                "file"
+              ];
+            };
+            gc.enabled = false;
+            logs.log_dir = "/var/lib/circus/logs";
+            cache.enabled = true;
+            signing = {
+              enabled = true;
+              key_file = "/etc/circus/cache-key.sec";
+            };
+            tracing = {
+              level = "info";
+              format = "compact";
+            };
+            queue_runner = {
+              poll_interval = 3;
+              work_dir = "/var/lib/circus/queue-runner";
+              strict_errors = false;
+              rpc = {
+                bind = "0.0.0.0:8443";
+                max_connections = 64;
+                heartbeat_ttl_secs = 30;
+                auth_tokens = [
+                  "${builtins.hashString "sha256" "demo-agent-token-please-rotate"}"
+                ];
+                cache_substituter = "http://runner:3000/nix-cache";
+                cache_public_key = "circus-test-cache-1:umbC3dkmiWcreOM+p1+UWp0pJK4zOMcGqalT53h2PNw=";
+              };
+            };
+          };
+
+          declarative.apiKeys = [
+            {
+              name = "bootstrap-admin";
+              key = "circus_bootstrap_key";
+              role = "admin";
+            }
+          ];
+        };
+      };
+
+      kvm = mkAgent {
+        name = "agent-kvm";
+        features = ["kvm"];
+        speed = 2.0;
+      };
+      plain = mkAgent {
+        name = "agent-plain";
+        features = [];
+        speed = 1.0;
+      };
+    };
+
+    testScript =
+      /*
+      py
+      */
+      ''
+        start_all()
+
+        auth = "-H 'Authorization: Bearer circus_bootstrap_key'"
+        api = "http://127.0.0.1:3000/api/v1"
+
+        def psql(q):
+            return f"""setpriv --reuid=circus --regid=circus --init-groups psql -U circus -d circus -tAc "{q}" """
+
+        def wait_row(q):
+            runner.wait_until_succeeds(psql(f"SELECT count(*) FROM {q}") + " | grep -qE '^ *1$'", timeout=240)
+
+        with subtest("Services up, both agents registered"):
+            runner.wait_for_unit("circus-server.service")
+            runner.wait_for_unit("circus-queue-runner.service")
+            runner.wait_until_succeeds("curl -sf http://127.0.0.1:3000/health", timeout=60)
+            runner.wait_for_open_port(8443)
+            kvm.wait_for_unit("circus-agent.service")
+            plain.wait_for_unit("circus-agent.service")
+            wait_row("builder_sessions WHERE name='agent-kvm' AND connected")
+            wait_row("builder_sessions WHERE name='agent-plain' AND connected")
+
+        with subtest("Publish flake, create jobset"):
+            runner.succeed(
+                "mkdir -p /var/lib/circus/test-repos",
+                "git init --bare -q /var/lib/circus/test-repos/test-flake.git",
+                "git init -q /tmp/wc",
+                "cp ${testFlake} /tmp/wc/flake.nix",
+                "git -C /tmp/wc add -A",
+                "git -C /tmp/wc -c user.email=circus@manic.systems -c user.name=circus commit -qm flake",
+                "git -C /tmp/wc push -q /var/lib/circus/test-repos/test-flake.git HEAD:refs/heads/master",
+                "chown -R circus:circus /var/lib/circus/test-repos",
+            )
+            project = runner.succeed(
+                f"""curl -sf -X POST {api}/projects {auth} -H 'Content-Type: application/json' """
+                """-d '{"name":"t","repository_url":"file:///var/lib/circus/test-repos/test-flake.git"}' | jq -r .id"""
+            ).strip()
+            runner.succeed(
+                f"""curl -sf -X POST {api}/projects/{project}/jobsets {auth} -H 'Content-Type: application/json' """
+                """-d '{"name":"packages","nix_expression":"packages","flake_mode":true,"enabled":true,"check_interval":10}'"""
+            )
+
+        with subtest("Both builds complete"):
+            wait_row("builds WHERE job_name LIKE '%kvmonly' AND status='succeeded'")
+            wait_row("builds WHERE job_name LIKE '%fungible' AND status='succeeded'")
+
+        with subtest("kvm-only build ran on agent-kvm"):
+            wait_row(
+                "builds b JOIN builder_sessions s ON b.agent_machine_id = s.machine_id "
+                "WHERE b.job_name LIKE '%kvmonly' AND s.name='agent-kvm'"
+            )
+
+        with subtest("fungible build was kept off agent-kvm"):
+            attributed = runner.succeed(psql(
+                "SELECT s.name FROM builds b JOIN builder_sessions s "
+                "ON b.agent_machine_id = s.machine_id WHERE b.job_name LIKE '%fungible'"
+            )).strip()
+            assert attributed == "agent-plain", f"fungible should be preserved off the kvm agent, ran on: {attributed!r}"
+      '';
+  }


### PR DESCRIPTION
A versatile builder (e.g. one advertising kvm) could be handed fungible work that any builder could run, occupying a scarce capability while a queued build that *only* it can run waited behind that work.

Rank eligible builders by how many currently-contended capabilities they would waste on a build, and use the configured load strategy as the tie-break. Here, a feature is contended when some pending build for the system requires it.