### PR TITLE
evaluator: derive `restrict-eval` `allowed-uris` from flake.lock

### DIFF
--- a/circus.example.toml
+++ b/circus.example.toml
@@ -38,12 +38,14 @@ enabled        = true
 # text   = "#0f172a"
 
 [evaluator]
-allow_ifd     = false
-git_timeout   = 600
-nix_timeout   = 1800
-poll_interval = 60
-restrict_eval = true
-work_dir      = "/tmp/circus-evaluator"
+allow_ifd            = false
+auto_allowed_uris    = true
+git_timeout          = 600
+nix_timeout          = 1800
+poll_interval        = 60
+require_locked_flake = false
+restrict_eval        = true
+work_dir             = "/tmp/circus-evaluator"
 
 [queue_runner]
 build_timeout = 3600

--- a/crates/config/src/structs.rs
+++ b/crates/config/src/structs.rs
@@ -224,6 +224,10 @@ impl Default for PageAccessConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[expect(
+  clippy::struct_excessive_bools,
+  reason = "EvaluatorConfig mirrors independent TOML switches"
+)]
 #[serde(default)]
 pub struct EvaluatorConfig {
   pub poll_interval:        u64,
@@ -233,11 +237,15 @@ pub struct EvaluatorConfig {
   pub work_dir:             PathBuf,
   pub restrict_eval:        bool,
   pub allow_ifd:            bool,
-  /// URIs that Nix is allowed to fetch even under `restrict_eval`. Space- or
-  /// newline-separated prefixes passed as `allowed-uris` to Nix. Useful for
-  /// permitting locked tarball inputs (e.g. `https://releases.nixos.org`)
-  /// without disabling `restrict_eval` entirely.
+  /// Extra `allowed-uris` prefixes honored under `restrict_eval`, merged with
+  /// the lock-derived set when `auto_allowed_uris` is on.
   pub allowed_uris:         Vec<String>,
+
+  /// Derive `allowed-uris` from the flake jobset's `flake.lock`.
+  pub auto_allowed_uris: bool,
+
+  /// Refuse a flake jobset that has no committed `flake.lock`.
+  pub require_locked_flake: bool,
 
   /// Whether to abort on the first evaluation cycle error instead of logging
   /// and retrying.
@@ -784,6 +792,8 @@ impl Default for EvaluatorConfig {
       restrict_eval:        true,
       allow_ifd:            false,
       allowed_uris:         Vec::new(),
+      auto_allowed_uris:    true,
+      require_locked_flake: false,
       strict_errors:        false,
     }
   }

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -5,6 +5,7 @@ use circus_config::EvaluatorConfig;
 use tokio::process::Command;
 
 mod eval_command;
+mod flake_lock;
 
 use eval_command::NixEvalPolicy;
 
@@ -218,6 +219,50 @@ fn rewrite_nixos_config_expr(expr: &str) -> Option<String> {
   }
 }
 
+/// Derive `allowed-uris` from the project's `flake.lock`.
+fn lock_derived_allowed_uris(
+  repo_path: &Path,
+  config: &EvaluatorConfig,
+) -> Result<Vec<String>> {
+  if !config.restrict_eval || !config.auto_allowed_uris {
+    return Ok(Vec::new());
+  }
+
+  let lock_path = repo_path.join("flake.lock");
+  match std::fs::read_to_string(&lock_path) {
+    Ok(contents) => {
+      let uris = flake_lock::allowed_uris_from_lock(&contents);
+      tracing::info!(
+        count = uris.len(),
+        "Derived allowed-uris from flake.lock"
+      );
+      Ok(uris)
+    },
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+      if config.require_locked_flake {
+        Err(CiError::NixEval(format!(
+          "No flake.lock at {} but require_locked_flake is enabled. Commit a \
+           lock file or disable require_locked_flake",
+          lock_path.display()
+        )))
+      } else {
+        tracing::warn!(
+          path = %lock_path.display(),
+          "No flake.lock found, deriving no allowed-uris (set \
+           evaluator.allowed_uris or restrict_eval = false if inputs are blocked)"
+        );
+        Ok(Vec::new())
+      }
+    },
+    Err(e) => {
+      Err(CiError::NixEval(format!(
+        "Failed to read {}: {e}",
+        lock_path.display()
+      )))
+    },
+  }
+}
+
 #[tracing::instrument(skip(config, inputs))]
 async fn evaluate_flake(
   repo_path: &Path,
@@ -260,6 +305,10 @@ async fn evaluate_flake(
     }
   }
 
+  let derived_uris = lock_derived_allowed_uris(repo_path, config)?;
+  let policy =
+    NixEvalPolicy::from(config).with_extra_allowed_uris(derived_uris);
+
   let evix_config = evix::Config {
     input: evix::Input::Flake(flake_ref),
     auto_args: Vec::new(),
@@ -270,7 +319,7 @@ async fn evaluate_flake(
     meta: true,
     show_input_drvs: true,
     override_inputs,
-    nix_options: NixEvalPolicy::from(config).nix_options(),
+    nix_options: policy.nix_options(),
   };
 
   eval_command::run_eval(evix_config, timeout, "flake").await
@@ -297,7 +346,10 @@ async fn evaluate_all_nixos_configs(
       "--no-write-lock-file",
     ])
     .kill_on_drop(true);
-  NixEvalPolicy::from(config).apply_to(&mut cmd);
+  let derived_uris = lock_derived_allowed_uris(repo_path, config)?;
+  NixEvalPolicy::from(config)
+    .with_extra_allowed_uris(derived_uris)
+    .apply_to(&mut cmd);
   let output = cmd.output().await.map_err(|e| {
     CiError::NixEval(format!("Failed to evaluate nixosConfigurations: {e}"))
   })?;

--- a/crates/evaluator/src/nix/eval_command.rs
+++ b/crates/evaluator/src/nix/eval_command.rs
@@ -22,6 +22,14 @@ pub(super) struct NixEvalPolicy {
 }
 
 impl NixEvalPolicy {
+  /// Merge extra `allowed-uris`, sorted and deduped.
+  pub(super) fn with_extra_allowed_uris(mut self, extra: Vec<String>) -> Self {
+    self.allowed_uris.extend(extra);
+    self.allowed_uris.sort();
+    self.allowed_uris.dedup();
+    self
+  }
+
   pub(super) fn nix_options(&self) -> Vec<(String, String)> {
     let mut options = Vec::new();
     if self.restrict_eval {
@@ -229,6 +237,25 @@ mod policy_tests {
   fn empty_allowed_uris_emits_no_option() {
     let opts = policy(true, false).nix_options();
     assert!(!opts.iter().any(|(k, _)| k == "allowed-uris"));
+  }
+
+  #[test]
+  fn with_extra_allowed_uris_merges_sorts_and_dedups() {
+    let p = NixEvalPolicy {
+      restrict_eval: true,
+      allow_ifd:     false,
+      allowed_uris:  vec!["https://github.com".to_string()],
+    }
+    .with_extra_allowed_uris(vec![
+      "github:NixOS/nixpkgs".to_string(),
+      "https://github.com".to_string(),
+    ]);
+    let opts = p.nix_options();
+    let (_, v) = opts
+      .iter()
+      .find(|(k, _)| k == "allowed-uris")
+      .expect("allowed-uris option must be present");
+    assert_eq!(v, "github:NixOS/nixpkgs https://github.com");
   }
 
   #[test]

--- a/crates/evaluator/src/nix/flake_lock.rs
+++ b/crates/evaluator/src/nix/flake_lock.rs
@@ -1,0 +1,141 @@
+//! Derive Nix `allowed-uris` from a flake's `flake.lock` so locked inputs stay
+//! fetchable under `restrict-eval`.
+
+use serde_json::Value;
+
+/// Parse `flake.lock` and return the sorted, deduped `allowed-uris` for its
+/// locked inputs.
+pub fn allowed_uris_from_lock(lock_json: &str) -> Vec<String> {
+  let root: Value = match serde_json::from_str(lock_json) {
+    Ok(v) => v,
+    Err(e) => {
+      tracing::warn!(error = %e, "Failed to parse flake.lock, deriving no allowed-uris");
+      return Vec::new();
+    },
+  };
+
+  let root_name = root.get("root").and_then(Value::as_str);
+  let Some(nodes) = root.get("nodes").and_then(Value::as_object) else {
+    return Vec::new();
+  };
+
+  let mut uris: Vec<String> = nodes
+    .iter()
+    .filter(|(name, _)| Some(name.as_str()) != root_name)
+    .filter_map(|(_, node)| node.get("locked"))
+    .flat_map(locked_node_to_uris)
+    .collect();
+
+  uris.sort();
+  uris.dedup();
+  uris
+}
+
+/// Map one `locked` node to the narrowest prefix(es) `checkURI` accepts.
+fn locked_node_to_uris(locked: &Value) -> Vec<String> {
+  let typ = locked
+    .get("type")
+    .and_then(Value::as_str)
+    .unwrap_or_default();
+
+  match typ {
+    "github" | "gitlab" | "sourcehut" => {
+      let (Some(owner), Some(repo)) = (
+        locked.get("owner").and_then(Value::as_str),
+        locked.get("repo").and_then(Value::as_str),
+      ) else {
+        return Vec::new();
+      };
+      // owner/repo, not the full /rev, whose trailing `?narHash` fails checkURI
+      vec![format!("{typ}:{owner}/{repo}")]
+    },
+
+    "tarball" | "file" => {
+      locked
+        .get("url")
+        .and_then(Value::as_str)
+        .map(|url| vec![url.to_owned()])
+        .unwrap_or_default()
+    },
+
+    "git" | "mercurial" => {
+      let scheme = if typ == "git" { "git+" } else { "hg+" };
+      locked
+        .get("url")
+        .and_then(Value::as_str)
+        .map(|url| with_scheme_and_parent(scheme, url))
+        .unwrap_or_default()
+    },
+
+    // `path` inputs are local. `indirect` is resolved to a concrete node.
+    "path" | "indirect" => Vec::new(),
+
+    other => {
+      let uris = locked
+        .get("url")
+        .and_then(Value::as_str)
+        .map(|url| with_scheme_and_parent("", url))
+        .unwrap_or_default();
+      tracing::warn!(
+        node_type = other,
+        derived = ?uris,
+        "Unrecognized flake.lock input type, deriving best-effort allowed-uris"
+      );
+      uris
+    },
+  }
+}
+
+/// Scheme-prefixed url plus its parent dir, covering the `?ref=&rev=` form.
+fn with_scheme_and_parent(scheme: &str, url: &str) -> Vec<String> {
+  let full = format!("{scheme}{url}");
+  let mut out = vec![full.clone()];
+  if let Some(slash) = full.rfind('/') {
+    out.push(full[..=slash].to_owned());
+  }
+  out
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn maps_each_input_type_and_skips_local_and_root() {
+    let lock = r#"{
+      "root": "root", "version": 7,
+      "nodes": {
+        "root": { "inputs": { "forge": "forge", "chan": "chan", "vcs": "vcs", "local": "local" } },
+        "forge": { "locked": { "type": "github", "owner": "ipetkov", "repo": "crane", "rev": "abc" } },
+        "chan": { "locked": { "type": "tarball", "url": "https://releases.nixos.org/x/nixexprs.tar.xz" } },
+        "vcs": { "locked": { "type": "git", "url": "https://git.example.com/team/lib", "rev": "def" } },
+        "local": { "locked": { "type": "path", "path": "/etc/nixos" } }
+      }
+    }"#;
+    assert_eq!(allowed_uris_from_lock(lock), vec![
+      "git+https://git.example.com/team/",
+      "git+https://git.example.com/team/lib",
+      "github:ipetkov/crane",
+      "https://releases.nixos.org/x/nixexprs.tar.xz",
+    ]);
+  }
+
+  #[test]
+  fn dedups_repeated_prefixes() {
+    let lock = r#"{
+      "root": "root", "version": 7,
+      "nodes": {
+        "root": { "inputs": { "a": "a" } },
+        "a": { "locked": { "type": "github", "owner": "o", "repo": "a", "rev": "1" } },
+        "b": { "locked": { "type": "github", "owner": "o", "repo": "a", "rev": "2" } }
+      }
+    }"#;
+    assert_eq!(allowed_uris_from_lock(lock), vec!["github:o/a"]);
+  }
+
+  #[test]
+  fn invalid_lock_yields_empty() {
+    assert!(allowed_uris_from_lock("not json").is_empty());
+    assert!(allowed_uris_from_lock("{}").is_empty());
+  }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -296,6 +296,13 @@ The server enforces several security measures:
 - LDAP DN injection prevention (metacharacter escaping)
 - Audit logging for all mutations
 
+Evaluation is sandboxed independently. The evaluator runs Nix with
+`restrict-eval`, so a jobset can only fetch URIs on an allowlist, and
+`import-from-derivation` is off by default. The allowlist is derived from the
+project's `flake.lock`, so locked inputs resolve while undeclared eval-time
+fetches are blocked. Deployers extend it with `evaluator.allowed_uris` or opt
+out with `restrict_eval = false`.
+
 ## Binary Cache and Channels
 
 Circus serves a Nix-compatible binary cache at `/nix-cache/`. It supports the

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -175,178 +175,181 @@ configuration or the Nix store.
 
 <!-- markdownlint-disable MD013 -->
 
-| Section              | Key                                                    | Default                                             | Description                                      |
-| -------------------- | ------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------ |
-| `database`           | `url`                                                  | `postgresql://circus:password@localhost/circus`     | PostgreSQL connection URL                        |
-| `database`           | `url_file`                                             | none                                                | File containing the PostgreSQL URL               |
-| `database`           | `max_connections`                                      | `20`                                                | Maximum connection pool size                     |
-| `database`           | `min_connections`                                      | `5`                                                 | Minimum idle connections                         |
-| `database`           | `connect_timeout`                                      | `30`                                                | Connection timeout (seconds)                     |
-| `database`           | `idle_timeout`                                         | `600`                                               | Idle connection timeout (seconds)                |
-| `database`           | `max_lifetime`                                         | `1800`                                              | Maximum connection lifetime (seconds)            |
-| `server`             | `host`                                                 | `127.0.0.1`                                         | HTTP listen address                              |
-| `server`             | `port`                                                 | `3000`                                              | HTTP listen port                                 |
-| `server`             | `request_timeout`                                      | `30`                                                | Per-request timeout (seconds)                    |
-| `server`             | `max_body_size`                                        | `10485760`                                          | Maximum request body size (10 MB)                |
-| `server`             | `api_key`                                              | none                                                | Optional legacy API key (prefer DB keys)         |
-| `server`             | `api_key_file`                                         | none                                                | File containing the optional legacy API key      |
-| `server`             | `cors_permissive`                                      | `false`                                             | Allow all CORS origins                           |
-| `server`             | `allowed_origins`                                      | `[]`                                                | Allowed CORS origins list                        |
-| `server`             | `force_secure_cookies`                                 | `false`                                             | Force Secure flag on cookies (HTTPS proxy)       |
-| `server`             | `rate_limit_rps`                                       | none                                                | Requests per second limit per IP                 |
-| `server`             | `rate_limit_burst`                                     | none                                                | Burst size for rate limiting                     |
-| `server`             | `allowed_url_schemes`                                  | `[ "https", "git", "ssh" ]`                         | Allowed URL schemes for repository URLs          |
-| `server`             | `config_editor_enabled`                                | `false`                                             | Allow admin config editing through API/dashboard |
-| `server`             | `require_api_key_for_reads`                            | `true`                                              | Require auth for read-only `/api/v1` requests    |
-| `server`             | `openapi_enabled`                                      | `true`                                              | Serve `/api/v1/openapi.json`                     |
-| `server`             | `webhook_secret_encryption_key`                        | none                                                | Encrypt webhook and notification secrets         |
-| `server`             | `webhook_secret_encryption_key_file`                   | none                                                | File containing the encryption key               |
-| `server`             | `ldap.enabled`                                         | `true`                                              | Enable configured LDAP login                     |
-| `server`             | `ldap.url`                                             | none                                                | LDAP server URL                                  |
-| `server`             | `ldap.bind_dn_template`                                | none                                                | LDAP bind DN template (`{username}` placeholder) |
-| `server`             | `ldap.base_dn`                                         | none                                                | LDAP base DN for user searches                   |
-| `server`             | `ldap.tls_ca_cert`                                     | none                                                | Custom CA cert for LDAP TLS                      |
-| `server`             | `email_validation_regex`                               | none                                                | Custom regex for email validation                |
-| `server.page_access` | per page                                               | mixed                                               | Dashboard page visibility policy                 |
-| `ui`                 | `enabled`                                              | `true`                                              | Mount bundled dashboard and static UI routes     |
-| `ui`                 | `dashboard`                                            | `true`                                              | Mount server-rendered dashboard/login pages      |
-| `ui`                 | `assets`                                               | `true`                                              | Serve bundled static UI assets                   |
-| `ui`                 | `brand_name`                                           | `circus`                                            | Dashboard sidebar brand name                     |
-| `ui`                 | `brand_subtitle`                                       | `Nix CI`                                            | Dashboard sidebar brand subtitle                 |
-| `ui`                 | `logo_url`                                             | none                                                | Optional logo URL                                |
-| `ui`                 | `favicon_url`                                          | none                                                | Optional favicon URL                             |
-| `ui`                 | `custom_css`                                           | none                                                | CSS file served as `/static/custom.css`          |
-| `ui`                 | `static_dir`                                           | none                                                | Directory served below `/static/custom/`         |
-| `ui.css_variables`   | CSS variable names                                     | `{}`                                                | Variables emitted in `/static/theme.css`         |
-| `evaluator`          | `poll_interval`                                        | `60`                                                | Seconds between git poll cycles                  |
-| `evaluator`          | `git_timeout`                                          | `600`                                               | Git operation timeout (seconds)                  |
-| `evaluator`          | `nix_timeout`                                          | `1800`                                              | Nix evaluation timeout (seconds)                 |
-| `evaluator`          | `max_concurrent_evals`                                 | `4`                                                 | Maximum concurrent evaluations                   |
-| `evaluator`          | `work_dir`                                             | `/tmp/circus-evaluator`                             | Working directory for clones                     |
-| `evaluator`          | `restrict_eval`                                        | `true`                                              | Pass `--option restrict-eval true` to Nix        |
-| `evaluator`          | `allow_ifd`                                            | `false`                                             | Allow import-from-derivation                     |
-| `evaluator`          | `strict_errors`                                        | `false`                                             | Abort on first evaluation cycle error            |
-| `queue_runner`       | `workers`                                              | `4`                                                 | Concurrent build slots                           |
-| `queue_runner`       | `poll_interval`                                        | `5`                                                 | Seconds between build queue polls                |
-| `queue_runner`       | `build_timeout`                                        | `3600`                                              | Per-build timeout (seconds)                      |
-| `queue_runner`       | `max_silent_time`                                      | `0`                                                 | Fail agent builds silent for `N` seconds         |
-| `queue_runner`       | `work_dir`                                             | `/tmp/circus-queue-runner`                          | Working directory for builds                     |
-| `queue_runner`       | `strict_errors`                                        | `false`                                             | Abort on first runner loop error                 |
-| `queue_runner`       | `failed_paths_cache`                                   | `true`                                              | Cache failed derivation paths                    |
-| `queue_runner`       | `failed_paths_ttl`                                     | `86400`                                             | TTL for failed paths cache (seconds)             |
-| `queue_runner`       | `unsupported_timeout`                                  | none                                                | Timeout for unsupported system builds            |
-| `queue_runner`       | `scheduling_strategy`                                  | `speed_factor_only`                                 | Builder selection strategy                       |
-| `queue_runner`       | `psi_threshold`                                        | none                                                | PSI pressure threshold (skip builders)           |
-| `queue_runner`       | `psi_check_timeout`                                    | `5`                                                 | SSH PSI check timeout (seconds)                  |
-| `queue_runner`       | `ssh_require_host_key`                                 | `false`                                             | Skip SSH builders without pinned host keys       |
-| `queue_runner`       | `extra_nix_build_args`                                 | `[]`                                                | Extra arguments passed to `nix build`            |
-| `queue_runner`       | `local_systems`                                        | none                                                | Systems the runner host may build locally        |
-| `queue_runner`       | `local_features`                                       | none                                                | System features available on local builds        |
-| `queue_runner`       | `rpc.bind`                                             | none                                                | Cap'n Proto RPC listen address                   |
-| `queue_runner`       | `rpc.auth_tokens`                                      | `[]`                                                | Valid authentication tokens for agents           |
-| `queue_runner`       | `rpc.max_connections`                                  | `256`                                               | Maximum concurrent agent connections             |
-| `queue_runner`       | `rpc.presign_expiry_secs`                              | `3600`                                              | Presigned URL expiry (seconds)                   |
-| `queue_runner`       | `rpc.tls`                                              | none                                                | TLS configuration for RPC endpoint               |
-| `queue_runner`       | `rpc.heartbeat_ttl_secs`                               | `60`                                                | Agent heartbeat TTL before marking unavailable   |
-| `queue_runner`       | `rpc.cache_substituter`                                | none                                                | Cache URL forwarded to agents for drv inputs     |
-| `queue_runner`       | `rpc.cache_public_key`                                 | none                                                | Public key trusted for `rpc.cache_substituter`   |
-| `queue_runner`       | `rpc.oidc.issuer`                                      | `https://token.actions.githubusercontent.com`       | OIDC issuer accepted for agent registration      |
-| `queue_runner`       | `rpc.oidc.jwks_url`                                    | discovered                                          | JWKS endpoint override                           |
-| `queue_runner`       | `rpc.oidc.audiences`                                   | `[]`                                                | Accepted OIDC audiences                          |
-| `queue_runner`       | `rpc.oidc.allowed_repositories`                        | `[]`                                                | GitHub `owner/repo` slugs allowed to register    |
-| `queue_runner`       | `rpc.oidc.allowed_subjects`                            | `[]`                                                | Exact OIDC `sub` claims allowed to register      |
-| `queue_runner`       | `rpc.oidc.allowed_subject_prefixes`                    | `[]`                                                | OIDC `sub` prefixes allowed to register          |
-| `queue_runner`       | `rpc.oidc.allowed_workflow_refs`                       | `[]`                                                | GitHub `workflow_ref` claims allowed             |
-| `queue_runner`       | `rpc.oidc.allowed_refs`                                | `[]`                                                | GitHub `ref` claims allowed                      |
-| `queue_runner`       | `ephemeral_pools`                                      | `[]`                                                | GitHub Actions ephemeral autoscaling pools       |
-| `queue_runner`       | `ephemeral_pools[].name`                               | `gha-x86_64-linux`                                  | Pool name and base agent name                    |
-| `queue_runner`       | `ephemeral_pools[].allowed_build_repositories`         | `[]`                                                | Source repositories this pool may build          |
-| `queue_runner`       | `ephemeral_pools[].systems`                            | `[ "x86_64-linux" ]`                                | Systems advertised by pool agents                |
-| `queue_runner`       | `ephemeral_pools[].supported_features`                 | `[]`                                                | Features advertised by pool agents               |
-| `queue_runner`       | `ephemeral_pools[].mandatory_features`                 | `[]`                                                | Required build features for pool agents          |
-| `queue_runner`       | `ephemeral_pools[].max_jobs`                           | `1`                                                 | Build slots per pool agent                       |
-| `queue_runner`       | `ephemeral_pools[].cores`                              | `0`                                                 | Nix `cores` value passed to pool agents          |
-| `queue_runner`       | `ephemeral_pools[].speed_factor`                       | `1.0`                                               | Scheduling weight for pool agents                |
-| `queue_runner`       | `ephemeral_pools[].max_inflight`                       | `4`                                                 | Maximum workflow launches waiting to register    |
-| `queue_runner`       | `ephemeral_pools[].inflight_ttl_secs`                  | `900`                                               | Time before an unregistered launch is forgotten  |
-| `queue_runner`       | `ephemeral_pools[].scale_up_cooldown_secs`             | `30`                                                | Minimum delay between autoscaler launches        |
-| `queue_runner`       | `ephemeral_pools[].poll_interval_secs`                 | `10`                                                | Autoscaler polling interval                      |
-| `queue_runner`       | `ephemeral_pools[].github_actions.workflow_repository` | `""`                                                | GitHub repo containing the builder workflow      |
-| `queue_runner`       | `ephemeral_pools[].github_actions.workflow`            | `circus-builder.yml`                                | Workflow file name or numeric workflow ID        |
-| `queue_runner`       | `ephemeral_pools[].github_actions.ref_name`            | `main`                                              | Git ref used for workflow dispatch               |
-| `queue_runner`       | `ephemeral_pools[].github_actions.token`               | none                                                | GitHub token with Actions write access           |
-| `queue_runner`       | `ephemeral_pools[].github_actions.token_file`          | none                                                | File containing the GitHub token                 |
-| `queue_runner`       | `ephemeral_pools[].github_actions.runner_url`          | `""`                                                | Runner URL passed to ephemeral agents            |
-| `queue_runner`       | `ephemeral_pools[].github_actions.oidc_audience`       | `circus-agent`                                      | Audience requested by the builder workflow       |
-| `queue_runner`       | `ephemeral_pools[].github_actions.agent_binary_url`    | `""`                                                | Pinned `circus-agent` binary URL                 |
-| `gc`                 | `enabled`                                              | `true`                                              | Manage GC roots for build outputs                |
-| `gc`                 | `gc_roots_dir`                                         | `/nix/var/nix/gcroots/per-user/circus/circus-roots` | GC roots directory                               |
-| `gc`                 | `max_age_days`                                         | `30`                                                | Remove GC roots older than N days                |
-| `gc`                 | `cleanup_interval`                                     | `3600`                                              | GC cleanup interval (seconds)                    |
-| `logs`               | `log_dir`                                              | `/var/lib/circus/logs`                              | Build log storage directory                      |
-| `logs`               | `compress`                                             | `false`                                             | Compress stored logs                             |
-| `cache`              | `enabled`                                              | `true`                                              | Serve a Nix binary cache at `/nix-cache/`        |
-| `cache`              | `secret_key_file`                                      | none                                                | Deprecated; outputs are signed via `[signing]`   |
-| `cache`              | `cache_url`                                            | none                                                | Public cache URL for channel manifests           |
-| `cache`              | `upstreams`                                            | `[]`                                                | Upstream binary caches used by global builds     |
-| `signing`            | `enabled`                                              | `false`                                             | Sign build outputs                               |
-| `signing`            | `key_file`                                             | none                                                | Signing key file path                            |
-| `cache_upload`       | `enabled`                                              | `false`                                             | Upload builds to external cache store            |
-| `cache_upload`       | `store_uri`                                            | none                                                | Cache store URI (`s3://bucket/path`)             |
-| `cache_upload`       | `s3.region`                                            | none                                                | AWS region                                       |
-| `cache_upload`       | `s3.prefix`                                            | none                                                | Extra path prefix within bucket                  |
-| `cache_upload`       | `s3.access_key_id`                                     | none                                                | Access key for presigned S3 uploads/redirects    |
-| `cache_upload`       | `s3.secret_access_key`                                 | none                                                | Secret key for presigned S3 uploads/redirects    |
-| `cache_upload`       | `s3.secret_access_key_file`                            | none                                                | File containing S3 secret access key             |
-| `cache_upload`       | `s3.session_token`                                     | none                                                | Session token for temporary credentials          |
-| `cache_upload`       | `s3.session_token_file`                                | none                                                | File containing S3 session token                 |
-| `cache_upload`       | `s3.endpoint_url`                                      | none                                                | S3-compatible endpoint URL                       |
-| `cache_upload`       | `s3.use_path_style`                                    | `false`                                             | Use path-style addressing                        |
-| `cache_upload`       | `upload_concurrency`                                   | `4`                                                 | Concurrent uploads per build                     |
-| `cache_upload`       | `upload_max_retries`                                   | `3`                                                 | Max retry attempts per path                      |
-| `cache_upload`       | `fail_build_on_upload_error`                           | `false`                                             | Mark build failed on upload error                |
-| `cache_upload`       | `compression`                                          | `zstd`                                              | Agent presigned-upload NAR compression           |
-| `notifications`      | `webhook_url`                                          | none                                                | HTTP endpoint for build status JSON              |
-| `notifications`      | `webhook_url_file`                                     | none                                                | File containing generic webhook URL              |
-| `notifications`      | `github_token`                                         | none                                                | GitHub token for commit status updates           |
-| `notifications`      | `github_token_file`                                    | none                                                | File containing GitHub token                     |
-| `notifications`      | `gitea_url`                                            | none                                                | Gitea/Forgejo instance URL                       |
-| `notifications`      | `gitea_token`                                          | none                                                | Gitea/Forgejo API token                          |
-| `notifications`      | `gitea_token_file`                                     | none                                                | File containing Gitea/Forgejo token              |
-| `notifications`      | `gitlab_url`                                           | none                                                | GitLab instance URL                              |
-| `notifications`      | `gitlab_token`                                         | none                                                | GitLab API token                                 |
-| `notifications`      | `gitlab_token_file`                                    | none                                                | File containing GitLab token                     |
-| `notifications`      | `enable_retry_queue`                                   | `true`                                              | Persistent retry queue with backoff              |
-| `notifications`      | `max_retry_attempts`                                   | `5`                                                 | Max notification retry attempts                  |
-| `notifications`      | `retention_days`                                       | `7`                                                 | Retention for completed notification tasks       |
-| `notifications`      | `retry_poll_interval`                                  | `5`                                                 | Retry poll interval (seconds)                    |
-| `notifications`      | `email.smtp_host`                                      | none                                                | SMTP host for email notifications                |
-| `notifications`      | `email.smtp_port`                                      | none                                                | SMTP port                                        |
-| `notifications`      | `email.smtp_user`                                      | none                                                | SMTP username (optional)                         |
-| `notifications`      | `email.smtp_password`                                  | none                                                | SMTP password (optional)                         |
-| `notifications`      | `email.smtp_password_file`                             | none                                                | File containing SMTP password                    |
-| `notifications`      | `email.tls`                                            | `false`                                             | Enable TLS for SMTP connection                   |
-| `notifications`      | `email.from_address`                                   | none                                                | From address for notification emails             |
-| `notifications`      | `email.to_addresses`                                   | `[]`                                                | Recipient addresses                              |
-| `notifications`      | `slack.webhook_url`                                    | none                                                | Slack incoming webhook URL                       |
-| `notifications`      | `slack.webhook_url_file`                               | none                                                | File containing Slack webhook URL                |
-| `notifications`      | `slack.on_failure_only`                                | `false`                                             | Only send Slack alerts on failure                |
-| `notifications`      | `alerts.enabled`                                       | `false`                                             | Enable error-rate threshold alerts               |
-| `notifications`      | `alerts.error_threshold`                               | `0.5`                                               | Error rate threshold to trigger alert            |
-| `notifications`      | `alerts.time_window_minutes`                           | `60`                                                | Time window for error rate calculation           |
-| `tracing`            | `level`                                                | `info`                                              | Log level (trace/debug/info/warn/error)          |
-| `tracing`            | `format`                                               | `compact`                                           | Log output format                                |
-| `tracing`            | `show_targets`                                         | `true`                                              | Show module path in log messages                 |
-| `tracing`            | `show_timestamps`                                      | `true`                                              | Show timestamps in log messages                  |
-| `oauth`              | `github.client_id`                                     | none                                                | GitHub OAuth App client ID                       |
-| `oauth`              | `github.client_secret`                                 | none                                                | GitHub OAuth App client secret                   |
-| `oauth`              | `github.client_secret_file`                            | none                                                | File containing GitHub OAuth secret              |
-| `oauth`              | `github.redirect_uri`                                  | none                                                | OAuth redirect URI                               |
-| `declarative`        | `projects`                                             | `[]`                                                | Declarative project definitions                  |
-| `declarative`        | `api_keys`                                             | `[]`                                                | Declarative API key definitions                  |
-| `declarative`        | `users`                                                | `[]`                                                | Declarative user definitions                     |
-| `declarative`        | `remote_builders`                                      | `[]`                                                | Declarative remote builder definitions           |
-| `nix`                | `store_dir`                                            | `/nix/store`                                        | Nix store directory                              |
+| Section              | Key                                                    | Default                                             | Description                                       |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------- |
+| `database`           | `url`                                                  | `postgresql://circus:password@localhost/circus`     | PostgreSQL connection URL                         |
+| `database`           | `url_file`                                             | none                                                | File containing the PostgreSQL URL                |
+| `database`           | `max_connections`                                      | `20`                                                | Maximum connection pool size                      |
+| `database`           | `min_connections`                                      | `5`                                                 | Minimum idle connections                          |
+| `database`           | `connect_timeout`                                      | `30`                                                | Connection timeout (seconds)                      |
+| `database`           | `idle_timeout`                                         | `600`                                               | Idle connection timeout (seconds)                 |
+| `database`           | `max_lifetime`                                         | `1800`                                              | Maximum connection lifetime (seconds)             |
+| `server`             | `host`                                                 | `127.0.0.1`                                         | HTTP listen address                               |
+| `server`             | `port`                                                 | `3000`                                              | HTTP listen port                                  |
+| `server`             | `request_timeout`                                      | `30`                                                | Per-request timeout (seconds)                     |
+| `server`             | `max_body_size`                                        | `10485760`                                          | Maximum request body size (10 MB)                 |
+| `server`             | `api_key`                                              | none                                                | Optional legacy API key (prefer DB keys)          |
+| `server`             | `api_key_file`                                         | none                                                | File containing the optional legacy API key       |
+| `server`             | `cors_permissive`                                      | `false`                                             | Allow all CORS origins                            |
+| `server`             | `allowed_origins`                                      | `[]`                                                | Allowed CORS origins list                         |
+| `server`             | `force_secure_cookies`                                 | `false`                                             | Force Secure flag on cookies (HTTPS proxy)        |
+| `server`             | `rate_limit_rps`                                       | none                                                | Requests per second limit per IP                  |
+| `server`             | `rate_limit_burst`                                     | none                                                | Burst size for rate limiting                      |
+| `server`             | `allowed_url_schemes`                                  | `[ "https", "git", "ssh" ]`                         | Allowed URL schemes for repository URLs           |
+| `server`             | `config_editor_enabled`                                | `false`                                             | Allow admin config editing through API/dashboard  |
+| `server`             | `require_api_key_for_reads`                            | `true`                                              | Require auth for read-only `/api/v1` requests     |
+| `server`             | `openapi_enabled`                                      | `true`                                              | Serve `/api/v1/openapi.json`                      |
+| `server`             | `webhook_secret_encryption_key`                        | none                                                | Encrypt webhook and notification secrets          |
+| `server`             | `webhook_secret_encryption_key_file`                   | none                                                | File containing the encryption key                |
+| `server`             | `ldap.enabled`                                         | `true`                                              | Enable configured LDAP login                      |
+| `server`             | `ldap.url`                                             | none                                                | LDAP server URL                                   |
+| `server`             | `ldap.bind_dn_template`                                | none                                                | LDAP bind DN template (`{username}` placeholder)  |
+| `server`             | `ldap.base_dn`                                         | none                                                | LDAP base DN for user searches                    |
+| `server`             | `ldap.tls_ca_cert`                                     | none                                                | Custom CA cert for LDAP TLS                       |
+| `server`             | `email_validation_regex`                               | none                                                | Custom regex for email validation                 |
+| `server.page_access` | per page                                               | mixed                                               | Dashboard page visibility policy                  |
+| `ui`                 | `enabled`                                              | `true`                                              | Mount bundled dashboard and static UI routes      |
+| `ui`                 | `dashboard`                                            | `true`                                              | Mount server-rendered dashboard/login pages       |
+| `ui`                 | `assets`                                               | `true`                                              | Serve bundled static UI assets                    |
+| `ui`                 | `brand_name`                                           | `circus`                                            | Dashboard sidebar brand name                      |
+| `ui`                 | `brand_subtitle`                                       | `Nix CI`                                            | Dashboard sidebar brand subtitle                  |
+| `ui`                 | `logo_url`                                             | none                                                | Optional logo URL                                 |
+| `ui`                 | `favicon_url`                                          | none                                                | Optional favicon URL                              |
+| `ui`                 | `custom_css`                                           | none                                                | CSS file served as `/static/custom.css`           |
+| `ui`                 | `static_dir`                                           | none                                                | Directory served below `/static/custom/`          |
+| `ui.css_variables`   | CSS variable names                                     | `{}`                                                | Variables emitted in `/static/theme.css`          |
+| `evaluator`          | `poll_interval`                                        | `60`                                                | Seconds between git poll cycles                   |
+| `evaluator`          | `git_timeout`                                          | `600`                                               | Git operation timeout (seconds)                   |
+| `evaluator`          | `nix_timeout`                                          | `1800`                                              | Nix evaluation timeout (seconds)                  |
+| `evaluator`          | `max_concurrent_evals`                                 | `4`                                                 | Maximum concurrent evaluations                    |
+| `evaluator`          | `work_dir`                                             | `/tmp/circus-evaluator`                             | Working directory for clones                      |
+| `evaluator`          | `restrict_eval`                                        | `true`                                              | Pass `--option restrict-eval true` to Nix         |
+| `evaluator`          | `allow_ifd`                                            | `false`                                             | Allow import-from-derivation                      |
+| `evaluator`          | `auto_allowed_uris`                                    | `true`                                              | Derive `allowed-uris` from the jobset flake.lock  |
+| `evaluator`          | `allowed_uris`                                         | `[]`                                                | Extra fetch URIs honored under `restrict_eval`    |
+| `evaluator`          | `require_locked_flake`                                 | `false`                                             | Refuse flake jobsets with no committed flake.lock |
+| `evaluator`          | `strict_errors`                                        | `false`                                             | Abort on first evaluation cycle error             |
+| `queue_runner`       | `workers`                                              | `4`                                                 | Concurrent build slots                            |
+| `queue_runner`       | `poll_interval`                                        | `5`                                                 | Seconds between build queue polls                 |
+| `queue_runner`       | `build_timeout`                                        | `3600`                                              | Per-build timeout (seconds)                       |
+| `queue_runner`       | `max_silent_time`                                      | `0`                                                 | Fail agent builds silent for `N` seconds          |
+| `queue_runner`       | `work_dir`                                             | `/tmp/circus-queue-runner`                          | Working directory for builds                      |
+| `queue_runner`       | `strict_errors`                                        | `false`                                             | Abort on first runner loop error                  |
+| `queue_runner`       | `failed_paths_cache`                                   | `true`                                              | Cache failed derivation paths                     |
+| `queue_runner`       | `failed_paths_ttl`                                     | `86400`                                             | TTL for failed paths cache (seconds)              |
+| `queue_runner`       | `unsupported_timeout`                                  | none                                                | Timeout for unsupported system builds             |
+| `queue_runner`       | `scheduling_strategy`                                  | `speed_factor_only`                                 | Builder selection strategy                        |
+| `queue_runner`       | `psi_threshold`                                        | none                                                | PSI pressure threshold (skip builders)            |
+| `queue_runner`       | `psi_check_timeout`                                    | `5`                                                 | SSH PSI check timeout (seconds)                   |
+| `queue_runner`       | `ssh_require_host_key`                                 | `false`                                             | Skip SSH builders without pinned host keys        |
+| `queue_runner`       | `extra_nix_build_args`                                 | `[]`                                                | Extra arguments passed to `nix build`             |
+| `queue_runner`       | `local_systems`                                        | none                                                | Systems the runner host may build locally         |
+| `queue_runner`       | `local_features`                                       | none                                                | System features available on local builds         |
+| `queue_runner`       | `rpc.bind`                                             | none                                                | Cap'n Proto RPC listen address                    |
+| `queue_runner`       | `rpc.auth_tokens`                                      | `[]`                                                | Valid authentication tokens for agents            |
+| `queue_runner`       | `rpc.max_connections`                                  | `256`                                               | Maximum concurrent agent connections              |
+| `queue_runner`       | `rpc.presign_expiry_secs`                              | `3600`                                              | Presigned URL expiry (seconds)                    |
+| `queue_runner`       | `rpc.tls`                                              | none                                                | TLS configuration for RPC endpoint                |
+| `queue_runner`       | `rpc.heartbeat_ttl_secs`                               | `60`                                                | Agent heartbeat TTL before marking unavailable    |
+| `queue_runner`       | `rpc.cache_substituter`                                | none                                                | Cache URL forwarded to agents for drv inputs      |
+| `queue_runner`       | `rpc.cache_public_key`                                 | none                                                | Public key trusted for `rpc.cache_substituter`    |
+| `queue_runner`       | `rpc.oidc.issuer`                                      | `https://token.actions.githubusercontent.com`       | OIDC issuer accepted for agent registration       |
+| `queue_runner`       | `rpc.oidc.jwks_url`                                    | discovered                                          | JWKS endpoint override                            |
+| `queue_runner`       | `rpc.oidc.audiences`                                   | `[]`                                                | Accepted OIDC audiences                           |
+| `queue_runner`       | `rpc.oidc.allowed_repositories`                        | `[]`                                                | GitHub `owner/repo` slugs allowed to register     |
+| `queue_runner`       | `rpc.oidc.allowed_subjects`                            | `[]`                                                | Exact OIDC `sub` claims allowed to register       |
+| `queue_runner`       | `rpc.oidc.allowed_subject_prefixes`                    | `[]`                                                | OIDC `sub` prefixes allowed to register           |
+| `queue_runner`       | `rpc.oidc.allowed_workflow_refs`                       | `[]`                                                | GitHub `workflow_ref` claims allowed              |
+| `queue_runner`       | `rpc.oidc.allowed_refs`                                | `[]`                                                | GitHub `ref` claims allowed                       |
+| `queue_runner`       | `ephemeral_pools`                                      | `[]`                                                | GitHub Actions ephemeral autoscaling pools        |
+| `queue_runner`       | `ephemeral_pools[].name`                               | `gha-x86_64-linux`                                  | Pool name and base agent name                     |
+| `queue_runner`       | `ephemeral_pools[].allowed_build_repositories`         | `[]`                                                | Source repositories this pool may build           |
+| `queue_runner`       | `ephemeral_pools[].systems`                            | `[ "x86_64-linux" ]`                                | Systems advertised by pool agents                 |
+| `queue_runner`       | `ephemeral_pools[].supported_features`                 | `[]`                                                | Features advertised by pool agents                |
+| `queue_runner`       | `ephemeral_pools[].mandatory_features`                 | `[]`                                                | Required build features for pool agents           |
+| `queue_runner`       | `ephemeral_pools[].max_jobs`                           | `1`                                                 | Build slots per pool agent                        |
+| `queue_runner`       | `ephemeral_pools[].cores`                              | `0`                                                 | Nix `cores` value passed to pool agents           |
+| `queue_runner`       | `ephemeral_pools[].speed_factor`                       | `1.0`                                               | Scheduling weight for pool agents                 |
+| `queue_runner`       | `ephemeral_pools[].max_inflight`                       | `4`                                                 | Maximum workflow launches waiting to register     |
+| `queue_runner`       | `ephemeral_pools[].inflight_ttl_secs`                  | `900`                                               | Time before an unregistered launch is forgotten   |
+| `queue_runner`       | `ephemeral_pools[].scale_up_cooldown_secs`             | `30`                                                | Minimum delay between autoscaler launches         |
+| `queue_runner`       | `ephemeral_pools[].poll_interval_secs`                 | `10`                                                | Autoscaler polling interval                       |
+| `queue_runner`       | `ephemeral_pools[].github_actions.workflow_repository` | `""`                                                | GitHub repo containing the builder workflow       |
+| `queue_runner`       | `ephemeral_pools[].github_actions.workflow`            | `circus-builder.yml`                                | Workflow file name or numeric workflow ID         |
+| `queue_runner`       | `ephemeral_pools[].github_actions.ref_name`            | `main`                                              | Git ref used for workflow dispatch                |
+| `queue_runner`       | `ephemeral_pools[].github_actions.token`               | none                                                | GitHub token with Actions write access            |
+| `queue_runner`       | `ephemeral_pools[].github_actions.token_file`          | none                                                | File containing the GitHub token                  |
+| `queue_runner`       | `ephemeral_pools[].github_actions.runner_url`          | `""`                                                | Runner URL passed to ephemeral agents             |
+| `queue_runner`       | `ephemeral_pools[].github_actions.oidc_audience`       | `circus-agent`                                      | Audience requested by the builder workflow        |
+| `queue_runner`       | `ephemeral_pools[].github_actions.agent_binary_url`    | `""`                                                | Pinned `circus-agent` binary URL                  |
+| `gc`                 | `enabled`                                              | `true`                                              | Manage GC roots for build outputs                 |
+| `gc`                 | `gc_roots_dir`                                         | `/nix/var/nix/gcroots/per-user/circus/circus-roots` | GC roots directory                                |
+| `gc`                 | `max_age_days`                                         | `30`                                                | Remove GC roots older than N days                 |
+| `gc`                 | `cleanup_interval`                                     | `3600`                                              | GC cleanup interval (seconds)                     |
+| `logs`               | `log_dir`                                              | `/var/lib/circus/logs`                              | Build log storage directory                       |
+| `logs`               | `compress`                                             | `false`                                             | Compress stored logs                              |
+| `cache`              | `enabled`                                              | `true`                                              | Serve a Nix binary cache at `/nix-cache/`         |
+| `cache`              | `secret_key_file`                                      | none                                                | Deprecated; outputs are signed via `[signing]`    |
+| `cache`              | `cache_url`                                            | none                                                | Public cache URL for channel manifests            |
+| `cache`              | `upstreams`                                            | `[]`                                                | Upstream binary caches used by global builds      |
+| `signing`            | `enabled`                                              | `false`                                             | Sign build outputs                                |
+| `signing`            | `key_file`                                             | none                                                | Signing key file path                             |
+| `cache_upload`       | `enabled`                                              | `false`                                             | Upload builds to external cache store             |
+| `cache_upload`       | `store_uri`                                            | none                                                | Cache store URI (`s3://bucket/path`)              |
+| `cache_upload`       | `s3.region`                                            | none                                                | AWS region                                        |
+| `cache_upload`       | `s3.prefix`                                            | none                                                | Extra path prefix within bucket                   |
+| `cache_upload`       | `s3.access_key_id`                                     | none                                                | Access key for presigned S3 uploads/redirects     |
+| `cache_upload`       | `s3.secret_access_key`                                 | none                                                | Secret key for presigned S3 uploads/redirects     |
+| `cache_upload`       | `s3.secret_access_key_file`                            | none                                                | File containing S3 secret access key              |
+| `cache_upload`       | `s3.session_token`                                     | none                                                | Session token for temporary credentials           |
+| `cache_upload`       | `s3.session_token_file`                                | none                                                | File containing S3 session token                  |
+| `cache_upload`       | `s3.endpoint_url`                                      | none                                                | S3-compatible endpoint URL                        |
+| `cache_upload`       | `s3.use_path_style`                                    | `false`                                             | Use path-style addressing                         |
+| `cache_upload`       | `upload_concurrency`                                   | `4`                                                 | Concurrent uploads per build                      |
+| `cache_upload`       | `upload_max_retries`                                   | `3`                                                 | Max retry attempts per path                       |
+| `cache_upload`       | `fail_build_on_upload_error`                           | `false`                                             | Mark build failed on upload error                 |
+| `cache_upload`       | `compression`                                          | `zstd`                                              | Agent presigned-upload NAR compression            |
+| `notifications`      | `webhook_url`                                          | none                                                | HTTP endpoint for build status JSON               |
+| `notifications`      | `webhook_url_file`                                     | none                                                | File containing generic webhook URL               |
+| `notifications`      | `github_token`                                         | none                                                | GitHub token for commit status updates            |
+| `notifications`      | `github_token_file`                                    | none                                                | File containing GitHub token                      |
+| `notifications`      | `gitea_url`                                            | none                                                | Gitea/Forgejo instance URL                        |
+| `notifications`      | `gitea_token`                                          | none                                                | Gitea/Forgejo API token                           |
+| `notifications`      | `gitea_token_file`                                     | none                                                | File containing Gitea/Forgejo token               |
+| `notifications`      | `gitlab_url`                                           | none                                                | GitLab instance URL                               |
+| `notifications`      | `gitlab_token`                                         | none                                                | GitLab API token                                  |
+| `notifications`      | `gitlab_token_file`                                    | none                                                | File containing GitLab token                      |
+| `notifications`      | `enable_retry_queue`                                   | `true`                                              | Persistent retry queue with backoff               |
+| `notifications`      | `max_retry_attempts`                                   | `5`                                                 | Max notification retry attempts                   |
+| `notifications`      | `retention_days`                                       | `7`                                                 | Retention for completed notification tasks        |
+| `notifications`      | `retry_poll_interval`                                  | `5`                                                 | Retry poll interval (seconds)                     |
+| `notifications`      | `email.smtp_host`                                      | none                                                | SMTP host for email notifications                 |
+| `notifications`      | `email.smtp_port`                                      | none                                                | SMTP port                                         |
+| `notifications`      | `email.smtp_user`                                      | none                                                | SMTP username (optional)                          |
+| `notifications`      | `email.smtp_password`                                  | none                                                | SMTP password (optional)                          |
+| `notifications`      | `email.smtp_password_file`                             | none                                                | File containing SMTP password                     |
+| `notifications`      | `email.tls`                                            | `false`                                             | Enable TLS for SMTP connection                    |
+| `notifications`      | `email.from_address`                                   | none                                                | From address for notification emails              |
+| `notifications`      | `email.to_addresses`                                   | `[]`                                                | Recipient addresses                               |
+| `notifications`      | `slack.webhook_url`                                    | none                                                | Slack incoming webhook URL                        |
+| `notifications`      | `slack.webhook_url_file`                               | none                                                | File containing Slack webhook URL                 |
+| `notifications`      | `slack.on_failure_only`                                | `false`                                             | Only send Slack alerts on failure                 |
+| `notifications`      | `alerts.enabled`                                       | `false`                                             | Enable error-rate threshold alerts                |
+| `notifications`      | `alerts.error_threshold`                               | `0.5`                                               | Error rate threshold to trigger alert             |
+| `notifications`      | `alerts.time_window_minutes`                           | `60`                                                | Time window for error rate calculation            |
+| `tracing`            | `level`                                                | `info`                                              | Log level (trace/debug/info/warn/error)           |
+| `tracing`            | `format`                                               | `compact`                                           | Log output format                                 |
+| `tracing`            | `show_targets`                                         | `true`                                              | Show module path in log messages                  |
+| `tracing`            | `show_timestamps`                                      | `true`                                              | Show timestamps in log messages                   |
+| `oauth`              | `github.client_id`                                     | none                                                | GitHub OAuth App client ID                        |
+| `oauth`              | `github.client_secret`                                 | none                                                | GitHub OAuth App client secret                    |
+| `oauth`              | `github.client_secret_file`                            | none                                                | File containing GitHub OAuth secret               |
+| `oauth`              | `github.redirect_uri`                                  | none                                                | OAuth redirect URI                                |
+| `declarative`        | `projects`                                             | `[]`                                                | Declarative project definitions                   |
+| `declarative`        | `api_keys`                                             | `[]`                                                | Declarative API key definitions                   |
+| `declarative`        | `users`                                                | `[]`                                                | Declarative user definitions                      |
+| `declarative`        | `remote_builders`                                      | `[]`                                                | Declarative remote builder definitions            |
+| `nix`                | `store_dir`                                            | `/nix/store`                                        | Nix store directory                               |
 
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
With `restrict_eval` on and an empty `allowed_uris`, every remote flake input was blocked, so no real flake could be evaluated.

Derive the allowlist from the project `flake.lock` instead, keeping undeclared `builtins.fetch*` still blocked.