### PR TITLE
server: treat blank build filter params as absent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha2 0.11.0",
  "sqlx",
  "subtle",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -52,7 +52,8 @@ circus-common.workspace = true
 regex.workspace = true
 
 [dev-dependencies]
-tower.workspace = true
+serde_urlencoded = "0.7"
+tower.workspace  = true
 
 [lints]
 workspace = true

--- a/crates/server/src/routes/builds.rs
+++ b/crates/server/src/routes/builds.rs
@@ -26,8 +26,20 @@ use crate::{
 #[derive(Debug, Deserialize)]
 struct ListBuildsParams {
   evaluation_id: Option<Uuid>,
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   status:        Option<String>,
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   system:        Option<String>,
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   job_name:      Option<String>,
   limit:         Option<i64>,
   offset:        Option<i64>,
@@ -43,9 +55,9 @@ async fn list_builds(
   };
   let limit = pagination.limit();
   let offset = pagination.offset();
-  let status = params.status.as_deref().filter(|s| !s.is_empty());
-  let system = params.system.as_deref().filter(|s| !s.is_empty());
-  let job_name = params.job_name.as_deref().filter(|s| !s.is_empty());
+  let status = params.status.as_deref();
+  let system = params.system.as_deref();
+  let job_name = params.job_name.as_deref();
   let items = circus_common::repo::builds::list_filtered(
     &state.pool,
     params.evaluation_id,

--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -65,8 +65,20 @@ pub(super) struct PageParams {
 
 #[derive(serde::Deserialize)]
 pub(super) struct BuildFilterParams {
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   status:   Option<String>,
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   system:   Option<String>,
+  #[serde(
+    default,
+    deserialize_with = "crate::routes::serde_util::empty_string_as_none"
+  )]
   job_name: Option<String>,
   limit:    Option<i64>,
   offset:   Option<i64>,
@@ -1365,4 +1377,25 @@ pub(super) async fn project_setup_page(
       .render()
       .unwrap_or_else(|e| format!("Template error: {e}")),
   ))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::BuildFilterParams;
+
+  #[test]
+  fn blank_filter_params_deserialize_to_none() {
+    let params = serde_urlencoded::from_str::<BuildFilterParams>(
+      "offset=50&limit=50&status=&system=&job_name=",
+    )
+    .expect("deserialize query");
+    assert_eq!(params.status, None);
+    assert_eq!(params.system, None);
+    assert_eq!(params.job_name, None);
+    assert_eq!(params.offset, Some(50));
+
+    let kept = serde_urlencoded::from_str::<BuildFilterParams>("status=failed")
+      .expect("deserialize query");
+    assert_eq!(kept.status.as_deref(), Some("failed"));
+  }
 }

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -17,6 +17,7 @@ pub mod oauth;
 pub mod openapi;
 pub mod projects;
 pub mod search;
+pub(crate) mod serde_util;
 pub mod users;
 pub mod webhooks;
 

--- a/crates/server/src/routes/serde_util.rs
+++ b/crates/server/src/routes/serde_util.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize an optional query-string field, mapping a blank value to
+/// [`None`].
+pub fn empty_string_as_none<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  Ok(Option::<String>::deserialize(de)?.filter(|s| !s.is_empty()))
+}


### PR DESCRIPTION
- Fixes #100

This commit collapses empty filter params to `None`, so 'no filter' means the same thing whether a key is omitted or left blank.