### PR TITLE
scheduler: select dependency-ready pending builds

### DIFF
--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -142,20 +142,22 @@ pub async fn list_pending(
 ) -> Result<Vec<Build>> {
   Ok(
     sqlx::query_as::<_, Build>(
-      "WITH running_counts AS ( SELECT e.jobset_id, COUNT(*) AS running FROM \
-       builds b JOIN evaluations e ON b.evaluation_id = e.id WHERE b.status = \
-       'running' GROUP BY e.jobset_id ), active_shares AS ( SELECT j.id AS \
-       jobset_id, j.scheduling_shares, COALESCE(rc.running, 0) AS running, \
-       SUM(j.scheduling_shares) OVER () AS total_shares FROM jobsets j JOIN \
-       evaluations e2 ON e2.jobset_id = j.id JOIN builds b2 ON \
-       b2.evaluation_id = e2.id AND b2.status = 'pending' LEFT JOIN \
+      "WITH eligible_pending AS ( SELECT b.* FROM builds b WHERE b.status = \
+       'pending' AND NOT EXISTS ( SELECT 1 FROM build_dependencies bd JOIN \
+       builds dep ON dep.id = bd.dependency_build_id WHERE bd.build_id = b.id \
+       AND dep.status != 'succeeded' ) ), running_counts AS ( SELECT \
+       e.jobset_id, COUNT(*) AS running FROM builds b JOIN evaluations e ON \
+       b.evaluation_id = e.id WHERE b.status = 'running' GROUP BY e.jobset_id \
+       ), active_shares AS ( SELECT j.id AS jobset_id, j.scheduling_shares, \
+       COALESCE(rc.running, 0) AS running, SUM(j.scheduling_shares) OVER () \
+       AS total_shares FROM jobsets j JOIN evaluations e2 ON e2.jobset_id = \
+       j.id JOIN eligible_pending b2 ON b2.evaluation_id = e2.id LEFT JOIN \
        running_counts rc ON rc.jobset_id = j.id WHERE j.scheduling_shares > 0 \
        GROUP BY j.id, j.scheduling_shares, rc.running ) SELECT b.* FROM \
-       builds b JOIN evaluations e ON b.evaluation_id = e.id JOIN \
-       active_shares ash ON ash.jobset_id = e.jobset_id WHERE b.status = \
-       'pending' ORDER BY b.priority DESC, \
-       cardinality(COALESCE(b.effective_features, b.required_features)) DESC, \
-       (ash.scheduling_shares::float / GREATEST(ash.total_shares, 1) - \
+       eligible_pending b JOIN evaluations e ON b.evaluation_id = e.id JOIN \
+       active_shares ash ON ash.jobset_id = e.jobset_id ORDER BY b.priority \
+       DESC, cardinality(COALESCE(b.effective_features, b.required_features)) \
+       DESC, (ash.scheduling_shares::float / GREATEST(ash.total_shares, 1) - \
        ash.running::float / GREATEST($2, 1)) DESC, b.created_at ASC, b.id ASC \
        LIMIT $1",
     )

--- a/crates/common/tests/repo_tests.rs
+++ b/crates/common/tests/repo_tests.rs
@@ -709,6 +709,43 @@ async fn test_batch_check_deps_for_builds() {
 }
 
 #[tokio::test]
+async fn test_list_pending_prioritizes_dependency_ready_builds() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "ready-deps").await;
+  let jobset = create_test_jobset(&pool, project.id).await;
+  let eval = create_test_eval(&pool, jobset.id).await;
+
+  let parent_drv = format!("/nix/store/{}.drv", uuid::Uuid::new_v4().simple());
+  let dependency_drv =
+    format!("/nix/store/{}.drv", uuid::Uuid::new_v4().simple());
+
+  let parent =
+    create_test_build(&pool, eval.id, "parent", &parent_drv, None).await;
+  let dependency =
+    create_test_build(&pool, eval.id, "dependency", &dependency_drv, None)
+      .await;
+  repo::build_dependencies::create(&pool, parent.id, dependency.id)
+    .await
+    .expect("create dependency edge");
+  let bumped = repo::builds::bump_priority(&pool, parent.id, 1)
+    .await
+    .expect("bump blocked parent priority");
+  assert!(bumped.is_some());
+
+  let pending = repo::builds::list_pending(&pool, 1, 1)
+    .await
+    .expect("list pending");
+
+  assert_eq!(pending.len(), 1);
+  assert_eq!(pending[0].id, dependency.id);
+
+  let _ = repo::projects::delete(&pool, project.id).await;
+}
+
+#[tokio::test]
 async fn test_list_filtered_with_system_filter() {
   let Some(pool) = get_pool().await else {
     return;


### PR DESCRIPTION
Fixes a bug where i had 2k builds in the queue but nothing got done.