### PR TITLE
server: split webhook handlers by forge provider

### DIFF
--- a/crates/server/src/routes/webhooks.rs
+++ b/crates/server/src/routes/webhooks.rs
@@ -1,8 +1,6 @@
 use axum::{
   Json,
   Router,
-  body::Bytes,
-  extract::{Path, State},
   http::{HeaderMap, StatusCode},
   routing::post,
 };
@@ -11,10 +9,18 @@ use circus_common::{
   repo,
 };
 use hmac::KeyInit;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::{error::ApiError, state::AppState};
+
+mod forgejo;
+mod gitea;
+mod gitea_compatible;
+mod github;
+mod gitlab;
+
+#[cfg(test)] mod tests;
 
 #[derive(Debug, Serialize)]
 struct WebhookResponse {
@@ -22,94 +28,24 @@ struct WebhookResponse {
   message:  String,
 }
 
-#[derive(Debug, Deserialize)]
-struct GithubPushPayload {
-  #[serde(alias = "ref")]
-  git_ref:    Option<String>,
-  after:      Option<String>,
-  repository: Option<GithubRepo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GithubRepo {
-  clone_url: Option<String>,
-  html_url:  Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GithubPullRequestPayload {
-  action:       Option<String>,
-  number:       Option<u64>,
-  pull_request: Option<GithubPullRequest>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GithubPullRequest {
-  head:  Option<GithubPrRef>,
-  base:  Option<GithubPrRef>,
-  draft: Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GithubPrRef {
-  sha:      Option<String>,
-  #[serde(alias = "ref")]
-  ref_name: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GiteaPushPayload {
-  #[serde(alias = "ref")]
-  git_ref:    Option<String>,
-  after:      Option<String>,
-  repository: Option<GiteaRepo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GiteaRepo {
-  clone_url: Option<String>,
-  html_url:  Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitLabPushPayload {
-  #[serde(alias = "ref")]
-  git_ref:      Option<String>,
-  after:        Option<String>,
-  checkout_sha: Option<String>,
-  project:      Option<GitLabProject>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitLabProject {
-  id:                  Option<i64>,
-  path_with_namespace: Option<String>,
-  web_url:             Option<String>,
-  git_http_url:        Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitLabMergeRequestPayload {
-  object_kind:       Option<String>,
-  object_attributes: Option<GitLabMergeRequestAttributes>,
-  project:           Option<GitLabProject>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitLabMergeRequestAttributes {
-  iid:              Option<u64>,
-  action:           Option<String>,
-  state:            Option<String>,
-  source_branch:    Option<String>,
-  target_branch:    Option<String>,
-  last_commit:      Option<GitLabCommit>,
-  work_in_progress: Option<bool>,
-  draft:            Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitLabCommit {
-  id: Option<String>,
+pub fn router() -> Router<AppState> {
+  Router::new()
+    .route(
+      "/api/v1/webhooks/{project_id}/github",
+      post(github::handle_webhook),
+    )
+    .route(
+      "/api/v1/webhooks/{project_id}/gitea",
+      post(gitea::handle_webhook),
+    )
+    .route(
+      "/api/v1/webhooks/{project_id}/forgejo",
+      post(forgejo::handle_webhook),
+    )
+    .route(
+      "/api/v1/webhooks/{project_id}/gitlab",
+      post(gitlab::handle_webhook),
+    )
 }
 
 fn trace_webhook_repo(
@@ -125,19 +61,6 @@ fn trace_webhook_repo(
     html_url,
     "webhook payload repository"
   );
-}
-
-fn trace_gitlab_project(project_id: Uuid, project: Option<&GitLabProject>) {
-  if let Some(project) = project {
-    tracing::debug!(
-      %project_id,
-      gitlab_project_id = ?project.id,
-      path_with_namespace = ?project.path_with_namespace,
-      web_url = ?project.web_url,
-      git_http_url = ?project.git_http_url,
-      "GitLab webhook payload project"
-    );
-  }
 }
 
 /// Strip the `refs/heads/` prefix from a git ref. Returns the original
@@ -160,6 +83,93 @@ fn jobset_accepts_source_trigger(jobset: &Jobset) -> bool {
   jobset.enabled && jobset.trigger_mode == JobsetTriggerMode::SourceChange
 }
 
+fn is_deleted_commit(commit: &str) -> bool {
+  commit.is_empty() || commit == "0000000000000000000000000000000000000000"
+}
+
+async fn trigger_push_evaluations(
+  state: &AppState,
+  project_id: Uuid,
+  commit: &str,
+  pushed_branch: &str,
+) -> Result<usize, ApiError> {
+  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
+    .await
+    .map_err(ApiError)?;
+
+  let mut triggered = 0;
+  for jobset in &jobsets {
+    if !jobset_accepts_source_trigger(jobset) {
+      continue;
+    }
+    if !jobset_matches_branch(jobset.branch.as_deref(), pushed_branch) {
+      continue;
+    }
+    match repo::evaluations::create(&state.pool, CreateEvaluation {
+      jobset_id:      jobset.id,
+      commit_hash:    commit.to_string(),
+      pr_number:      None,
+      pr_head_branch: None,
+      pr_base_branch: None,
+      pr_action:      None,
+    })
+    .await
+    {
+      Ok(_) => triggered += 1,
+      Err(circus_common::CiError::Conflict(_)) => {},
+      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
+    }
+  }
+
+  Ok(triggered)
+}
+
+struct ChangeRequestEvaluation {
+  commit:      String,
+  number:      Option<i32>,
+  head_branch: Option<String>,
+  base_branch: Option<String>,
+  action:      Option<String>,
+}
+
+async fn trigger_change_request_evaluations(
+  state: &AppState,
+  project_id: Uuid,
+  input: &ChangeRequestEvaluation,
+) -> Result<usize, ApiError> {
+  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
+    .await
+    .map_err(ApiError)?;
+
+  let base = input.base_branch.as_deref().unwrap_or("");
+
+  let mut triggered = 0;
+  for jobset in &jobsets {
+    if !jobset_accepts_source_trigger(jobset) {
+      continue;
+    }
+    if !jobset_matches_branch(jobset.branch.as_deref(), base) {
+      continue;
+    }
+    match repo::evaluations::create(&state.pool, CreateEvaluation {
+      jobset_id:      jobset.id,
+      commit_hash:    input.commit.clone(),
+      pr_number:      input.number,
+      pr_head_branch: input.head_branch.clone(),
+      pr_base_branch: input.base_branch.clone(),
+      pr_action:      input.action.clone(),
+    })
+    .await
+    {
+      Ok(_) => triggered += 1,
+      Err(circus_common::CiError::Conflict(_)) => {},
+      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
+    }
+  }
+
+  Ok(triggered)
+}
+
 /// Verify HMAC-SHA256 webhook signature.
 /// The `secret` parameter is the raw webhook secret stored in DB.
 fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
@@ -171,7 +181,6 @@ fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
   };
   mac.update(body);
 
-  // Parse the hex signature (strip "sha256=" prefix if present)
   let hex_sig = signature
     .strip_prefix("sha256=")
     .or_else(|| signature.strip_prefix("sha1="))
@@ -184,525 +193,50 @@ fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
   mac.verify_slice(&sig_bytes).is_ok()
 }
 
-async fn handle_github_webhook(
-  State(state): State<AppState>,
-  Path(project_id): Path<Uuid>,
-  headers: HeaderMap,
-  body: Bytes,
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  // Check webhook config exists
-  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
-    &state.pool,
-    project_id,
-    "github",
-  )
-  .await
-  .map_err(ApiError)?;
-
-  let Some(webhook_config) = webhook_config else {
-    return Ok((
-      StatusCode::NOT_FOUND,
-      Json(WebhookResponse {
-        accepted: false,
-        message:  "No GitHub webhook configured for this project".to_string(),
-      }),
-    ));
-  };
-
-  // Verify signature if secret is configured
-  if let Some(ref secret_hash) = webhook_config.secret_hash {
-    let signature = headers
-      .get("x-hub-signature-256")
-      .and_then(|v| v.to_str().ok())
-      .unwrap_or("");
-
-    if !verify_signature(secret_hash, &body, signature) {
-      return Ok((
-        StatusCode::UNAUTHORIZED,
-        Json(WebhookResponse {
-          accepted: false,
-          message:  "Invalid webhook signature".to_string(),
-        }),
-      ));
-    }
-  }
-
-  // Determine event type from X-GitHub-Event header
-  let event_type = headers
-    .get("x-github-event")
+fn header_value<'a>(headers: &'a HeaderMap, name: &'static str) -> &'a str {
+  headers
+    .get(name)
     .and_then(|v| v.to_str().ok())
-    .unwrap_or("");
-
-  match event_type {
-    "push" => handle_github_push(state, project_id, &body).await,
-    "pull_request" => {
-      handle_github_pull_request(state, project_id, &body).await
-    },
-    _ => {
-      Ok((
-        StatusCode::OK,
-        Json(WebhookResponse {
-          accepted: true,
-          message:  format!("Ignored GitHub event: {event_type}"),
-        }),
-      ))
-    },
-  }
+    .unwrap_or("")
 }
 
-async fn handle_github_push(
-  state: AppState,
-  project_id: Uuid,
-  body: &[u8],
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  let payload: GithubPushPayload =
-    serde_json::from_slice(body).map_err(|e| {
-      ApiError(circus_common::CiError::Validation(format!(
-        "Invalid payload: {e}"
-      )))
-    })?;
-  if let Some(repo) = payload.repository.as_ref() {
-    trace_webhook_repo(
-      "github",
-      project_id,
-      repo.clone_url.as_deref(),
-      repo.html_url.as_deref(),
-    );
-  }
-
-  let commit = payload.after.unwrap_or_default();
-  if commit.is_empty() || commit == "0000000000000000000000000000000000000000" {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "Branch deletion event, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
-
-  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
-    .await
-    .map_err(ApiError)?;
-
-  let mut triggered = 0;
-  for jobset in &jobsets {
-    if !jobset_accepts_source_trigger(jobset) {
-      continue;
-    }
-    if !jobset_matches_branch(jobset.branch.as_deref(), pushed_branch) {
-      continue;
-    }
-    match repo::evaluations::create(&state.pool, CreateEvaluation {
-      jobset_id:      jobset.id,
-      commit_hash:    commit.clone(),
-      pr_number:      None,
-      pr_head_branch: None,
-      pr_base_branch: None,
-      pr_action:      None,
-    })
-    .await
-    {
-      Ok(_) => triggered += 1,
-      Err(circus_common::CiError::Conflict(_)) => {}, // already exists
-      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
-    }
-  }
-
-  Ok((
-    StatusCode::OK,
+fn webhook_not_configured(
+  forge_name: &str,
+) -> (StatusCode, Json<WebhookResponse>) {
+  (
+    StatusCode::NOT_FOUND,
     Json(WebhookResponse {
-      accepted: true,
-      message:  format!(
-        "Triggered {triggered} evaluations for commit {commit}"
-      ),
+      accepted: false,
+      message:  format!("No {forge_name} webhook configured for this project"),
     }),
-  ))
-}
-
-async fn handle_github_pull_request(
-  state: AppState,
-  project_id: Uuid,
-  body: &[u8],
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  let payload: GithubPullRequestPayload = serde_json::from_slice(body)
-    .map_err(|e| {
-      ApiError(circus_common::CiError::Validation(format!(
-        "Invalid GitHub PR payload: {e}"
-      )))
-    })?;
-
-  let action = payload.action.as_deref().unwrap_or("");
-
-  // Only trigger on open/synchronize/reopen actions
-  if !matches!(action, "opened" | "synchronize" | "reopened") {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  format!("Ignored PR action: {action}"),
-      }),
-    ));
-  }
-
-  let Some(pr) = payload.pull_request else {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "No pull request data, skipping".to_string(),
-      }),
-    ));
-  };
-
-  // Skip draft PRs
-  if pr.draft.unwrap_or(false) {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "Draft pull request, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let commit = pr
-    .head
-    .as_ref()
-    .and_then(|h| h.sha.clone())
-    .unwrap_or_default();
-  if commit.is_empty() {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "No commit in pull request, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let pr_number = payload.number.map(|n| n as i32);
-  let pr_head_branch = pr.head.as_ref().and_then(|h| h.ref_name.clone());
-  let pr_base_branch = pr.base.as_ref().and_then(|b| b.ref_name.clone());
-  let pr_action = Some(action.to_string());
-
-  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
-    .await
-    .map_err(ApiError)?;
-
-  let base = pr_base_branch.as_deref().unwrap_or("");
-
-  let mut triggered = 0;
-  for jobset in &jobsets {
-    if !jobset_accepts_source_trigger(jobset) {
-      continue;
-    }
-    // PR builds against the merge target. Only fire jobsets that track
-    // (or are untargetted to) the PR's base branch.
-    if !jobset_matches_branch(jobset.branch.as_deref(), base) {
-      continue;
-    }
-    match repo::evaluations::create(&state.pool, CreateEvaluation {
-      jobset_id: jobset.id,
-      commit_hash: commit.clone(),
-      pr_number,
-      pr_head_branch: pr_head_branch.clone(),
-      pr_base_branch: pr_base_branch.clone(),
-      pr_action: pr_action.clone(),
-    })
-    .await
-    {
-      Ok(_) => triggered += 1,
-      Err(circus_common::CiError::Conflict(_)) => {},
-      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
-    }
-  }
-
-  let pr_num = payload.number.unwrap_or(0);
-  Ok((
-    StatusCode::OK,
-    Json(WebhookResponse {
-      accepted: true,
-      message:  format!(
-        "Triggered {triggered} evaluations for PR #{pr_num} commit {commit}"
-      ),
-    }),
-  ))
-}
-
-async fn handle_gitea_push(
-  State(state): State<AppState>,
-  Path(project_id): Path<Uuid>,
-  headers: HeaderMap,
-  body: Bytes,
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  // Check webhook config exists
-  let forge_type = if headers.get("x-forgejo-event").is_some() {
-    "forgejo"
-  } else {
-    "gitea"
-  };
-
-  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
-    &state.pool,
-    project_id,
-    forge_type,
   )
-  .await
-  .map_err(ApiError)?;
-
-  // Fall back to the other type if not found
-  let webhook_config = if let Some(c) = webhook_config {
-    c
-  } else {
-    let alt = if forge_type == "gitea" {
-      "forgejo"
-    } else {
-      "gitea"
-    };
-    match repo::webhook_configs::get_by_project_and_forge(
-      &state.pool,
-      project_id,
-      alt,
-    )
-    .await
-    .map_err(ApiError)?
-    {
-      Some(c) => c,
-      None => {
-        return Ok((
-          StatusCode::NOT_FOUND,
-          Json(WebhookResponse {
-            accepted: false,
-            message:  "No Gitea/Forgejo webhook configured for this project"
-              .to_string(),
-          }),
-        ));
-      },
-    }
-  };
-
-  // Verify signature if configured
-  if let Some(ref secret_hash) = webhook_config.secret_hash {
-    let signature = headers
-      .get("x-gitea-signature")
-      .or_else(|| headers.get("x-forgejo-signature"))
-      .and_then(|v| v.to_str().ok())
-      .unwrap_or("");
-
-    if !verify_signature(secret_hash, &body, signature) {
-      return Ok((
-        StatusCode::UNAUTHORIZED,
-        Json(WebhookResponse {
-          accepted: false,
-          message:  "Invalid webhook signature".to_string(),
-        }),
-      ));
-    }
-  }
-
-  let payload: GiteaPushPayload =
-    serde_json::from_slice(&body).map_err(|e| {
-      ApiError(circus_common::CiError::Validation(format!(
-        "Invalid payload: {e}"
-      )))
-    })?;
-  if let Some(repo) = payload.repository.as_ref() {
-    trace_webhook_repo(
-      forge_type,
-      project_id,
-      repo.clone_url.as_deref(),
-      repo.html_url.as_deref(),
-    );
-  }
-
-  let commit = payload.after.unwrap_or_default();
-  if commit.is_empty() || commit == "0000000000000000000000000000000000000000" {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "Branch deletion event, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
-
-  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
-    .await
-    .map_err(ApiError)?;
-
-  let mut triggered = 0;
-  for jobset in &jobsets {
-    if !jobset_accepts_source_trigger(jobset) {
-      continue;
-    }
-    if !jobset_matches_branch(jobset.branch.as_deref(), pushed_branch) {
-      continue;
-    }
-    match repo::evaluations::create(&state.pool, CreateEvaluation {
-      jobset_id:      jobset.id,
-      commit_hash:    commit.clone(),
-      pr_number:      None,
-      pr_head_branch: None,
-      pr_base_branch: None,
-      pr_action:      None,
-    })
-    .await
-    {
-      Ok(_) => triggered += 1,
-      Err(circus_common::CiError::Conflict(_)) => {},
-      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
-    }
-  }
-
-  Ok((
-    StatusCode::OK,
-    Json(WebhookResponse {
-      accepted: true,
-      message:  format!(
-        "Triggered {triggered} evaluations for commit {commit}"
-      ),
-    }),
-  ))
 }
 
-async fn handle_gitlab_webhook(
-  State(state): State<AppState>,
-  Path(project_id): Path<Uuid>,
-  headers: HeaderMap,
-  body: Bytes,
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  use subtle::ConstantTimeEq;
-
-  // Check webhook config exists
-  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
-    &state.pool,
-    project_id,
-    "gitlab",
+fn invalid_signature_response() -> (StatusCode, Json<WebhookResponse>) {
+  (
+    StatusCode::UNAUTHORIZED,
+    Json(WebhookResponse {
+      accepted: false,
+      message:  "Invalid webhook signature".to_string(),
+    }),
   )
-  .await
-  .map_err(ApiError)?;
-
-  let Some(webhook_config) = webhook_config else {
-    return Ok((
-      StatusCode::NOT_FOUND,
-      Json(WebhookResponse {
-        accepted: false,
-        message:  "No GitLab webhook configured for this project".to_string(),
-      }),
-    ));
-  };
-
-  // Verify token if secret is configured
-  // GitLab uses X-Gitlab-Token header with plain token (not HMAC)
-  if let Some(ref secret) = webhook_config.secret_hash {
-    let token = headers
-      .get("x-gitlab-token")
-      .and_then(|v| v.to_str().ok())
-      .unwrap_or("");
-
-    // Use constant-time comparison to prevent timing attacks
-    let token_matches = token.len() == secret.len()
-      && token.as_bytes().ct_eq(secret.as_bytes()).into();
-
-    if !token_matches {
-      return Ok((
-        StatusCode::UNAUTHORIZED,
-        Json(WebhookResponse {
-          accepted: false,
-          message:  "Invalid webhook token".to_string(),
-        }),
-      ));
-    }
-  }
-
-  // Determine event type from X-Gitlab-Event header
-  let event_type = headers
-    .get("x-gitlab-event")
-    .and_then(|v| v.to_str().ok())
-    .unwrap_or("");
-
-  match event_type {
-    "Push Hook" => handle_gitlab_push(state, project_id, &body).await,
-    "Merge Request Hook" => {
-      handle_gitlab_merge_request(state, project_id, &body).await
-    },
-    _ => {
-      Ok((
-        StatusCode::OK,
-        Json(WebhookResponse {
-          accepted: true,
-          message:  format!("Ignored GitLab event: {event_type}"),
-        }),
-      ))
-    },
-  }
 }
 
-async fn handle_gitlab_push(
-  state: AppState,
-  project_id: Uuid,
-  body: &[u8],
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  let payload: GitLabPushPayload =
-    serde_json::from_slice(body).map_err(|e| {
-      ApiError(circus_common::CiError::Validation(format!(
-        "Invalid GitLab push payload: {e}"
-      )))
-    })?;
-  trace_gitlab_project(project_id, payload.project.as_ref());
+fn branch_deletion_response() -> (StatusCode, Json<WebhookResponse>) {
+  (
+    StatusCode::OK,
+    Json(WebhookResponse {
+      accepted: true,
+      message:  "Branch deletion event, skipping".to_string(),
+    }),
+  )
+}
 
-  // Use checkout_sha (the actual commit checked out) or fall back to after
-  let commit = payload.checkout_sha.or(payload.after).unwrap_or_default();
-
-  if commit.is_empty() || commit == "0000000000000000000000000000000000000000" {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "Branch deletion event, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
-
-  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
-    .await
-    .map_err(ApiError)?;
-
-  let mut triggered = 0;
-  for jobset in &jobsets {
-    if !jobset_accepts_source_trigger(jobset) {
-      continue;
-    }
-    if !jobset_matches_branch(jobset.branch.as_deref(), pushed_branch) {
-      continue;
-    }
-    match repo::evaluations::create(&state.pool, CreateEvaluation {
-      jobset_id:      jobset.id,
-      commit_hash:    commit.clone(),
-      pr_number:      None,
-      pr_head_branch: None,
-      pr_base_branch: None,
-      pr_action:      None,
-    })
-    .await
-    {
-      Ok(_) => triggered += 1,
-      Err(circus_common::CiError::Conflict(_)) => {},
-      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
-    }
-  }
-
-  Ok((
+fn triggered_push_response(
+  triggered: usize,
+  commit: &str,
+) -> (StatusCode, Json<WebhookResponse>) {
+  (
     StatusCode::OK,
     Json(WebhookResponse {
       accepted: true,
@@ -710,364 +244,5 @@ async fn handle_gitlab_push(
         "Triggered {triggered} evaluations for commit {commit}"
       ),
     }),
-  ))
-}
-
-async fn handle_gitlab_merge_request(
-  state: AppState,
-  project_id: Uuid,
-  body: &[u8],
-) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
-  let payload: GitLabMergeRequestPayload = serde_json::from_slice(body)
-    .map_err(|e| {
-      ApiError(circus_common::CiError::Validation(format!(
-        "Invalid GitLab MR payload: {e}"
-      )))
-    })?;
-  trace_gitlab_project(project_id, payload.project.as_ref());
-
-  if let Some(kind) = payload.object_kind.as_deref()
-    && kind != "merge_request"
-  {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  format!("Ignored GitLab object kind: {kind}"),
-      }),
-    ));
-  }
-
-  let Some(attrs) = payload.object_attributes else {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "No merge request attributes, skipping".to_string(),
-      }),
-    ));
-  };
-
-  // Skip draft/WIP merge requests
-  if attrs.work_in_progress.unwrap_or(false) || attrs.draft.unwrap_or(false) {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "Draft/WIP merge request, skipping".to_string(),
-      }),
-    ));
-  }
-
-  if let Some(state) = attrs.state.as_deref()
-    && state != "opened"
-  {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  format!("Ignored MR state: {state}"),
-      }),
-    ));
-  }
-
-  // Only trigger on open/update/reopen actions
-  let action = attrs.action.as_deref().unwrap_or("");
-  if !matches!(action, "open" | "update" | "reopen") {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  format!("Ignored MR action: {action}"),
-      }),
-    ));
-  }
-
-  // Get the commit from the last commit in the MR
-  let commit = attrs.last_commit.and_then(|c| c.id).unwrap_or_default();
-
-  if commit.is_empty() {
-    return Ok((
-      StatusCode::OK,
-      Json(WebhookResponse {
-        accepted: true,
-        message:  "No commit in merge request, skipping".to_string(),
-      }),
-    ));
-  }
-
-  let pr_number = attrs.iid.map(|n| n as i32);
-  let pr_head_branch = attrs.source_branch.clone();
-  let pr_base_branch = attrs.target_branch.clone();
-  let pr_action = Some(action.to_string());
-
-  let jobsets = repo::jobsets::list_all_for_project(&state.pool, project_id)
-    .await
-    .map_err(ApiError)?;
-
-  let base = pr_base_branch.as_deref().unwrap_or("");
-
-  let mut triggered = 0;
-  for jobset in &jobsets {
-    if !jobset_accepts_source_trigger(jobset) {
-      continue;
-    }
-    if !jobset_matches_branch(jobset.branch.as_deref(), base) {
-      continue;
-    }
-    match repo::evaluations::create(&state.pool, CreateEvaluation {
-      jobset_id: jobset.id,
-      commit_hash: commit.clone(),
-      pr_number,
-      pr_head_branch: pr_head_branch.clone(),
-      pr_base_branch: pr_base_branch.clone(),
-      pr_action: pr_action.clone(),
-    })
-    .await
-    {
-      Ok(_) => triggered += 1,
-      Err(circus_common::CiError::Conflict(_)) => {},
-      Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
-    }
-  }
-
-  let mr_iid = pr_number.unwrap_or(0);
-  Ok((
-    StatusCode::OK,
-    Json(WebhookResponse {
-      accepted: true,
-      message:  format!(
-        "Triggered {triggered} evaluations for MR !{mr_iid} commit {commit}"
-      ),
-    }),
-  ))
-}
-
-pub fn router() -> Router<AppState> {
-  Router::new()
-    .route(
-      "/api/v1/webhooks/{project_id}/github",
-      post(handle_github_webhook),
-    )
-    .route(
-      "/api/v1/webhooks/{project_id}/gitea",
-      post(handle_gitea_push),
-    )
-    .route(
-      "/api/v1/webhooks/{project_id}/forgejo",
-      post(handle_gitea_push),
-    )
-    .route(
-      "/api/v1/webhooks/{project_id}/gitlab",
-      post(handle_gitlab_webhook),
-    )
-}
-
-#[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "Fine in tests")]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn test_verify_signature_valid() {
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-
-    let secret = "test-secret";
-    let body = b"test-body";
-
-    // Compute expected signature
-    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
-    mac.update(body);
-    let expected = hex::encode(mac.finalize().into_bytes());
-
-    assert!(verify_signature(
-      secret,
-      body,
-      &format!("sha256={expected}")
-    ));
-  }
-
-  #[test]
-  fn test_verify_signature_invalid() {
-    let secret = "test-secret";
-    let body = b"test-body";
-    assert!(!verify_signature(secret, body, "sha256=invalidsignature"));
-  }
-
-  #[test]
-  fn test_verify_signature_wrong_secret() {
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-
-    let body = b"test-body";
-    let mut mac = Hmac::<Sha256>::new_from_slice(b"secret1").unwrap();
-    mac.update(body);
-    let sig = hex::encode(mac.finalize().into_bytes());
-
-    // Verify with different secret should fail
-    assert!(!verify_signature("secret2", body, &format!("sha256={sig}")));
-  }
-
-  #[test]
-  fn test_parse_github_push_payload() {
-    let payload = r#"{
-      "ref": "refs/heads/main",
-      "after": "abc123def456789012345678901234567890abcd"
-    }"#;
-
-    let parsed: GithubPushPayload = serde_json::from_str(payload).unwrap();
-    assert_eq!(
-      parsed.after,
-      Some("abc123def456789012345678901234567890abcd".to_string())
-    );
-    assert_eq!(parsed.git_ref, Some("refs/heads/main".to_string()));
-  }
-
-  #[test]
-  fn test_parse_github_pr_payload() {
-    let payload = r#"{
-      "action": "opened",
-      "number": 42,
-      "pull_request": {
-        "head": {"sha": "abc123", "ref": "feature-branch"},
-        "base": {"sha": "def456", "ref": "main"},
-        "draft": false
-      }
-    }"#;
-
-    let parsed: GithubPullRequestPayload =
-      serde_json::from_str(payload).unwrap();
-    assert_eq!(parsed.action, Some("opened".to_string()));
-    assert_eq!(parsed.number, Some(42));
-
-    let pr = parsed.pull_request.unwrap();
-    assert_eq!(pr.draft, Some(false));
-    assert_eq!(
-      pr.head.as_ref().and_then(|h| h.sha.clone()),
-      Some("abc123".to_string())
-    );
-    assert_eq!(
-      pr.head.as_ref().and_then(|h| h.ref_name.clone()),
-      Some("feature-branch".to_string())
-    );
-  }
-
-  #[test]
-  fn test_parse_github_pr_draft() {
-    let payload = r#"{
-      "action": "opened",
-      "number": 99,
-      "pull_request": {
-        "head": {"sha": "abc123", "ref": "draft-branch"},
-        "base": {"sha": "def456", "ref": "main"},
-        "draft": true
-      }
-    }"#;
-
-    let parsed: GithubPullRequestPayload =
-      serde_json::from_str(payload).unwrap();
-    let pr = parsed.pull_request.unwrap();
-    assert_eq!(pr.draft, Some(true));
-  }
-
-  #[test]
-  fn test_parse_gitlab_push_payload() {
-    let payload = r#"{
-      "ref": "refs/heads/main",
-      "after": "abc123",
-      "checkout_sha": "def456789012345678901234567890abcdef12"
-    }"#;
-
-    let parsed: GitLabPushPayload = serde_json::from_str(payload).unwrap();
-    assert_eq!(
-      parsed.checkout_sha,
-      Some("def456789012345678901234567890abcdef12".to_string())
-    );
-    assert_eq!(parsed.after, Some("abc123".to_string()));
-  }
-
-  #[test]
-  fn test_parse_gitlab_mr_payload() {
-    let payload = r#"{
-      "object_kind": "merge_request",
-      "object_attributes": {
-        "iid": 123,
-        "action": "open",
-        "source_branch": "feature",
-        "target_branch": "main",
-        "last_commit": {"id": "abc123def456"},
-        "draft": false,
-        "work_in_progress": false
-      }
-    }"#;
-
-    let parsed: GitLabMergeRequestPayload =
-      serde_json::from_str(payload).unwrap();
-    let attrs = parsed.object_attributes.unwrap();
-    assert_eq!(attrs.iid, Some(123));
-    assert_eq!(attrs.action, Some("open".to_string()));
-    assert_eq!(attrs.source_branch, Some("feature".to_string()));
-    assert_eq!(attrs.target_branch, Some("main".to_string()));
-    assert_eq!(attrs.draft, Some(false));
-    assert_eq!(attrs.work_in_progress, Some(false));
-  }
-
-  #[test]
-  fn test_parse_gitlab_mr_draft() {
-    let payload = r#"{
-      "object_kind": "merge_request",
-      "object_attributes": {
-        "iid": 999,
-        "action": "open",
-        "draft": true
-      }
-    }"#;
-
-    let parsed: GitLabMergeRequestPayload =
-      serde_json::from_str(payload).unwrap();
-    let attrs = parsed.object_attributes.unwrap();
-    assert_eq!(attrs.draft, Some(true));
-  }
-
-  #[test]
-  fn test_parse_gitlab_mr_wip() {
-    let payload = r#"{
-      "object_kind": "merge_request",
-      "object_attributes": {
-        "iid": 888,
-        "action": "open",
-        "work_in_progress": true
-      }
-    }"#;
-
-    let parsed: GitLabMergeRequestPayload =
-      serde_json::from_str(payload).unwrap();
-    let attrs = parsed.object_attributes.unwrap();
-    assert_eq!(attrs.work_in_progress, Some(true));
-  }
-
-  #[test]
-  fn test_parse_gitea_push_payload() {
-    let payload = r#"{
-      "ref": "refs/heads/main",
-      "after": "abc123def456789012345678901234567890abcd"
-    }"#;
-
-    let parsed: GiteaPushPayload = serde_json::from_str(payload).unwrap();
-    assert_eq!(
-      parsed.after,
-      Some("abc123def456789012345678901234567890abcd".to_string())
-    );
-    assert_eq!(parsed.git_ref, Some("refs/heads/main".to_string()));
-  }
-
-  #[test]
-  fn test_branch_deletion_detection() {
-    // The null SHA indicates branch deletion
-    let commit = "0000000000000000000000000000000000000000";
-    assert!(
-      commit.is_empty() || commit == "0000000000000000000000000000000000000000"
-    );
-  }
+  )
 }

--- a/crates/server/src/routes/webhooks/forgejo.rs
+++ b/crates/server/src/routes/webhooks/forgejo.rs
@@ -1,0 +1,29 @@
+use axum::{
+  Json,
+  body::Bytes,
+  extract::{Path, State},
+  http::{HeaderMap, StatusCode},
+};
+use uuid::Uuid;
+
+use super::{WebhookResponse, gitea_compatible};
+use crate::{error::ApiError, state::AppState};
+
+pub(super) const PROVIDER: gitea_compatible::SignedPushProvider =
+  gitea_compatible::SignedPushProvider::new(
+    "forgejo",
+    "Forgejo",
+    "x-forgejo-signature",
+  );
+
+pub(super) async fn handle_webhook(
+  State(state): State<AppState>,
+  Path(project_id): Path<Uuid>,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  gitea_compatible::handle_signed_push(
+    PROVIDER, state, project_id, headers, body,
+  )
+  .await
+}

--- a/crates/server/src/routes/webhooks/gitea.rs
+++ b/crates/server/src/routes/webhooks/gitea.rs
@@ -1,0 +1,29 @@
+use axum::{
+  Json,
+  body::Bytes,
+  extract::{Path, State},
+  http::{HeaderMap, StatusCode},
+};
+use uuid::Uuid;
+
+use super::{WebhookResponse, gitea_compatible};
+use crate::{error::ApiError, state::AppState};
+
+pub(super) const PROVIDER: gitea_compatible::SignedPushProvider =
+  gitea_compatible::SignedPushProvider::new(
+    "gitea",
+    "Gitea",
+    "x-gitea-signature",
+  );
+
+pub(super) async fn handle_webhook(
+  State(state): State<AppState>,
+  Path(project_id): Path<Uuid>,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  gitea_compatible::handle_signed_push(
+    PROVIDER, state, project_id, headers, body,
+  )
+  .await
+}

--- a/crates/server/src/routes/webhooks/gitea_compatible.rs
+++ b/crates/server/src/routes/webhooks/gitea_compatible.rs
@@ -1,0 +1,155 @@
+use axum::{
+  Json,
+  body::Bytes,
+  http::{HeaderMap, StatusCode},
+};
+use circus_common::repo;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{
+  WebhookResponse,
+  branch_deletion_response,
+  header_value,
+  invalid_signature_response,
+  is_deleted_commit,
+  strip_branch_prefix,
+  trace_webhook_repo,
+  trigger_push_evaluations,
+  triggered_push_response,
+  verify_signature,
+  webhook_not_configured,
+};
+use crate::{error::ApiError, state::AppState};
+
+#[derive(Clone, Copy)]
+pub(super) struct SignedPushProvider {
+  config_type:      &'static str,
+  display_name:     &'static str,
+  signature_header: &'static str,
+}
+
+impl SignedPushProvider {
+  pub(super) const fn new(
+    config_type: &'static str,
+    display_name: &'static str,
+    signature_header: &'static str,
+  ) -> Self {
+    Self {
+      config_type,
+      display_name,
+      signature_header,
+    }
+  }
+
+  pub(super) fn is_signature_valid(
+    self,
+    headers: &HeaderMap,
+    body: &[u8],
+    secret: &str,
+  ) -> bool {
+    let signature = header_value(headers, self.signature_header);
+    verify_signature(secret, body, signature)
+  }
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaCompatiblePushPayload {
+  #[serde(alias = "ref")]
+  git_ref:    Option<String>,
+  after:      Option<String>,
+  repository: Option<GiteaCompatibleRepo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaCompatibleRepo {
+  clone_url: Option<String>,
+  html_url:  Option<String>,
+}
+
+pub(super) async fn handle_signed_push(
+  provider: SignedPushProvider,
+  state: AppState,
+  project_id: Uuid,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
+    &state.pool,
+    project_id,
+    provider.config_type,
+  )
+  .await
+  .map_err(ApiError)?;
+
+  let Some(webhook_config) = webhook_config else {
+    return Ok(webhook_not_configured(provider.display_name));
+  };
+
+  if let Some(ref secret_hash) = webhook_config.secret_hash
+    && !provider.is_signature_valid(&headers, &body, secret_hash)
+  {
+    return Ok(invalid_signature_response());
+  }
+
+  process_push(state, project_id, provider.config_type, body).await
+}
+
+async fn process_push(
+  state: AppState,
+  project_id: Uuid,
+  forge_type: &'static str,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let payload: GiteaCompatiblePushPayload = serde_json::from_slice(&body)
+    .map_err(|e| {
+      ApiError(circus_common::CiError::Validation(format!(
+        "Invalid payload: {e}"
+      )))
+    })?;
+  if let Some(repo) = payload.repository.as_ref() {
+    trace_webhook_repo(
+      forge_type,
+      project_id,
+      repo.clone_url.as_deref(),
+      repo.html_url.as_deref(),
+    );
+  }
+
+  let commit = payload.after.unwrap_or_default();
+  if is_deleted_commit(&commit) {
+    return Ok(branch_deletion_response());
+  }
+
+  let pushed_branch =
+    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+
+  let triggered =
+    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
+      .await?;
+
+  Ok(triggered_push_response(triggered, &commit))
+}
+
+#[cfg(test)]
+mod tests {
+  #![expect(clippy::unwrap_used, reason = "Fine in tests")]
+
+  use super::*;
+
+  #[test]
+  fn test_parse_gitea_compatible_push_payload() {
+    let payload = r#"{
+      "ref": "refs/heads/main",
+      "after": "abc123def456789012345678901234567890abcd"
+    }"#;
+
+    let parsed: GiteaCompatiblePushPayload =
+      serde_json::from_str(payload).unwrap();
+    assert_eq!(
+      parsed.after,
+      Some("abc123def456789012345678901234567890abcd".to_string())
+    );
+    assert_eq!(parsed.git_ref, Some("refs/heads/main".to_string()));
+  }
+}

--- a/crates/server/src/routes/webhooks/github.rs
+++ b/crates/server/src/routes/webhooks/github.rs
@@ -1,0 +1,301 @@
+use axum::{
+  Json,
+  body::Bytes,
+  extract::{Path, State},
+  http::{HeaderMap, StatusCode},
+};
+use circus_common::repo;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{
+  ChangeRequestEvaluation,
+  WebhookResponse,
+  branch_deletion_response,
+  header_value,
+  invalid_signature_response,
+  is_deleted_commit,
+  strip_branch_prefix,
+  trace_webhook_repo,
+  trigger_change_request_evaluations,
+  trigger_push_evaluations,
+  triggered_push_response,
+  verify_signature,
+  webhook_not_configured,
+};
+use crate::{error::ApiError, state::AppState};
+
+const CONFIG_TYPE: &str = "github";
+const DISPLAY_NAME: &str = "GitHub";
+const SIGNATURE_HEADER: &str = "x-hub-signature-256";
+const EVENT_HEADER: &str = "x-github-event";
+
+#[derive(Debug, Deserialize)]
+struct GithubPushPayload {
+  #[serde(alias = "ref")]
+  git_ref:    Option<String>,
+  after:      Option<String>,
+  repository: Option<GithubRepo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRepo {
+  clone_url: Option<String>,
+  html_url:  Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubPullRequestPayload {
+  action:       Option<String>,
+  number:       Option<u64>,
+  pull_request: Option<GithubPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubPullRequest {
+  head:  Option<GithubPrRef>,
+  base:  Option<GithubPrRef>,
+  draft: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubPrRef {
+  sha:      Option<String>,
+  #[serde(alias = "ref")]
+  ref_name: Option<String>,
+}
+
+pub(super) async fn handle_webhook(
+  State(state): State<AppState>,
+  Path(project_id): Path<Uuid>,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
+    &state.pool,
+    project_id,
+    CONFIG_TYPE,
+  )
+  .await
+  .map_err(ApiError)?;
+
+  let Some(webhook_config) = webhook_config else {
+    return Ok(webhook_not_configured(DISPLAY_NAME));
+  };
+
+  if let Some(ref secret_hash) = webhook_config.secret_hash {
+    let signature = header_value(&headers, SIGNATURE_HEADER);
+    if !verify_signature(secret_hash, &body, signature) {
+      return Ok(invalid_signature_response());
+    }
+  }
+
+  let event_type = header_value(&headers, EVENT_HEADER);
+
+  match event_type {
+    "push" => handle_push(state, project_id, &body).await,
+    "pull_request" => handle_pull_request(state, project_id, &body).await,
+    _ => {
+      Ok((
+        StatusCode::OK,
+        Json(WebhookResponse {
+          accepted: true,
+          message:  format!("Ignored GitHub event: {event_type}"),
+        }),
+      ))
+    },
+  }
+}
+
+async fn handle_push(
+  state: AppState,
+  project_id: Uuid,
+  body: &[u8],
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let payload: GithubPushPayload =
+    serde_json::from_slice(body).map_err(|e| {
+      ApiError(circus_common::CiError::Validation(format!(
+        "Invalid payload: {e}"
+      )))
+    })?;
+  if let Some(repo) = payload.repository.as_ref() {
+    trace_webhook_repo(
+      CONFIG_TYPE,
+      project_id,
+      repo.clone_url.as_deref(),
+      repo.html_url.as_deref(),
+    );
+  }
+
+  let commit = payload.after.unwrap_or_default();
+  if is_deleted_commit(&commit) {
+    return Ok(branch_deletion_response());
+  }
+
+  let pushed_branch =
+    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+
+  let triggered =
+    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
+      .await?;
+
+  Ok(triggered_push_response(triggered, &commit))
+}
+
+async fn handle_pull_request(
+  state: AppState,
+  project_id: Uuid,
+  body: &[u8],
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let payload: GithubPullRequestPayload = serde_json::from_slice(body)
+    .map_err(|e| {
+      ApiError(circus_common::CiError::Validation(format!(
+        "Invalid GitHub PR payload: {e}"
+      )))
+    })?;
+
+  let action = payload.action.as_deref().unwrap_or("");
+
+  if !matches!(action, "opened" | "synchronize" | "reopened") {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  format!("Ignored PR action: {action}"),
+      }),
+    ));
+  }
+
+  let Some(pr) = payload.pull_request else {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "No pull request data, skipping".to_string(),
+      }),
+    ));
+  };
+
+  if pr.draft.unwrap_or(false) {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "Draft pull request, skipping".to_string(),
+      }),
+    ));
+  }
+
+  let commit = pr
+    .head
+    .as_ref()
+    .and_then(|h| h.sha.clone())
+    .unwrap_or_default();
+  if commit.is_empty() {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "No commit in pull request, skipping".to_string(),
+      }),
+    ));
+  }
+
+  let pr_number = payload.number.map(|n| n as i32);
+  let pr_head_branch = pr.head.as_ref().and_then(|h| h.ref_name.clone());
+  let pr_base_branch = pr.base.as_ref().and_then(|b| b.ref_name.clone());
+  let pr_action = Some(action.to_string());
+
+  let triggered = trigger_change_request_evaluations(
+    &state,
+    project_id,
+    &ChangeRequestEvaluation {
+      commit:      commit.clone(),
+      number:      pr_number,
+      head_branch: pr_head_branch,
+      base_branch: pr_base_branch,
+      action:      pr_action,
+    },
+  )
+  .await?;
+
+  let pr_num = payload.number.unwrap_or(0);
+  Ok((
+    StatusCode::OK,
+    Json(WebhookResponse {
+      accepted: true,
+      message:  format!(
+        "Triggered {triggered} evaluations for PR #{pr_num} commit {commit}"
+      ),
+    }),
+  ))
+}
+
+#[cfg(test)]
+mod tests {
+  #![expect(clippy::unwrap_used, reason = "Fine in tests")]
+
+  use super::*;
+
+  #[test]
+  fn test_parse_github_push_payload() {
+    let payload = r#"{
+      "ref": "refs/heads/main",
+      "after": "abc123def456789012345678901234567890abcd"
+    }"#;
+
+    let parsed: GithubPushPayload = serde_json::from_str(payload).unwrap();
+    assert_eq!(
+      parsed.after,
+      Some("abc123def456789012345678901234567890abcd".to_string())
+    );
+    assert_eq!(parsed.git_ref, Some("refs/heads/main".to_string()));
+  }
+
+  #[test]
+  fn test_parse_github_pr_payload() {
+    let payload = r#"{
+      "action": "opened",
+      "number": 42,
+      "pull_request": {
+        "head": {"sha": "abc123", "ref": "feature-branch"},
+        "base": {"sha": "def456", "ref": "main"},
+        "draft": false
+      }
+    }"#;
+
+    let parsed: GithubPullRequestPayload =
+      serde_json::from_str(payload).unwrap();
+    assert_eq!(parsed.action, Some("opened".to_string()));
+    assert_eq!(parsed.number, Some(42));
+
+    let pr = parsed.pull_request.unwrap();
+    assert_eq!(pr.draft, Some(false));
+    assert_eq!(
+      pr.head.as_ref().and_then(|h| h.sha.clone()),
+      Some("abc123".to_string())
+    );
+    assert_eq!(
+      pr.head.as_ref().and_then(|h| h.ref_name.clone()),
+      Some("feature-branch".to_string())
+    );
+  }
+
+  #[test]
+  fn test_parse_github_pr_draft() {
+    let payload = r#"{
+      "action": "opened",
+      "number": 99,
+      "pull_request": {
+        "head": {"sha": "abc123", "ref": "draft-branch"},
+        "base": {"sha": "def456", "ref": "main"},
+        "draft": true
+      }
+    }"#;
+
+    let parsed: GithubPullRequestPayload =
+      serde_json::from_str(payload).unwrap();
+    let pr = parsed.pull_request.unwrap();
+    assert_eq!(pr.draft, Some(true));
+  }
+}

--- a/crates/server/src/routes/webhooks/gitlab.rs
+++ b/crates/server/src/routes/webhooks/gitlab.rs
@@ -1,0 +1,359 @@
+use axum::{
+  Json,
+  body::Bytes,
+  extract::{Path, State},
+  http::{HeaderMap, StatusCode},
+};
+use circus_common::repo;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{
+  ChangeRequestEvaluation,
+  WebhookResponse,
+  branch_deletion_response,
+  header_value,
+  is_deleted_commit,
+  strip_branch_prefix,
+  trigger_change_request_evaluations,
+  trigger_push_evaluations,
+  triggered_push_response,
+  webhook_not_configured,
+};
+use crate::{error::ApiError, state::AppState};
+
+const CONFIG_TYPE: &str = "gitlab";
+const DISPLAY_NAME: &str = "GitLab";
+const TOKEN_HEADER: &str = "x-gitlab-token";
+const EVENT_HEADER: &str = "x-gitlab-event";
+
+#[derive(Debug, Deserialize)]
+struct GitLabPushPayload {
+  #[serde(alias = "ref")]
+  git_ref:      Option<String>,
+  after:        Option<String>,
+  checkout_sha: Option<String>,
+  project:      Option<GitLabProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabProject {
+  id:                  Option<i64>,
+  path_with_namespace: Option<String>,
+  web_url:             Option<String>,
+  git_http_url:        Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabMergeRequestPayload {
+  object_kind:       Option<String>,
+  object_attributes: Option<GitLabMergeRequestAttributes>,
+  project:           Option<GitLabProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabMergeRequestAttributes {
+  iid:              Option<u64>,
+  action:           Option<String>,
+  state:            Option<String>,
+  source_branch:    Option<String>,
+  target_branch:    Option<String>,
+  last_commit:      Option<GitLabCommit>,
+  work_in_progress: Option<bool>,
+  draft:            Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabCommit {
+  id: Option<String>,
+}
+
+pub(super) async fn handle_webhook(
+  State(state): State<AppState>,
+  Path(project_id): Path<Uuid>,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  use subtle::ConstantTimeEq;
+
+  let webhook_config = repo::webhook_configs::get_by_project_and_forge(
+    &state.pool,
+    project_id,
+    CONFIG_TYPE,
+  )
+  .await
+  .map_err(ApiError)?;
+
+  let Some(webhook_config) = webhook_config else {
+    return Ok(webhook_not_configured(DISPLAY_NAME));
+  };
+
+  if let Some(ref secret) = webhook_config.secret_hash {
+    let token = header_value(&headers, TOKEN_HEADER);
+    let token_matches = token.len() == secret.len()
+      && token.as_bytes().ct_eq(secret.as_bytes()).into();
+
+    if !token_matches {
+      return Ok((
+        StatusCode::UNAUTHORIZED,
+        Json(WebhookResponse {
+          accepted: false,
+          message:  "Invalid webhook token".to_string(),
+        }),
+      ));
+    }
+  }
+
+  let event_type = header_value(&headers, EVENT_HEADER);
+
+  match event_type {
+    "Push Hook" => handle_push(state, project_id, &body).await,
+    "Merge Request Hook" => {
+      handle_merge_request(state, project_id, &body).await
+    },
+    _ => {
+      Ok((
+        StatusCode::OK,
+        Json(WebhookResponse {
+          accepted: true,
+          message:  format!("Ignored GitLab event: {event_type}"),
+        }),
+      ))
+    },
+  }
+}
+
+async fn handle_push(
+  state: AppState,
+  project_id: Uuid,
+  body: &[u8],
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let payload: GitLabPushPayload =
+    serde_json::from_slice(body).map_err(|e| {
+      ApiError(circus_common::CiError::Validation(format!(
+        "Invalid GitLab push payload: {e}"
+      )))
+    })?;
+  trace_project(project_id, payload.project.as_ref());
+
+  let commit = payload.checkout_sha.or(payload.after).unwrap_or_default();
+
+  if is_deleted_commit(&commit) {
+    return Ok(branch_deletion_response());
+  }
+
+  let pushed_branch =
+    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+
+  let triggered =
+    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
+      .await?;
+
+  Ok(triggered_push_response(triggered, &commit))
+}
+
+async fn handle_merge_request(
+  state: AppState,
+  project_id: Uuid,
+  body: &[u8],
+) -> Result<(StatusCode, Json<WebhookResponse>), ApiError> {
+  let payload: GitLabMergeRequestPayload = serde_json::from_slice(body)
+    .map_err(|e| {
+      ApiError(circus_common::CiError::Validation(format!(
+        "Invalid GitLab MR payload: {e}"
+      )))
+    })?;
+  trace_project(project_id, payload.project.as_ref());
+
+  if let Some(kind) = payload.object_kind.as_deref()
+    && kind != "merge_request"
+  {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  format!("Ignored GitLab object kind: {kind}"),
+      }),
+    ));
+  }
+
+  let Some(attrs) = payload.object_attributes else {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "No merge request attributes, skipping".to_string(),
+      }),
+    ));
+  };
+
+  if attrs.work_in_progress.unwrap_or(false) || attrs.draft.unwrap_or(false) {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "Draft/WIP merge request, skipping".to_string(),
+      }),
+    ));
+  }
+
+  if let Some(state) = attrs.state.as_deref()
+    && state != "opened"
+  {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  format!("Ignored MR state: {state}"),
+      }),
+    ));
+  }
+
+  let action = attrs.action.as_deref().unwrap_or("");
+  if !matches!(action, "open" | "update" | "reopen") {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  format!("Ignored MR action: {action}"),
+      }),
+    ));
+  }
+
+  let commit = attrs.last_commit.and_then(|c| c.id).unwrap_or_default();
+
+  if commit.is_empty() {
+    return Ok((
+      StatusCode::OK,
+      Json(WebhookResponse {
+        accepted: true,
+        message:  "No commit in merge request, skipping".to_string(),
+      }),
+    ));
+  }
+
+  let pr_number = attrs.iid.map(|n| n as i32);
+  let pr_head_branch = attrs.source_branch.clone();
+  let pr_base_branch = attrs.target_branch.clone();
+  let pr_action = Some(action.to_string());
+
+  let triggered = trigger_change_request_evaluations(
+    &state,
+    project_id,
+    &ChangeRequestEvaluation {
+      commit:      commit.clone(),
+      number:      pr_number,
+      head_branch: pr_head_branch,
+      base_branch: pr_base_branch,
+      action:      pr_action,
+    },
+  )
+  .await?;
+
+  let mr_iid = pr_number.unwrap_or(0);
+  Ok((
+    StatusCode::OK,
+    Json(WebhookResponse {
+      accepted: true,
+      message:  format!(
+        "Triggered {triggered} evaluations for MR !{mr_iid} commit {commit}"
+      ),
+    }),
+  ))
+}
+
+fn trace_project(project_id: Uuid, project: Option<&GitLabProject>) {
+  if let Some(project) = project {
+    tracing::debug!(
+      %project_id,
+      gitlab_project_id = ?project.id,
+      path_with_namespace = ?project.path_with_namespace,
+      web_url = ?project.web_url,
+      git_http_url = ?project.git_http_url,
+      "GitLab webhook payload project"
+    );
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #![expect(clippy::unwrap_used, reason = "Fine in tests")]
+
+  use super::*;
+
+  #[test]
+  fn test_parse_gitlab_push_payload() {
+    let payload = r#"{
+      "ref": "refs/heads/main",
+      "after": "abc123",
+      "checkout_sha": "def456789012345678901234567890abcdef12"
+    }"#;
+
+    let parsed: GitLabPushPayload = serde_json::from_str(payload).unwrap();
+    assert_eq!(
+      parsed.checkout_sha,
+      Some("def456789012345678901234567890abcdef12".to_string())
+    );
+    assert_eq!(parsed.after, Some("abc123".to_string()));
+  }
+
+  #[test]
+  fn test_parse_gitlab_mr_payload() {
+    let payload = r#"{
+      "object_kind": "merge_request",
+      "object_attributes": {
+        "iid": 123,
+        "action": "open",
+        "source_branch": "feature",
+        "target_branch": "main",
+        "last_commit": {"id": "abc123def456"},
+        "draft": false,
+        "work_in_progress": false
+      }
+    }"#;
+
+    let parsed: GitLabMergeRequestPayload =
+      serde_json::from_str(payload).unwrap();
+    let attrs = parsed.object_attributes.unwrap();
+    assert_eq!(attrs.iid, Some(123));
+    assert_eq!(attrs.action, Some("open".to_string()));
+    assert_eq!(attrs.source_branch, Some("feature".to_string()));
+    assert_eq!(attrs.target_branch, Some("main".to_string()));
+    assert_eq!(attrs.draft, Some(false));
+    assert_eq!(attrs.work_in_progress, Some(false));
+  }
+
+  #[test]
+  fn test_parse_gitlab_mr_draft() {
+    let payload = r#"{
+      "object_kind": "merge_request",
+      "object_attributes": {
+        "iid": 999,
+        "action": "open",
+        "draft": true
+      }
+    }"#;
+
+    let parsed: GitLabMergeRequestPayload =
+      serde_json::from_str(payload).unwrap();
+    let attrs = parsed.object_attributes.unwrap();
+    assert_eq!(attrs.draft, Some(true));
+  }
+
+  #[test]
+  fn test_parse_gitlab_mr_wip() {
+    let payload = r#"{
+      "object_kind": "merge_request",
+      "object_attributes": {
+        "iid": 888,
+        "action": "open",
+        "work_in_progress": true
+      }
+    }"#;
+
+    let parsed: GitLabMergeRequestPayload =
+      serde_json::from_str(payload).unwrap();
+    let attrs = parsed.object_attributes.unwrap();
+    assert_eq!(attrs.work_in_progress, Some(true));
+  }
+}

--- a/crates/server/src/routes/webhooks/tests.rs
+++ b/crates/server/src/routes/webhooks/tests.rs
@@ -1,0 +1,92 @@
+#![expect(clippy::unwrap_used, reason = "Fine in tests")]
+
+use axum::http::{HeaderMap, HeaderValue};
+
+use super::*;
+
+fn signed_header_value(secret: &str, body: &[u8]) -> HeaderValue {
+  use hmac::{Hmac, Mac};
+  use sha2::Sha256;
+
+  let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+  mac.update(body);
+  let signature =
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+  HeaderValue::from_str(&signature).unwrap()
+}
+
+#[test]
+fn test_verify_signature_valid() {
+  use hmac::{Hmac, Mac};
+  use sha2::Sha256;
+
+  let secret = "test-secret";
+  let body = b"test-body";
+
+  let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+  mac.update(body);
+  let expected = hex::encode(mac.finalize().into_bytes());
+
+  assert!(verify_signature(
+    secret,
+    body,
+    &format!("sha256={expected}")
+  ));
+}
+
+#[test]
+fn test_verify_signature_invalid() {
+  let secret = "test-secret";
+  let body = b"test-body";
+  assert!(!verify_signature(secret, body, "sha256=invalidsignature"));
+}
+
+#[test]
+fn test_verify_signature_wrong_secret() {
+  use hmac::{Hmac, Mac};
+  use sha2::Sha256;
+
+  let body = b"test-body";
+  let mut mac = Hmac::<Sha256>::new_from_slice(b"secret1").unwrap();
+  mac.update(body);
+  let sig = hex::encode(mac.finalize().into_bytes());
+
+  assert!(!verify_signature("secret2", body, &format!("sha256={sig}")));
+}
+
+#[test]
+fn strip_branch_prefix_handles_heads_and_plain_names() {
+  assert_eq!(strip_branch_prefix("refs/heads/main"), "main");
+  assert_eq!(strip_branch_prefix("feature"), "feature");
+}
+
+#[test]
+fn gitea_policy_rejects_valid_forgejo_signature_header() {
+  let secret = "test-secret";
+  let body = b"test-body";
+  let mut headers = HeaderMap::new();
+
+  headers.insert("x-forgejo-signature", signed_header_value(secret, body));
+
+  assert!(!gitea::PROVIDER.is_signature_valid(&headers, body, secret));
+
+  headers.insert("x-gitea-signature", signed_header_value(secret, body));
+
+  assert!(gitea::PROVIDER.is_signature_valid(&headers, body, secret));
+}
+
+#[test]
+fn forgejo_policy_rejects_valid_gitea_signature_header() {
+  let secret = "test-secret";
+  let body = b"test-body";
+  let mut headers = HeaderMap::new();
+
+  headers.insert("x-gitea-signature", signed_header_value(secret, body));
+
+  assert!(!forgejo::PROVIDER.is_signature_valid(&headers, body, secret));
+
+  headers.insert("x-forgejo-signature", signed_header_value(secret, body));
+
+  assert!(forgejo::PROVIDER.is_signature_valid(&headers, body, secret));
+}


### PR DESCRIPTION
This PR splits webhook handling into provider-specific modules for GitHub, GitLab, Gitea, and Forgejo. 
Furthermore,
- /webhooks/{project_id}/gitea now only uses forge_type = "gitea"
- /webhooks/{project_id}/forgejo now only uses forge_type = "forgejo"
- Gitea only checks x-gitea-signature
- Forgejo only checks x-forgejo-signature
- no fallback between Gitea and Forgejo configs/signatures anymore