### PR TITLE
webhooks: trigger pattern jobsets for push refs

### DIFF
--- a/crates/common/src/glob.rs
+++ b/crates/common/src/glob.rs
@@ -1,0 +1,34 @@
+//! Minimal glob matching for ref patterns.
+
+/// Match `value` against `pattern`, where `*` matches any run and `?` one char.
+#[must_use]
+pub fn glob_matches(pattern: &str, value: &str) -> bool {
+  fn inner(pattern: &[u8], value: &[u8]) -> bool {
+    match pattern {
+      [] => value.is_empty(),
+      [b'*', rest @ ..] => {
+        inner(rest, value) || (!value.is_empty() && inner(pattern, &value[1..]))
+      },
+      [b'?', rest @ ..] => !value.is_empty() && inner(rest, &value[1..]),
+      [ch, rest @ ..] => {
+        value.first().is_some_and(|v| v == ch) && inner(rest, &value[1..])
+      },
+    }
+  }
+  inner(pattern.as_bytes(), value.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::glob_matches;
+
+  #[test]
+  fn matches_wildcards_and_single_chars() {
+    assert!(glob_matches("release-*", "release-2026"));
+    assert!(!glob_matches("release-*", "main"));
+    assert!(glob_matches("v1.?", "v1.0"));
+    assert!(!glob_matches("v1.?", "v1.10"));
+    assert!(glob_matches("*", ""));
+    assert!(!glob_matches("", "x"));
+  }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod crypto;
 pub mod database;
 pub mod error;
 pub mod gc_roots;
+pub mod glob;
 pub mod log_storage;
 pub mod migrate;
 pub mod migrate_cli;

--- a/crates/evaluator/src/git.rs
+++ b/crates/evaluator/src/git.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use circus_common::error::{CiError, Result};
+use circus_common::{
+  error::{CiError, Result},
+  glob::glob_matches,
+};
 use git2::Repository;
 
 /// Refspecs fetched on every sync. The first is the standard branch fetch.
@@ -46,22 +49,6 @@ pub struct DiscoveredRef {
   pub kind:        RefKind,
   pub name:        String,
   pub commit_hash: String,
-}
-
-fn glob_matches(pattern: &str, value: &str) -> bool {
-  fn inner(pattern: &[u8], value: &[u8]) -> bool {
-    match pattern {
-      [] => value.is_empty(),
-      [b'*', rest @ ..] => {
-        inner(rest, value) || (!value.is_empty() && inner(pattern, &value[1..]))
-      },
-      [b'?', rest @ ..] => !value.is_empty() && inner(rest, &value[1..]),
-      [ch, rest @ ..] => {
-        value.first().is_some_and(|v| v == ch) && inner(rest, &value[1..])
-      },
-    }
-  }
-  inner(pattern.as_bytes(), value.as_bytes())
 }
 
 fn resolve_ref(

--- a/crates/server/src/routes/webhooks.rs
+++ b/crates/server/src/routes/webhooks.rs
@@ -9,6 +9,7 @@ use axum::{
   routing::post,
 };
 use circus_common::{
+  glob::glob_matches,
   models::{CreateEvaluation, Jobset, JobsetTriggerMode},
   repo,
 };
@@ -70,20 +71,61 @@ fn trace_webhook_repo(
   );
 }
 
-/// Strip the `refs/heads/` prefix from a git ref. Returns the original
-/// string if no such prefix is present.
-fn strip_branch_prefix(git_ref: &str) -> &str {
-  git_ref.strip_prefix("refs/heads/").unwrap_or(git_ref)
+/// A push ref classified by kind.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PushedRef<'a> {
+  Branch(&'a str),
+  Tag(&'a str),
+  Other(&'a str),
 }
 
-/// True if a jobset configured for `jobset_branch` should react to a push
-/// to `pushed_branch`. A jobset with no configured branch matches every
-/// push (treat None as "any branch").
-fn jobset_matches_branch(
-  jobset_branch: Option<&str>,
-  pushed_branch: &str,
-) -> bool {
-  jobset_branch.is_none_or(|b| b == pushed_branch)
+/// Classify a raw push ref.
+fn parse_push_ref(git_ref: &str) -> PushedRef<'_> {
+  git_ref.strip_prefix("refs/heads/").map_or_else(
+    || {
+      git_ref
+        .strip_prefix("refs/tags/")
+        .map_or(PushedRef::Other(git_ref), PushedRef::Tag)
+    },
+    PushedRef::Branch,
+  )
+}
+
+fn normalize_branch_name(branch: &str) -> &str {
+  branch.strip_prefix("refs/heads/").unwrap_or(branch)
+}
+
+/// Matches `branch_pattern` as a glob if set, otherwise `branch` exactly.
+/// A jobset with neither matches every branch unless it is tag-only.
+fn jobset_matches_branch(jobset: &Jobset, pushed_branch: &str) -> bool {
+  if let Some(pattern) = jobset.branch_pattern.as_deref() {
+    return glob_matches(pattern, pushed_branch);
+  }
+  jobset
+    .branch
+    .as_deref()
+    .map(normalize_branch_name)
+    .map_or_else(
+      || jobset.tag_pattern.is_none(),
+      |branch| branch == pushed_branch,
+    )
+}
+
+/// Whether a tag push should trigger `jobset`.
+fn jobset_matches_tag(jobset: &Jobset, pushed_tag: &str) -> bool {
+  jobset
+    .tag_pattern
+    .as_deref()
+    .is_some_and(|pattern| glob_matches(pattern, pushed_tag))
+}
+
+/// Whether a push to `pushed_ref` should trigger `jobset`.
+fn jobset_matches_push_ref(jobset: &Jobset, pushed_ref: PushedRef<'_>) -> bool {
+  match pushed_ref {
+    PushedRef::Branch(branch) => jobset_matches_branch(jobset, branch),
+    PushedRef::Tag(tag) => jobset_matches_tag(jobset, tag),
+    PushedRef::Other(_) => false,
+  }
 }
 
 fn jobset_accepts_source_trigger(jobset: &Jobset) -> bool {
@@ -98,7 +140,7 @@ async fn trigger_push_evaluations(
   state: &AppState,
   project_id: Uuid,
   commit: &str,
-  pushed_branch: &str,
+  pushed_ref: PushedRef<'_>,
 ) -> Result<usize, ApiError> {
   let jobsets =
     repo::jobsets::list_all_for_project(&state.pool, project_id).await?;
@@ -108,7 +150,7 @@ async fn trigger_push_evaluations(
     if !jobset_accepts_source_trigger(jobset) {
       continue;
     }
-    if !jobset_matches_branch(jobset.branch.as_deref(), pushed_branch) {
+    if !jobset_matches_push_ref(jobset, pushed_ref) {
       continue;
     }
     match repo::evaluations::create(&state.pool, CreateEvaluation {
@@ -153,7 +195,7 @@ async fn trigger_change_request_evaluations(
     if !jobset_accepts_source_trigger(jobset) {
       continue;
     }
-    if !jobset_matches_branch(jobset.branch.as_deref(), base) {
+    if !jobset_matches_branch(jobset, base) {
       continue;
     }
     match repo::evaluations::create(&state.pool, CreateEvaluation {

--- a/crates/server/src/routes/webhooks/gitea_compatible.rs
+++ b/crates/server/src/routes/webhooks/gitea_compatible.rs
@@ -8,12 +8,13 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use super::{
+  PushedRef,
   WebhookResponse,
   branch_deletion_response,
   header_value,
   invalid_signature_response,
   is_deleted_commit,
-  strip_branch_prefix,
+  parse_push_ref,
   trace_webhook_repo,
   trigger_push_evaluations,
   triggered_push_response,
@@ -122,12 +123,13 @@ async fn process_push(
     return Ok(branch_deletion_response());
   }
 
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+  let pushed_ref = payload
+    .git_ref
+    .as_deref()
+    .map_or(PushedRef::Other(""), parse_push_ref);
 
   let triggered =
-    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
-      .await?;
+    trigger_push_evaluations(&state, project_id, &commit, pushed_ref).await?;
 
   Ok(triggered_push_response(triggered, &commit))
 }

--- a/crates/server/src/routes/webhooks/github.rs
+++ b/crates/server/src/routes/webhooks/github.rs
@@ -10,12 +10,13 @@ use uuid::Uuid;
 
 use super::{
   ChangeRequestEvaluation,
+  PushedRef,
   WebhookResponse,
   branch_deletion_response,
   header_value,
   invalid_signature_response,
   is_deleted_commit,
-  strip_branch_prefix,
+  parse_push_ref,
   trace_webhook_repo,
   trigger_change_request_evaluations,
   trigger_push_evaluations,
@@ -133,12 +134,13 @@ async fn handle_push(
     return Ok(branch_deletion_response());
   }
 
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+  let pushed_ref = payload
+    .git_ref
+    .as_deref()
+    .map_or(PushedRef::Other(""), parse_push_ref);
 
   let triggered =
-    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
-      .await?;
+    trigger_push_evaluations(&state, project_id, &commit, pushed_ref).await?;
 
   Ok(triggered_push_response(triggered, &commit))
 }

--- a/crates/server/src/routes/webhooks/gitlab.rs
+++ b/crates/server/src/routes/webhooks/gitlab.rs
@@ -10,11 +10,12 @@ use uuid::Uuid;
 
 use super::{
   ChangeRequestEvaluation,
+  PushedRef,
   WebhookResponse,
   branch_deletion_response,
   header_value,
   is_deleted_commit,
-  strip_branch_prefix,
+  parse_push_ref,
   trigger_change_request_evaluations,
   trigger_push_evaluations,
   triggered_push_response,
@@ -143,12 +144,13 @@ async fn handle_push(
     return Ok(branch_deletion_response());
   }
 
-  let pushed_branch =
-    payload.git_ref.as_deref().map_or("", strip_branch_prefix);
+  let pushed_ref = payload
+    .git_ref
+    .as_deref()
+    .map_or(PushedRef::Other(""), parse_push_ref);
 
   let triggered =
-    trigger_push_evaluations(&state, project_id, &commit, pushed_branch)
-      .await?;
+    trigger_push_evaluations(&state, project_id, &commit, pushed_ref).await?;
 
   Ok(triggered_push_response(triggered, &commit))
 }

--- a/crates/server/src/routes/webhooks/tests.rs
+++ b/crates/server/src/routes/webhooks/tests.rs
@@ -62,10 +62,90 @@ fn test_verify_signature_wrong_secret() {
   assert!(!verify_signature("secret2", body, &format!("sha256={sig}")));
 }
 
+fn test_jobset(
+  branch: Option<&str>,
+  branch_pattern: Option<&str>,
+  tag_pattern: Option<&str>,
+) -> Jobset {
+  Jobset {
+    id:                uuid::Uuid::new_v4(),
+    project_id:        uuid::Uuid::new_v4(),
+    name:              "checks".to_string(),
+    nix_expression:    ".".to_string(),
+    enabled:           true,
+    flake_mode:        true,
+    check_interval:    60,
+    trigger_mode:      JobsetTriggerMode::SourceChange,
+    branch:            branch.map(str::to_string),
+    branch_pattern:    branch_pattern.map(str::to_string),
+    tag_pattern:       tag_pattern.map(str::to_string),
+    scheduling_shares: 100,
+    created_at:        chrono::Utc::now(),
+    updated_at:        chrono::Utc::now(),
+    state:             circus_common::models::JobsetState::Enabled,
+    last_checked_at:   None,
+    keep_nr:           3,
+  }
+}
+
 #[test]
-fn strip_branch_prefix_handles_heads_and_plain_names() {
-  assert_eq!(strip_branch_prefix("refs/heads/main"), "main");
-  assert_eq!(strip_branch_prefix("feature"), "feature");
+fn parse_push_ref_handles_branches_tags_and_unknown_refs() {
+  assert_eq!(parse_push_ref("refs/heads/main"), PushedRef::Branch("main"));
+  assert_eq!(parse_push_ref("refs/tags/v1.0"), PushedRef::Tag("v1.0"));
+  assert_eq!(parse_push_ref("feature"), PushedRef::Other("feature"));
+}
+
+#[test]
+fn jobset_push_ref_matching_supports_branch_and_tag_patterns() {
+  let legacy_any = test_jobset(None, None, None);
+  assert!(jobset_matches_push_ref(
+    &legacy_any,
+    PushedRef::Branch("feature")
+  ));
+  assert!(!jobset_matches_push_ref(
+    &legacy_any,
+    PushedRef::Tag("v1.0")
+  ));
+
+  let legacy_branch = test_jobset(Some("main"), None, None);
+  assert!(jobset_matches_push_ref(
+    &legacy_branch,
+    PushedRef::Branch("main")
+  ));
+  assert!(!jobset_matches_push_ref(
+    &legacy_branch,
+    PushedRef::Branch("release")
+  ));
+
+  let release_branches = test_jobset(None, Some("release-*"), None);
+  assert!(jobset_matches_push_ref(
+    &release_branches,
+    PushedRef::Branch("release-2026")
+  ));
+  assert!(!jobset_matches_push_ref(
+    &release_branches,
+    PushedRef::Branch("main")
+  ));
+
+  let release_tags = test_jobset(None, None, Some("v1.*"));
+  assert!(jobset_matches_push_ref(
+    &release_tags,
+    PushedRef::Tag("v1.2")
+  ));
+  assert!(!jobset_matches_push_ref(
+    &release_tags,
+    PushedRef::Branch("main")
+  ));
+
+  let branch_and_tags = test_jobset(Some("main"), None, Some("v1.*"));
+  assert!(jobset_matches_push_ref(
+    &branch_and_tags,
+    PushedRef::Branch("main")
+  ));
+  assert!(jobset_matches_push_ref(
+    &branch_and_tags,
+    PushedRef::Tag("v1.2")
+  ));
 }
 
 #[test]


### PR DESCRIPTION
Parse push refs as branches or tags before fan-out, then match them against `branch_pattern` and `tag_pattern`. This lets pattern-only jobsets react immediately to branch and tag webhook events.