### PR TITLE
queue-runner: match venue capabilities against the will-build closure

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -211,6 +211,14 @@ pub struct QueueRunnerConfig {
   #[serde(default)]
   pub extra_nix_build_args: Vec<String>,
 
+  /// Systems the runner host itself may build.
+  #[serde(default)]
+  pub local_systems: Option<Vec<String>>,
+
+  /// `system-features` of the runner host's nix.
+  #[serde(default)]
+  pub local_features: Option<Vec<String>>,
+
   /// Capnp-rpc endpoint for persistent build agents. When set, the
   /// queue-runner listens on this address and dispatches eligible builds
   /// to connected agents in preference to the SSH `remote_builders`
@@ -914,6 +922,8 @@ impl Default for QueueRunnerConfig {
       psi_threshold:        None,
       psi_check_timeout:    5,
       extra_nix_build_args: Vec::new(),
+      local_systems:        None,
+      local_features:       None,
       rpc:                  None,
     }
   }

--- a/crates/common/src/drv.rs
+++ b/crates/common/src/drv.rs
@@ -1,0 +1,175 @@
+//! Read `requiredSystemFeatures` out of `nix derivation show` output.
+
+use std::collections::BTreeSet;
+
+use crate::{CiError, error::Result};
+
+fn features_of_structured(sa: &serde_json::Value, out: &mut BTreeSet<String>) {
+  if let Some(arr) = sa.get("requiredSystemFeatures").and_then(|v| v.as_array())
+  {
+    out.extend(
+      arr
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_owned))
+        .filter(|s| !s.is_empty()),
+    );
+  }
+}
+
+/// Plain drvs flatten the list to a space-separated string in `env`, whereas
+/// structuredAttrs drvs carry a real list under `structuredAttrs`.
+fn features_of_drv(drv: &serde_json::Value, out: &mut BTreeSet<String>) {
+  let Some(drv) = drv.as_object() else {
+    return;
+  };
+
+  if let Some(sa) = drv.get("structuredAttrs") {
+    features_of_structured(sa, out);
+    return;
+  }
+
+  let Some(env) = drv.get("env").and_then(|v| v.as_object()) else {
+    return;
+  };
+  if let Some(json_str) = env.get("__json").and_then(|v| v.as_str()) {
+    if let Ok(sa) = serde_json::from_str::<serde_json::Value>(json_str) {
+      features_of_structured(&sa, out);
+    }
+    return;
+  }
+  if let Some(env_str) =
+    env.get("requiredSystemFeatures").and_then(|v| v.as_str())
+  {
+    out.extend(
+      env_str
+        .split(|c: char| c.is_whitespace() || c == ':' || c == ',')
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned),
+    );
+  }
+}
+
+/// Union of `requiredSystemFeatures` over every derivation in a `nix derivation
+/// show` document.
+#[must_use]
+pub fn union_required_features(parsed: &serde_json::Value) -> Vec<String> {
+  let Some(obj) = parsed.as_object() else {
+    return Vec::new();
+  };
+  let drvs = obj
+    .get("derivations")
+    .and_then(|v| v.as_object())
+    .unwrap_or(obj);
+
+  let mut out = BTreeSet::new();
+  for drv in drvs.values() {
+    features_of_drv(drv, &mut out);
+  }
+  out.into_iter().collect::<Vec<String>>()
+}
+
+/// Run `nix derivation show` over `drvs` and union their
+/// `requiredSystemFeatures`.
+///
+/// # Errors
+///
+/// Returns [`NixEval`](`CiError::NixEval`) when nix cannot be spawned, exits
+/// non-zero, or emits unparseable JSON.
+pub async fn show_required_features(drvs: &[String]) -> Result<Vec<String>> {
+  let mut features = BTreeSet::new();
+  // Chunked to stay under `ARG_MAX` on huge closures.
+  for chunk in drvs.chunks(1024) {
+    let out = tokio::process::Command::new("nix")
+      .args([
+        "--extra-experimental-features",
+        "nix-command",
+        "derivation",
+        "show",
+      ])
+      .args(chunk)
+      .output()
+      .await
+      .map_err(|e| {
+        CiError::NixEval(format!("failed to run nix derivation show: {e}"))
+      })?;
+    if !out.status.success() {
+      return Err(CiError::NixEval(format!(
+        "nix derivation show failed: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+      )));
+    }
+    let parsed = serde_json::from_slice::<serde_json::Value>(&out.stdout)
+      .map_err(|e| {
+        CiError::NixEval(format!("nix derivation show output: {e}"))
+      })?;
+    features.extend(union_required_features(&parsed));
+  }
+  Ok(features.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json::json;
+
+  use super::*;
+
+  #[test]
+  fn reads_wrapped_derivation_show() {
+    let shown = json!({
+      "derivations": {
+        "/nix/store/example.drv": {
+          "env": {
+            "requiredSystemFeatures": "kvm nixos-test uid-range"
+          }
+        }
+      },
+      "version": 3
+    });
+
+    assert_eq!(union_required_features(&shown), vec![
+      "kvm",
+      "nixos-test",
+      "uid-range"
+    ]);
+  }
+
+  #[test]
+  fn splits_legacy_colon_and_comma_separators() {
+    let shown = json!({
+      "/nix/store/example.drv": {
+        "env": {
+          "requiredSystemFeatures": "kvm:nixos-test,uid-range"
+        }
+      }
+    });
+
+    assert_eq!(union_required_features(&shown), vec![
+      "kvm",
+      "nixos-test",
+      "uid-range"
+    ]);
+  }
+
+  #[test]
+  fn unions_structured_attrs_and_env_drvs() {
+    let shown = json!({
+      "/nix/store/a.drv": {
+        "structuredAttrs": { "requiredSystemFeatures": ["kvm", "nixos-test"] }
+      },
+      "/nix/store/b.drv": {
+        "env": { "requiredSystemFeatures": "uid-range kvm" }
+      },
+      "/nix/store/c.drv": {
+        "env": { "__json": "{\"requiredSystemFeatures\":[\"benchmark\"]}" }
+      },
+      "/nix/store/d.drv": {}
+    });
+
+    assert_eq!(union_required_features(&shown), vec![
+      "benchmark",
+      "kvm",
+      "nixos-test",
+      "uid-range"
+    ]);
+  }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod config;
 pub mod crypto;
 pub mod database;
+pub mod drv;
 pub mod error;
 pub mod gc_roots;
 pub mod log_storage;

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -206,6 +206,21 @@ pub struct Build {
   /// is eligible.
   #[serde(default)]
   pub required_features:          Vec<String>,
+  /// `requiredSystemFeatures` unioned over the drvs the venue will actually
+  /// build. [`None`] means this was not yet computed.
+  #[serde(default)]
+  pub effective_features:         Option<Vec<String>>,
+}
+
+impl Build {
+  /// The effective features, else the job drv's own `required_features`.
+  #[must_use]
+  pub fn scheduling_features(&self) -> &[String] {
+    self
+      .effective_features
+      .as_deref()
+      .unwrap_or(&self.required_features)
+  }
 }
 
 #[derive(

--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -213,9 +213,10 @@ pub async fn mark_started_notified(pool: &PgPool, id: Uuid) -> Result<bool> {
 pub async fn requeue(pool: &PgPool, id: Uuid) -> Result<Option<Build>> {
   sqlx::query_as::<_, Build>(
     "WITH bumped AS ( UPDATE builds SET status = 'pending', started_at = \
-     NULL, completed_at = NULL WHERE id = $1 AND status = 'running' RETURNING \
-     * ), cleared AS ( DELETE FROM build_steps WHERE build_id = $1 AND EXISTS \
-     (SELECT 1 FROM bumped) ) SELECT * FROM bumped",
+     NULL, completed_at = NULL, effective_features = NULL WHERE id = $1 AND \
+     status = 'running' RETURNING * ), cleared AS ( DELETE FROM build_steps \
+     WHERE build_id = $1 AND EXISTS (SELECT 1 FROM bumped) ) SELECT * FROM \
+     bumped",
   )
   .bind(id)
   .fetch_optional(pool)
@@ -288,8 +289,8 @@ pub async fn pending_feature_demand(
   system: &str,
 ) -> Result<HashSet<String>> {
   let rows = sqlx::query_as(
-    "SELECT DISTINCT unnest(required_features) FROM builds WHERE status = \
-     'pending' AND system = $1",
+    "SELECT DISTINCT unnest(COALESCE(effective_features, required_features)) \
+     FROM builds WHERE status = 'pending' AND system = $1",
   )
   .bind(system)
   .fetch_all(pool)
@@ -398,8 +399,9 @@ pub async fn reset_orphaned(
   older_than_secs: i64,
 ) -> Result<u64> {
   let result = sqlx::query(
-    "UPDATE builds SET status = 'pending', started_at = NULL WHERE status = \
-     'running' AND started_at < NOW() - make_interval(secs => $1)",
+    "UPDATE builds SET status = 'pending', started_at = NULL, \
+     effective_features = NULL WHERE status = 'running' AND started_at < \
+     NOW() - make_interval(secs => $1)",
   )
   .bind(older_than_secs)
   .execute(pool)
@@ -557,9 +559,9 @@ pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Build> {
   let build = sqlx::query_as::<_, Build>(
     "UPDATE builds SET status = 'pending', started_at = NULL, completed_at = \
      NULL, log_path = NULL, build_output_path = NULL, error_message = NULL, \
-     started_notified_at = NULL, retry_count = retry_count + 1 WHERE id = $1 \
-     AND status IN ('failed', 'succeeded', 'cancelled', 'cached_failure') \
-     RETURNING *",
+     started_notified_at = NULL, effective_features = NULL, retry_count = \
+     retry_count + 1 WHERE id = $1 AND status IN ('failed', 'succeeded', \
+     'cancelled', 'cached_failure') RETURNING *",
   )
   .bind(id)
   .fetch_optional(pool)
@@ -577,6 +579,25 @@ pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Build> {
   }
 
   Ok(build)
+}
+
+/// Persist the dispatch-time effective features for a build.
+///
+/// # Errors
+///
+/// Returns error if database update fails.
+pub async fn set_effective_features(
+  pool: &PgPool,
+  id: Uuid,
+  features: &[String],
+) -> Result<()> {
+  sqlx::query("UPDATE builds SET effective_features = $1 WHERE id = $2")
+    .bind(features)
+    .bind(id)
+    .execute(pool)
+    .await
+    .map_err(CiError::Database)?;
+  Ok(())
 }
 
 /// Mark a build's outputs as signed.

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -688,97 +688,18 @@ async fn evaluate_jobset(
   Ok(())
 }
 
+/// Read the derivation's `requiredSystemFeatures` via `nix derivation show`.
+/// Failure returns an empty list, mirroring the SSH path which treats absence
+/// as "no constraint".
+async fn read_required_features(drv_path: &str) -> Vec<String> {
+  circus_common::drv::show_required_features(&[drv_path.to_owned()])
+    .await
+    .unwrap_or_default()
+}
+
 /// Detect whether a derivation is a fixed-output derivation by reading the
 /// `.drv` file and checking for `outputHash` in its env vars.
 /// Returns `(is_fod, fod_hash)`.
-/// Read the derivation's `requiredSystemFeatures` env var via
-/// `nix derivation show`. The Nix derivation format encodes this attribute
-/// as a colon- or space-separated string in `env.requiredSystemFeatures`
-/// (a function of how nixpkgs builds the drv); modern Nix exposes a
-/// structured `requiredSystemFeatures` key on the derivation too.
-///
-/// We accept either: parse a JSON list if present, otherwise split the
-/// env string on whitespace. Failure (drv not on disk, nix not on PATH,
-/// malformed JSON) returns an empty list, mirroring the SSH path which
-/// treats absence as "no constraint".
-async fn read_required_features(drv_path: &str) -> Vec<String> {
-  let Ok(output) = tokio::process::Command::new("nix")
-    .args([
-      "--extra-experimental-features",
-      "nix-command",
-      "derivation",
-      "show",
-      drv_path,
-    ])
-    .output()
-    .await
-  else {
-    return Vec::new();
-  };
-  if !output.status.success() {
-    return Vec::new();
-  }
-  let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&output.stdout)
-  else {
-    return Vec::new();
-  };
-  required_features_from_derivation_show(&parsed)
-}
-
-fn derivation_from_show(
-  parsed: &serde_json::Value,
-) -> Option<&serde_json::Map<String, serde_json::Value>> {
-  let obj = parsed.as_object()?;
-  if let Some(derivations) = obj.get("derivations").and_then(|v| v.as_object())
-  {
-    return derivations.values().next()?.as_object();
-  }
-  obj.values().next()?.as_object()
-}
-
-fn split_required_features(value: &str) -> Vec<String> {
-  value
-    .split(|c: char| c.is_whitespace() || c == ':' || c == ',')
-    .filter(|s| !s.is_empty())
-    .map(str::to_owned)
-    .collect()
-}
-
-fn required_features_from_derivation_show(
-  parsed: &serde_json::Value,
-) -> Vec<String> {
-  let Some(drv) = derivation_from_show(parsed) else {
-    return Vec::new();
-  };
-
-  // 1. Top-level `requiredSystemFeatures` list (modern Nix).
-  if let Some(arr) =
-    drv.get("requiredSystemFeatures").and_then(|v| v.as_array())
-  {
-    return arr
-      .iter()
-      .filter_map(|v| v.as_str().map(str::to_owned))
-      .filter(|s| !s.is_empty())
-      .collect();
-  }
-
-  // 2. `env.requiredSystemFeatures`, a space-separated string.
-  if let Some(env_str) =
-    drv.get("requiredSystemFeatures").and_then(|v| v.as_str())
-  {
-    return split_required_features(env_str);
-  }
-  if let Some(env_str) = drv
-    .get("env")
-    .and_then(|v| v.as_object())
-    .and_then(|env| env.get("requiredSystemFeatures"))
-    .and_then(|v| v.as_str())
-  {
-    return split_required_features(env_str);
-  }
-  Vec::new()
-}
-
 fn detect_fod(drv_path: &str) -> (bool, Option<String>) {
   let Ok(content) = std::fs::read_to_string(drv_path) else {
     return (false, None);
@@ -1054,47 +975,5 @@ async fn discover_projects_without_jobsets(
     };
 
     sync_repo_declarative_config(pool, &repo_path, project.id).await;
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use serde_json::json;
-
-  use super::*;
-
-  #[test]
-  fn required_features_read_wrapped_derivation_show() {
-    let shown = json!({
-      "derivations": {
-        "/nix/store/example.drv": {
-          "env": {
-            "requiredSystemFeatures": "kvm nixos-test uid-range"
-          }
-        }
-      },
-      "version": 3
-    });
-
-    assert_eq!(required_features_from_derivation_show(&shown), vec![
-      "kvm",
-      "nixos-test",
-      "uid-range"
-    ]);
-  }
-
-  #[test]
-  fn required_features_split_legacy_separators() {
-    let shown = json!({
-      "/nix/store/example.drv": {
-        "requiredSystemFeatures": "kvm:nixos-test,uid-range"
-      }
-    });
-
-    assert_eq!(required_features_from_derivation_show(&shown), vec![
-      "kvm",
-      "nixos-test",
-      "uid-range"
-    ]);
   }
 }

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -288,6 +288,8 @@ async fn evaluate_flake(
     // Surface meta.{description, license, homepage, maintainers} so the
     // channel tarball can carry them through to nix-env / nix search.
     cmd.arg("--meta");
+    // `inputDrvs` is what create_builds_from_eval wires into build_dependencies
+    cmd.arg("--show-input-drvs");
     // Evaluation must never mutate the consumer's flake.lock. Without this,
     // nix-eval-jobs can race against the checked-out working tree and write a
     // refreshed lock that the next eval then disagrees with.
@@ -470,6 +472,7 @@ async fn evaluate_legacy(
     let mut cmd = tokio::process::Command::new("nix-eval-jobs");
     cmd.arg(&expr_path).arg("--force-recurse");
     cmd.arg("--meta");
+    cmd.arg("--show-input-drvs");
     cmd.kill_on_drop(true);
 
     if config.restrict_eval {

--- a/crates/migrations/migrations/0022_build_effective_features.sql
+++ b/crates/migrations/migrations/0022_build_effective_features.sql
@@ -1,0 +1,4 @@
+-- requiredSystemFeatures unioned over the drvs a dispatch-time
+-- `nix-store --realise --dry-run` says will be built
+ALTER TABLE builds
+ADD COLUMN IF NOT EXISTS effective_features TEXT[];

--- a/crates/queue-runner/src/caps.rs
+++ b/crates/queue-runner/src/caps.rs
@@ -1,0 +1,115 @@
+//! What the runner host itself can execute, gating the local-build fallback
+//! the same way agent `supported_features` gate dispatch.
+
+#[derive(Debug)]
+pub struct RunnerCaps {
+  enabled:  bool,
+  systems:  Vec<String>,
+  features: Vec<String>,
+}
+
+async fn nix_config_show(setting: &str) -> Option<String> {
+  let out = tokio::process::Command::new("nix")
+    .args([
+      "--extra-experimental-features",
+      "nix-command",
+      "config",
+      "show",
+      setting,
+    ])
+    .output()
+    .await
+    .ok()?;
+  if !out.status.success() {
+    return None;
+  }
+  Some(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+impl RunnerCaps {
+  #[must_use]
+  pub const fn new(
+    enabled: bool,
+    systems: Vec<String>,
+    features: Vec<String>,
+  ) -> Self {
+    Self {
+      enabled,
+      systems,
+      features,
+    }
+  }
+
+  /// Resolve from config overrides, else the host nix's own settings.
+  pub async fn detect(
+    enabled: bool,
+    systems: Option<Vec<String>>,
+    features: Option<Vec<String>>,
+  ) -> Self {
+    let systems = if let Some(systems) = systems {
+      systems
+    } else {
+      let native = nix_config_show("system").await;
+      if native.is_none() {
+        tracing::error!(
+          "could not detect the native nix system; local builds may not be \
+           scheduled (set queue_runner.local_systems to override)"
+        );
+      }
+      let mut detected = native.into_iter().collect::<Vec<String>>();
+      if let Some(extra) = nix_config_show("extra-platforms").await {
+        detected.extend(extra.split_whitespace().map(str::to_owned));
+      }
+      detected
+    };
+    let features = if let Some(features) = features {
+      features
+    } else {
+      nix_config_show("system-features").await.map_or_else(
+        || {
+          tracing::error!(
+            "could not detect local nix system-features; only featureless \
+             builds will run locally (set queue_runner.local_features to \
+             override)"
+          );
+          Vec::new()
+        },
+        |raw| raw.split_whitespace().map(str::to_owned).collect(),
+      )
+    };
+    Self::new(enabled, systems, features)
+  }
+
+  #[must_use]
+  pub const fn enabled(&self) -> bool {
+    self.enabled
+  }
+
+  /// Whether the runner host can run a build for `system` demanding `features`.
+  #[must_use]
+  pub fn supports(&self, system: Option<&str>, features: &[String]) -> bool {
+    self.enabled
+      && system.is_none_or(|s| self.systems.iter().any(|x| x == s))
+      && features.iter().all(|f| self.features.contains(f))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn supports_checks_system_features_and_enablement() {
+    let caps = RunnerCaps::new(true, vec!["x86_64-linux".into()], vec![
+      "kvm".into(),
+      "nixos-test".into(),
+    ]);
+    assert!(caps.supports(Some("x86_64-linux"), &["kvm".into()]));
+    assert!(caps.supports(None, &[]));
+    assert!(!caps.supports(Some("aarch64-linux"), &[]));
+    assert!(!caps.supports(Some("x86_64-linux"), &["uid-range".into()]));
+
+    let disabled = RunnerCaps::new(false, vec!["x86_64-linux".into()], vec![]);
+    assert!(!disabled.supports(Some("x86_64-linux"), &[]));
+  }
+}

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -132,12 +132,17 @@ pub struct AgentDispatch<'a> {
   pub fail_build_on_upload_error: bool,
 }
 
-/// Reserve capacity before the build is claimed as running.
+/// Reserve capacity before the build is claimed as running. [`None`] means
+/// there is no capable venue.
 ///
 /// # Panics
 ///
 /// Only if the worker semaphore has been closed, which never happens during
 /// normal operation.
+#[expect(
+  clippy::too_many_arguments,
+  reason = "venue reservation needs the same scheduling context as dispatch"
+)]
 pub async fn reserve_venue(
   agent_pool: &Arc<AgentPool>,
   pool: &PgPool,
@@ -147,7 +152,10 @@ pub async fn reserve_venue(
   heartbeat_ttl: Duration,
   strategy: &BuilderSchedulingStrategy,
   worker_semaphore: &Arc<Semaphore>,
-) -> ExecutionReservation {
+  runner_caps: &crate::caps::RunnerCaps,
+  psi_cache: &crate::psi::PsiCache,
+  psi_check_timeout: Duration,
+) -> Option<ExecutionReservation> {
   if let Some(system) = system
     && let Some((meta, snap, slot)) = select_and_reserve_agent(
       agent_pool,
@@ -160,7 +168,53 @@ pub async fn reserve_venue(
     )
     .await
   {
-    return ExecutionReservation::Agent { meta, snap, slot };
+    return Some(ExecutionReservation::Agent { meta, snap, slot });
+  }
+
+  let features = build.scheduling_features();
+  let runner_ok = runner_caps.supports(system, features);
+  let ssh_ok = if runner_ok {
+    false // the runner already qualifies
+  } else if let Some(system) = system {
+    match repo::remote_builders::find_for_system(pool, system, strategy).await {
+      Ok(builders) => {
+        let mut any = false;
+        for b in &builders {
+          if !supports_required_features(
+            features,
+            &b.supported_features,
+            &b.mandatory_features,
+          ) {
+            continue;
+          }
+          if let Some(threshold) = psi_threshold
+            && let Some(snap) =
+              crate::psi::read_cached(psi_cache, &b.ssh_uri, psi_check_timeout)
+                .await
+            && snap.exceeds(threshold)
+          {
+            continue;
+          }
+          any = true;
+          break;
+        }
+        any
+      },
+      Err(e) => {
+        tracing::warn!(build_id = %build.id, "failed to check SSH builders for venue reservation: {e}");
+        false
+      },
+    }
+  } else {
+    false
+  };
+  if !runner_ok && !ssh_ok {
+    tracing::debug!(
+      build_id = %build.id,
+      ?features,
+      "no capable venue; leaving build pending"
+    );
+    return None;
   }
 
   #[expect(
@@ -171,7 +225,7 @@ pub async fn reserve_venue(
     .acquire_owned()
     .await
     .expect("worker semaphore is never closed");
-  ExecutionReservation::Runner(permit)
+  Some(ExecutionReservation::Runner(permit))
 }
 
 async fn select_and_reserve_agent(
@@ -207,7 +261,7 @@ async fn select_and_reserve_agent(
 
   candidates.retain(|(_, snap)| {
     supports_required_features(
-      &build.required_features,
+      build.scheduling_features(),
       &snap.supported_features,
       &snap.mandatory_features,
     )
@@ -249,12 +303,12 @@ async fn select_and_reserve_agent(
   eligible.sort_by(|a, b| {
     let sa = contended_surplus(
       &a.1.supported_features,
-      &build.required_features,
+      build.scheduling_features(),
       &demand,
     );
     let sb = contended_surplus(
       &b.1.supported_features,
-      &build.required_features,
+      build.scheduling_features(),
       &demand,
     );
     sa.cmp(&sb)

--- a/crates/queue-runner/src/features.rs
+++ b/crates/queue-runner/src/features.rs
@@ -1,0 +1,163 @@
+//! Dispatch-time effective features
+//!
+//! The venue realizes the whole unbuilt closure, not just the job drv, so union
+//! `requiredSystemFeatures` over what nix says will actually be built.
+
+use std::{collections::BTreeSet, path::Path};
+
+use circus_common::{models::Build, repo};
+use sqlx::PgPool;
+use tokio::{process::Command, sync::Semaphore};
+
+/// Cap dry-run fan-out on a cold queue.
+static COMPUTE_SLOTS: Semaphore = Semaphore::const_new(4);
+
+/// Parse the will-build list from `nix-store --realise --dry-run` stderr.
+fn parse_dry_run_will_build(stderr: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  let mut in_built_section = false;
+  for line in stderr.lines() {
+    if line.starts_with(' ') || line.starts_with('\t') {
+      if in_built_section {
+        let path = line.trim();
+        if Path::new(path)
+          .extension()
+          .is_some_and(|ext| ext.eq_ignore_ascii_case("drv"))
+        {
+          out.push(path.to_owned());
+        }
+      }
+      continue;
+    }
+    in_built_section = line.contains("will be built");
+  }
+  out
+}
+
+async fn will_build_set(drv_path: &str) -> color_eyre::Result<Vec<String>> {
+  let out = Command::new("nix-store")
+    .args(["--realise", "--dry-run", drv_path])
+    .output()
+    .await?;
+  if !out.status.success() {
+    color_eyre::eyre::bail!(
+      "nix-store --realise --dry-run failed: {}",
+      String::from_utf8_lossy(&out.stderr).trim()
+    );
+  }
+  Ok(parse_dry_run_will_build(&String::from_utf8_lossy(
+    &out.stderr,
+  )))
+}
+
+/// Union `requiredSystemFeatures` over the drvs the runner's nix says will
+/// be built for `drv_path` given current store and substituter state.
+async fn compute(drv_path: &str) -> color_eyre::Result<Vec<String>> {
+  let drvs = will_build_set(drv_path).await?;
+  Ok(circus_common::drv::show_required_features(&drvs).await?)
+}
+
+/// Floor the computed set to the job-level features so a silent dry-run
+/// parse miss can never erase the drv's own constraints.
+fn with_required_floor(
+  computed: Vec<String>,
+  required: &[String],
+) -> Vec<String> {
+  computed
+    .into_iter()
+    .chain(required.iter().cloned())
+    .collect::<BTreeSet<_>>()
+    .into_iter()
+    .collect()
+}
+
+/// Populate `effective_features` on the first dispatch attempt, and on failure
+/// fall back to the job-level `required_features`.
+///
+/// # Panics
+///
+/// Only if the compute semaphore has been closed, which never happens.
+pub async fn ensure_effective_features(
+  pool: &PgPool,
+  mut build: Build,
+) -> Build {
+  if build.effective_features.is_some() {
+    return build;
+  }
+  #[expect(
+    clippy::expect_used,
+    reason = "the static semaphore is never closed, so acquire never errors"
+  )]
+  let _slot = COMPUTE_SLOTS
+    .acquire()
+    .await
+    .expect("compute semaphore is never closed");
+  match compute(&build.drv_path).await {
+    Ok(computed) => {
+      let features = with_required_floor(computed, &build.required_features);
+      if let Err(e) =
+        repo::builds::set_effective_features(pool, build.id, &features).await
+      {
+        tracing::warn!(
+          build_id = %build.id,
+          "failed to persist effective_features: {e}"
+        );
+      }
+      tracing::debug!(
+        build_id = %build.id,
+        ?features,
+        "computed effective features"
+      );
+      build.effective_features = Some(features);
+    },
+    Err(e) => {
+      tracing::warn!(
+        build_id = %build.id,
+        drv = %build.drv_path,
+        "effective feature computation failed, scheduling on job-level \
+         required_features: {e}"
+      );
+    },
+  }
+  build
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn collects_built_drvs_under_singular_and_plural_headers() {
+    let plural = "these 2 derivations will be built:\n  \
+                  /nix/store/aaa-inner.drv\n  /nix/store/bbb-outer.drv\n";
+    assert_eq!(parse_dry_run_will_build(plural), vec![
+      "/nix/store/aaa-inner.drv",
+      "/nix/store/bbb-outer.drv"
+    ]);
+
+    let singular =
+      "this derivation will be built:\n  /nix/store/ccc-single.drv\n";
+    assert_eq!(parse_dry_run_will_build(singular), vec![
+      "/nix/store/ccc-single.drv"
+    ]);
+  }
+
+  #[test]
+  fn floor_keeps_job_features_when_computed_is_empty() {
+    assert_eq!(
+      with_required_floor(Vec::new(), &["kvm".into(), "uid-range".into()]),
+      vec!["kvm", "uid-range"]
+    );
+  }
+
+  #[test]
+  fn ignores_fetched_section_even_for_drv_paths() {
+    let stderr = "these 1 derivations will be built:\n  \
+                  /nix/store/aaa-built.drv\nthese 2 paths will be fetched \
+                  (1.0 MiB download):\n  /nix/store/bbb-out\n  \
+                  /nix/store/ccc-substituted.drv\n";
+    assert_eq!(parse_dry_run_will_build(stderr), vec![
+      "/nix/store/aaa-built.drv"
+    ]);
+  }
+}

--- a/crates/queue-runner/src/lib.rs
+++ b/crates/queue-runner/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod builder;
+pub mod caps;
 pub mod dispatch;
+pub mod features;
 pub mod psi;
 pub mod rpc;
 pub mod runner_loop;

--- a/crates/queue-runner/src/main.rs
+++ b/crates/queue-runner/src/main.rs
@@ -7,6 +7,7 @@ use circus_common::{
   repo,
 };
 use circus_queue_runner::{
+  caps::RunnerCaps,
   rpc::{AgentPool, server::ServerConfig as RpcServerConfig},
   worker::{ActiveBuilds, WorkerPool},
 };
@@ -46,6 +47,15 @@ async fn main() -> color_eyre::Result<()> {
   let nix_store_dir = config.nix.store_dir;
 
   let workers = cli.workers.unwrap_or(qr_config.workers);
+  let runner_caps = Arc::new(
+    RunnerCaps::detect(
+      workers > 0,
+      qr_config.local_systems.clone(),
+      qr_config.local_features.clone(),
+    )
+    .await,
+  );
+  tracing::info!(?runner_caps, "resolved local runner capabilities");
   let strict_errors = qr_config.strict_errors;
   let failed_paths_cache = qr_config.failed_paths_cache;
   let work_dir = qr_config.work_dir;
@@ -96,6 +106,7 @@ async fn main() -> color_eyre::Result<()> {
     cache_upload_config,
     alert_config,
     Arc::clone(&agent_pool),
+    runner_caps,
     heartbeat_ttl,
   ));
 

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -343,72 +343,82 @@ pub async fn run(
             },
           }
 
-          if let Some(timeout) = unsupported_timeout
-            && let Some(system) = &build.system
-          {
-            match repo::remote_builders::find_for_system(
-              &pool,
-              system,
-              &scheduling_strategy,
-            )
-            .await
-            {
-              Ok(builders) => {
-                let has_builder = builders.iter().any(|builder| {
-                  supports_required_features(
-                    &build.required_features,
-                    &builder.supported_features,
-                    &builder.mandatory_features,
-                  )
-                });
-                let has_agent =
-                  worker_pool.agent_pool().snapshot_all().iter().any(|agent| {
-                    agent.systems.iter().any(|s| s == system)
-                      && supports_required_features(
-                        &build.required_features,
-                        &agent.supported_features,
-                        &agent.mandatory_features,
-                      )
-                  });
-                if !has_builder && !has_agent {
-                  let timeout_at = build.created_at + timeout;
-                  if chrono::Utc::now() > timeout_at {
-                    tracing::info!(
-                      build_id = %build.id,
-                      system = %system,
-                      timeout = ?timeout,
-                      "Aborting build: no builder available for system/features"
-                    );
-
-                    if let Err(e) = repo::builds::start(&pool, build.id).await {
-                      tracing::warn!(build_id = %build.id, "Failed to start unsupported build: {e}");
-                    }
-
-                    if let Err(e) = repo::builds::complete(
-                      &pool,
-                      build.id,
-                      BuildStatus::UnsupportedSystem,
-                      None,
-                      None,
-                      Some("No builder available for system/features"),
+          if let Some(timeout) = unsupported_timeout {
+            // Builders and agents are system-keyed, but a system-less build can
+            // only run on the runner host.
+            let (has_builder, has_agent) = if let Some(system) = &build.system {
+              match repo::remote_builders::find_for_system(
+                &pool,
+                system,
+                &scheduling_strategy,
+              )
+              .await
+              {
+                Ok(builders) => {
+                  let has_builder = builders.iter().any(|builder| {
+                    supports_required_features(
+                      build.scheduling_features(),
+                      &builder.supported_features,
+                      &builder.mandatory_features,
                     )
-                    .await
-                    {
-                      tracing::warn!(build_id = %build.id, "Failed to complete unsupported build: {e}");
-                    }
-
-                    continue;
-                  }
+                  });
+                  let has_agent =
+                    worker_pool.agent_pool().snapshot_all().iter().any(
+                      |agent| {
+                        agent.systems.iter().any(|s| s == system)
+                          && supports_required_features(
+                            build.scheduling_features(),
+                            &agent.supported_features,
+                            &agent.mandatory_features,
+                          )
+                      },
+                    );
+                  (has_builder, has_agent)
+                },
+                Err(e) => {
+                  tracing::error!(
+                    build_id = %build.id,
+                    "Failed to check builders for unsupported system: {e}"
+                  );
                   continue;
-                }
-              },
-              Err(e) => {
-                tracing::error!(
+                },
+              }
+            } else {
+              (false, false)
+            };
+            let has_runner = worker_pool
+              .runner_caps()
+              .supports(build.system.as_deref(), build.scheduling_features());
+            if !has_builder && !has_agent && !has_runner {
+              let timeout_at = build.created_at + timeout;
+              if chrono::Utc::now() > timeout_at {
+                tracing::info!(
                   build_id = %build.id,
-                  "Failed to check builders for unsupported system: {e}"
+                  system = ?build.system,
+                  timeout = ?timeout,
+                  "Aborting build: no builder available for system/features"
                 );
+
+                if let Err(e) = repo::builds::start(&pool, build.id).await {
+                  tracing::warn!(build_id = %build.id, "Failed to start unsupported build: {e}");
+                }
+
+                if let Err(e) = repo::builds::complete(
+                  &pool,
+                  build.id,
+                  BuildStatus::UnsupportedSystem,
+                  None,
+                  None,
+                  Some("No builder available for system/features"),
+                )
+                .await
+                {
+                  tracing::warn!(build_id = %build.id, "Failed to complete unsupported build: {e}");
+                }
+
                 continue;
-              },
+              }
+              continue;
             }
           }
 

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -51,6 +51,7 @@ pub struct WorkerPool {
   alert_manager:       Arc<Option<AlertManager>>,
   psi_cache:           Arc<crate::psi::PsiCache>,
   agent_pool:          Arc<crate::rpc::AgentPool>,
+  runner_caps:         Arc<crate::caps::RunnerCaps>,
   heartbeat_ttl:       Duration,
   drain_token:         CancellationToken,
   active_builds:       ActiveBuilds,
@@ -74,6 +75,7 @@ impl WorkerPool {
     cache_upload_config: CacheUploadConfig,
     alert_config: Option<AlertConfig>,
     agent_pool: Arc<crate::rpc::AgentPool>,
+    runner_caps: Arc<crate::caps::RunnerCaps>,
     heartbeat_ttl: Duration,
   ) -> Self {
     let alert_manager = alert_config.map(AlertManager::new);
@@ -93,6 +95,7 @@ impl WorkerPool {
       alert_manager: Arc::new(alert_manager),
       psi_cache: crate::psi::PsiCache::new(),
       agent_pool,
+      runner_caps,
       heartbeat_ttl,
       drain_token: CancellationToken::new(),
       active_builds: Arc::new(DashMap::new()),
@@ -131,6 +134,11 @@ impl WorkerPool {
   }
 
   #[must_use]
+  pub const fn runner_caps(&self) -> &Arc<crate::caps::RunnerCaps> {
+    &self.runner_caps
+  }
+
+  #[must_use]
   pub const fn active_builds(&self) -> &ActiveBuilds {
     &self.active_builds
   }
@@ -155,6 +163,7 @@ impl WorkerPool {
     let alert_manager = Arc::clone(&self.alert_manager);
     let psi_cache = Arc::clone(&self.psi_cache);
     let agent_pool = Arc::clone(&self.agent_pool);
+    let runner_caps = Arc::clone(&self.runner_caps);
     let heartbeat_ttl = self.heartbeat_ttl;
     let active_builds = Arc::clone(&self.active_builds);
     let cancel_token = CancellationToken::new();
@@ -164,6 +173,11 @@ impl WorkerPool {
 
     tokio::spawn(async move {
       let result = async {
+        // Computed here so slow dry-runs on a cold queue don't serialize the
+        // scheduler loop.
+        let build =
+          crate::features::ensure_effective_features(&pool, build).await;
+
         let (
           timeout,
           max_silent_time,
@@ -206,6 +220,7 @@ impl WorkerPool {
           Arc::clone(&psi_cache),
           extra_nix_args,
           Arc::clone(&agent_pool),
+          Arc::clone(&runner_caps),
           heartbeat_ttl,
         )
         .await
@@ -535,14 +550,14 @@ async fn try_remote_build(
   for builder in &builders {
     // Leave the build pending for a builder with the right feature set.
     if !supports_required_features(
-      &build.required_features,
+      build.scheduling_features(),
       &builder.supported_features,
       &builder.mandatory_features,
     ) {
       tracing::debug!(
         build_id = %build.id,
         builder = %builder.name,
-        required = ?build.required_features,
+        required = ?build.scheduling_features(),
         supported = ?builder.supported_features,
         mandatory = ?builder.mandatory_features,
         "skipping builder: missing required_features"
@@ -687,7 +702,7 @@ async fn collect_metrics_and_alert(
 }
 
 /// Runs with a worker permit, trying configured SSH builders before local
-/// execution.
+/// execution. `Ok(None)` means no venue could take the build.
 #[expect(
   clippy::too_many_arguments,
   reason = "on-runner execution needs the full SSH/local scheduling context"
@@ -705,7 +720,8 @@ async fn run_on_runner(
   psi_check_timeout: Duration,
   psi_cache: &Arc<crate::psi::PsiCache>,
   extra_nix_args: &[String],
-) -> circus_common::error::Result<crate::builder::BuildResult> {
+  runner_caps: &crate::caps::RunnerCaps,
+) -> circus_common::error::Result<Option<crate::builder::BuildResult>> {
   let _permit = permit;
   if build.system.is_some()
     && let Some(r) = try_remote_build(
@@ -723,7 +739,18 @@ async fn run_on_runner(
     )
     .await
   {
-    return Ok(r);
+    return Ok(Some(r));
+  }
+  if !runner_caps.supports(build.system.as_deref(), build.scheduling_features())
+  {
+    tracing::warn!(
+      build_id = %build.id,
+      system = ?build.system,
+      features = ?build.scheduling_features(),
+      "no capable SSH builder and the runner host lacks the required \
+       system/features; requeueing"
+    );
+    return Ok(None);
   }
   crate::builder::run_nix_build(
     drv_path,
@@ -733,14 +760,10 @@ async fn run_on_runner(
     extra_nix_args,
   )
   .await
+  .map(Some)
 }
 
 #[tracing::instrument(skip(pool, build, work_dir, nix_store_dir, log_config, gc_config, notifications_config, signing_config, cache_upload_config, upload_semaphore, scheduling_strategy), fields(build_id = %build.id, job = %build.job_name))]
-#[expect(
-  clippy::significant_drop_tightening,
-  reason = "the execution reservation is held deliberately from before the DB \
-            claim until the build completes"
-)]
 #[expect(
   clippy::too_many_arguments,
   reason = "build execution coordinates database state, config, \
@@ -769,11 +792,12 @@ async fn run_build(
   psi_cache: Arc<crate::psi::PsiCache>,
   extra_nix_args: Arc<Vec<String>>,
   agent_pool: Arc<crate::rpc::AgentPool>,
+  runner_caps: Arc<crate::caps::RunnerCaps>,
   heartbeat_ttl: Duration,
 ) -> color_eyre::Result<()> {
   // Reserve capacity before claiming the build so `running` means execution
   // can start immediately.
-  let venue = crate::dispatch::reserve_venue(
+  let Some(venue) = crate::dispatch::reserve_venue(
     &agent_pool,
     pool,
     build,
@@ -782,8 +806,14 @@ async fn run_build(
     heartbeat_ttl,
     &scheduling_strategy,
     &worker_semaphore,
+    &runner_caps,
+    &psi_cache,
+    psi_check_timeout,
   )
-  .await;
+  .await
+  else {
+    return Ok(());
+  };
 
   let Some(claimed_build) = repo::builds::start(pool, build.id).await? else {
     tracing::debug!(build_id = %build.id, "Build already claimed, skipping");
@@ -890,7 +920,7 @@ async fn run_build(
       )
       .await
       {
-        Ok(r)
+        Ok(Some(r))
       } else if let Ok(permit) =
         Arc::clone(&worker_semaphore).try_acquire_owned()
       {
@@ -907,26 +937,11 @@ async fn run_build(
           psi_check_timeout,
           &psi_cache,
           &build_extra_nix_args,
+          &runner_caps,
         )
         .await
       } else {
-        // Only remove the live log when requeue succeeds. Cancelled or
-        // completed builds may still need it.
-        match repo::builds::requeue(pool, build.id).await {
-          Ok(Some(_)) => {
-            let _ = tokio::fs::remove_file(&live_log_path).await;
-          },
-          Ok(None) => {
-            tracing::debug!(
-              build_id = %build.id,
-              "build no longer running at requeue (cancelled or completed elsewhere)"
-            );
-          },
-          Err(e) => {
-            tracing::warn!(build_id = %build.id, "Failed to requeue after agent loss: {e}");
-          },
-        }
-        return Ok(());
+        Ok(None)
       }
     },
     crate::dispatch::ExecutionReservation::Runner(permit) => {
@@ -943,9 +958,35 @@ async fn run_build(
         psi_check_timeout,
         &psi_cache,
         &build_extra_nix_args,
+        &runner_caps,
       )
       .await
     },
+  };
+
+  // No venue executed the build, so hand it back to the queue. Only remove
+  // the live log when requeuing succeeds, as cancelled or completed builds may
+  // still need it.
+  let result = match result {
+    Ok(Some(r)) => Ok(r),
+    Ok(None) => {
+      match repo::builds::requeue(pool, build.id).await {
+        Ok(Some(_)) => {
+          let _ = tokio::fs::remove_file(&live_log_path).await;
+        },
+        Ok(None) => {
+          tracing::debug!(
+            build_id = %build.id,
+            "build no longer running at requeue (cancelled or completed elsewhere)"
+          );
+        },
+        Err(e) => {
+          tracing::warn!(build_id = %build.id, "Failed to requeue after venue loss: {e}");
+        },
+      }
+      return Ok(());
+    },
+    Err(e) => Err(e),
   };
 
   // Initialize log storage
@@ -1198,7 +1239,8 @@ async fn run_build(
           );
           sqlx::query(
             "UPDATE builds SET status = 'pending', started_at = NULL, \
-             retry_count = retry_count + 1, completed_at = NULL WHERE id = $1",
+             retry_count = retry_count + 1, completed_at = NULL, \
+             effective_features = NULL WHERE id = $1",
           )
           .bind(build.id)
           .execute(pool)

--- a/crates/queue-runner/tests/runner_tests.rs
+++ b/crates/queue-runner/tests/runner_tests.rs
@@ -10,6 +10,10 @@
 
 // Nix log line parsing
 
+use std::sync::Arc;
+
+use circus_queue_runner::caps::RunnerCaps;
+
 #[test]
 fn test_parse_nix_log_start() {
   let line =
@@ -82,8 +86,8 @@ async fn test_worker_pool_drain_stops_dispatch() {
     .await
     .expect("failed to connect");
 
-  let hot_config = std::sync::Arc::new(tokio::sync::RwLock::new(
-    circus_common::config::HotConfig {
+  let hot_config =
+    Arc::new(tokio::sync::RwLock::new(circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
       max_silent_time:      std::time::Duration::ZERO,
@@ -95,8 +99,7 @@ async fn test_worker_pool_drain_stops_dispatch() {
       psi_threshold:        None,
       psi_check_timeout:    std::time::Duration::from_secs(5),
       extra_nix_build_args: Vec::new(),
-    },
-  ));
+    }));
   let worker_pool = circus_queue_runner::worker::WorkerPool::new(
     pool,
     2,
@@ -109,6 +112,11 @@ async fn test_worker_pool_drain_stops_dispatch() {
     circus_common::config::CacheUploadConfig::default(),
     None,
     circus_queue_runner::rpc::AgentPool::new(),
+    Arc::new(RunnerCaps::new(
+      true,
+      vec!["x86_64-linux".into()],
+      Vec::new(),
+    )),
     std::time::Duration::from_mins(1),
   );
 
@@ -124,8 +132,6 @@ async fn test_worker_pool_drain_stops_dispatch() {
 
 #[tokio::test]
 async fn test_active_builds_registry_cancellation() {
-  use std::sync::Arc;
-
   use dashmap::DashMap;
   use tokio_util::sync::CancellationToken;
 
@@ -207,8 +213,8 @@ async fn test_worker_pool_active_builds_cancel() {
     .await
     .expect("failed to connect");
 
-  let hot_config = std::sync::Arc::new(tokio::sync::RwLock::new(
-    circus_common::config::HotConfig {
+  let hot_config =
+    Arc::new(tokio::sync::RwLock::new(circus_common::config::HotConfig {
       poll_interval:        std::time::Duration::from_secs(1),
       build_timeout:        std::time::Duration::from_mins(1),
       max_silent_time:      std::time::Duration::ZERO,
@@ -220,8 +226,7 @@ async fn test_worker_pool_active_builds_cancel() {
       psi_threshold:        None,
       psi_check_timeout:    std::time::Duration::from_secs(5),
       extra_nix_build_args: Vec::new(),
-    },
-  ));
+    }));
   let worker_pool = circus_queue_runner::worker::WorkerPool::new(
     pool,
     2,
@@ -234,6 +239,11 @@ async fn test_worker_pool_active_builds_cancel() {
     circus_common::config::CacheUploadConfig::default(),
     None,
     circus_queue_runner::rpc::AgentPool::new(),
+    Arc::new(RunnerCaps::new(
+      true,
+      vec!["x86_64-linux".into()],
+      Vec::new(),
+    )),
     std::time::Duration::from_mins(1),
   );
 


### PR DESCRIPTION
`required_features` only covers the job's own drv, but the venue realises
the whole unbuilt closure.

Dispatch now dry-runs the drv and schedules on the `requiredSystemFeatures`
union of the will-build set. A build with no capable venue stays pending
instead of crashing.

(Also a small commit beforehand passes `--show-input-drvs` to nix-eval-jobs, see commit msg for why)