### PR TITLE
circus-server: parse Nix's `internal-json` logs and render structured build logs

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -28,6 +28,9 @@ exceptions = [
   ], crate = "evix" },
   { allow = [
     "EUPL-1.2",
+  ], crate = "cognos" },
+  { allow = [
+    "EUPL-1.2",
   ], crate = "pound" },
   { allow = [
     "EUPL-1.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "circus-proto",
  "circus-s3",
  "clap",
+ "cognos",
  "color-eyre",
  "config",
  "dashmap",
@@ -1086,6 +1087,17 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cognos"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde1effdc2ca9df723c82f6b5f394de16cd8ca226f5ca6c6f5313f7f98dcf51c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
 
 [[package]]
 name = "color-eyre"
@@ -3955,6 +3967,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,9 @@ argon2 = { version = "0.5.3", features = [ "std" ] }
 # crate keeps ring (matching the rest of our stack) for RS256 verification.
 jsonwebtoken = { version = "10.4.0", default-features = false }
 
-# evix, in-process Nix evaluator (nix-eval-jobs replacement) driven as a library.
-evix = { version = "0.3.3", features = [ "flake" ] }
+# In-house crates and Nix utilities
+cognos = "1.0.0"
+evix   = { version = "0.3.3", features = [ "flake" ] }
 
 # Workspace Clippy lints. All workspace crates must inherit them in individual
 # manifests for subcrates. The below list is a rather pedantic list of lints

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -55,7 +55,8 @@ circus-nix.workspace          = true
 circus-notification.workspace = true
 circus-s3.workspace           = true
 
-regex.workspace = true
+cognos.workspace = true
+regex.workspace  = true
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/crates/server/src/routes/dashboard/build_log.rs
+++ b/crates/server/src/routes/dashboard/build_log.rs
@@ -1,0 +1,495 @@
+//! Structured Nix build-log parsing for the dashboard log page.
+
+use std::collections::HashMap;
+
+use cognos::internal::json::{
+  self as nix_json,
+  Actions,
+  Activities,
+  Id,
+  ResultType,
+};
+
+use super::shared::{
+  classify_plain_line,
+  classify_verbosity,
+  display_log_line,
+  strip_ansi,
+};
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum Severity {
+  Error,
+  Warn,
+  Notice,
+  Info,
+  Debug,
+  Phase,
+}
+
+impl Severity {
+  const fn css_class(self) -> &'static str {
+    match self {
+      Self::Error => "error",
+      Self::Warn => "warn",
+      Self::Notice => "notice",
+      Self::Info => "info",
+      Self::Debug => "debug",
+      Self::Phase => "phase",
+    }
+  }
+}
+
+impl From<&'static str> for Severity {
+  fn from(class: &'static str) -> Self {
+    match class {
+      "error" => Self::Error,
+      "warn" => Self::Warn,
+      "notice" => Self::Notice,
+      "debug" => Self::Debug,
+      "phase" => Self::Phase,
+      _ => Self::Info,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ActivityStatus {
+  Running,
+  Success,
+  Failed,
+  Open,
+}
+
+impl ActivityStatus {
+  const fn label(self) -> &'static str {
+    match self {
+      Self::Running => "running",
+      Self::Success => "completed",
+      Self::Failed => "failed",
+      Self::Open => "open",
+    }
+  }
+
+  const fn css_class(self) -> &'static str {
+    match self {
+      Self::Running | Self::Open => "running",
+      Self::Success => "success",
+      Self::Failed => "failed",
+    }
+  }
+}
+
+#[derive(Clone, Copy)]
+enum ActivityKind {
+  Unknown,
+  CopyPath,
+  FileTransfer,
+  Realise,
+  CopyPaths,
+  Builds,
+  Build,
+  OptimiseStore,
+  VerifyPath,
+  Substitute,
+  QueryPathInfo,
+  PostBuildHook,
+  BuildWaiting,
+  FetchTree,
+}
+
+impl ActivityKind {
+  const fn label(self) -> &'static str {
+    match self {
+      Self::Unknown => "activity",
+      Self::CopyPath => "copy path",
+      Self::FileTransfer => "file transfer",
+      Self::Realise => "realise",
+      Self::CopyPaths => "copy paths",
+      Self::Builds => "build set",
+      Self::Build => "build",
+      Self::OptimiseStore => "optimise store",
+      Self::VerifyPath => "verify path",
+      Self::Substitute => "substitute",
+      Self::QueryPathInfo => "query path",
+      Self::PostBuildHook => "post-build hook",
+      Self::BuildWaiting => "waiting",
+      Self::FetchTree => "fetch tree",
+    }
+  }
+}
+
+impl From<Activities> for ActivityKind {
+  fn from(activity: Activities) -> Self {
+    match activity {
+      Activities::Unknown => Self::Unknown,
+      Activities::CopyPath => Self::CopyPath,
+      Activities::FileTransfer => Self::FileTransfer,
+      Activities::Realise => Self::Realise,
+      Activities::CopyPaths => Self::CopyPaths,
+      Activities::Builds => Self::Builds,
+      Activities::Build => Self::Build,
+      Activities::OptimiseStore => Self::OptimiseStore,
+      Activities::VerifyPath => Self::VerifyPath,
+      Activities::Substitute => Self::Substitute,
+      Activities::QueryPathInfo => Self::QueryPathInfo,
+      Activities::PostBuildHook => Self::PostBuildHook,
+      Activities::BuildWaiting => Self::BuildWaiting,
+      Activities::FetchTree => Self::FetchTree,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum BuildLogLineKind {
+  Message,
+  Phase,
+}
+
+pub(super) struct BuildLogSummaryView {
+  pub(super) visible_lines:  usize,
+  pub(super) activity_count: usize,
+  pub(super) error_count:    usize,
+  pub(super) warning_count:  usize,
+}
+
+pub(super) struct BuildLogActivityView {
+  pub(super) depth:      usize,
+  kind:                  ActivityKind,
+  pub(super) label:      String,
+  pub(super) detail:     String,
+  status:                ActivityStatus,
+  pub(super) line_count: usize,
+  pub(super) line_range: String,
+  first_line:            Option<usize>,
+  last_line:             Option<usize>,
+}
+
+impl BuildLogActivityView {
+  pub(super) const fn kind(&self) -> &'static str {
+    self.kind.label()
+  }
+
+  pub(super) const fn status(&self) -> &'static str {
+    self.status.label()
+  }
+
+  pub(super) const fn status_class(&self) -> &'static str {
+    self.status.css_class()
+  }
+
+  pub(super) const fn is_failed(&self) -> bool {
+    matches!(self.status, ActivityStatus::Failed)
+  }
+}
+
+pub(super) struct BuildLogLineView {
+  pub(super) number: usize,
+  level:             Severity,
+  kind:              BuildLogLineKind,
+  pub(super) text:   String,
+}
+
+impl BuildLogLineView {
+  pub(super) const fn level_class(&self) -> &'static str {
+    self.level.css_class()
+  }
+
+  pub(super) const fn is_phase(&self) -> bool {
+    matches!(self.kind, BuildLogLineKind::Phase)
+  }
+}
+
+pub(super) struct BuildLogView {
+  pub(super) summary:    BuildLogSummaryView,
+  pub(super) activities: Vec<BuildLogActivityView>,
+  pub(super) lines:      Vec<BuildLogLineView>,
+}
+
+fn field_as_display(value: &serde_json::Value) -> Option<String> {
+  match value {
+    serde_json::Value::String(s) => Some(s.clone()),
+    serde_json::Value::Number(n) => Some(n.to_string()),
+    serde_json::Value::Bool(b) => Some(b.to_string()),
+    _ => None,
+  }
+}
+
+fn first_field(fields: &[serde_json::Value]) -> String {
+  fields.iter().find_map(field_as_display).unwrap_or_default()
+}
+
+fn field_at(fields: &[serde_json::Value], index: usize) -> String {
+  fields
+    .get(index)
+    .and_then(field_as_display)
+    .unwrap_or_default()
+}
+
+fn activity_depth(
+  activities: &[BuildLogActivityView],
+  activity_index: &HashMap<Id, usize>,
+  parent: Id,
+) -> usize {
+  if parent == 0 {
+    return 0;
+  }
+  activity_index
+    .get(&parent)
+    .map_or(0, |idx| activities[*idx].depth.saturating_add(1))
+    .min(6)
+}
+
+fn activity_label(text: &str, fields: &[serde_json::Value]) -> String {
+  let text = strip_ansi(text).trim().to_string();
+  if text.is_empty() {
+    first_field(fields)
+  } else {
+    text
+  }
+}
+
+fn activity_detail(
+  kind: ActivityKind,
+  fields: &[serde_json::Value],
+  label: &str,
+) -> String {
+  let detail = match kind {
+    ActivityKind::Builds | ActivityKind::Unknown => String::new(),
+    ActivityKind::Build => field_at(fields, 0),
+    ActivityKind::Substitute => {
+      let cache = field_at(fields, 1);
+      if cache.starts_with("http://") || cache.starts_with("https://") {
+        format!("from {cache}")
+      } else {
+        field_at(fields, 0)
+      }
+    },
+    _ => first_field(fields),
+  };
+
+  if detail == label {
+    String::new()
+  } else {
+    detail
+  }
+}
+
+fn record_activity_line(
+  activities: &mut [BuildLogActivityView],
+  idx: usize,
+  line_number: usize,
+) {
+  let activity = &mut activities[idx];
+  activity.line_count += 1;
+  if activity.first_line.is_none() {
+    activity.first_line = Some(line_number);
+  }
+  activity.last_line = Some(line_number);
+  activity.line_range = match (activity.first_line, activity.last_line) {
+    (Some(first), Some(last)) if first == last => format!("line {first}"),
+    (Some(first), Some(last)) => format!("lines {first}-{last}"),
+    _ => String::new(),
+  };
+}
+
+pub(super) fn parse_build_log(raw: &str) -> BuildLogView {
+  let mut activities = Vec::<BuildLogActivityView>::new();
+  let mut activity_index = HashMap::<Id, usize>::new();
+  let mut active_stack = Vec::<Id>::new();
+  let mut lines = Vec::<BuildLogLineView>::new();
+  let mut error_count = 0usize;
+  let mut warning_count = 0usize;
+
+  for raw_line in raw.lines() {
+    match nix_json::parse_line(raw_line) {
+      Some(Actions::Start {
+        id,
+        parent,
+        text,
+        activity,
+        fields,
+        ..
+      }) => {
+        let kind = ActivityKind::from(activity);
+        let label = activity_label(&text, &fields);
+        let detail = activity_detail(kind, &fields, &label);
+        let depth = activity_depth(&activities, &activity_index, parent);
+        activity_index.insert(id, activities.len());
+        activities.push(BuildLogActivityView {
+          depth,
+          kind,
+          label: if label.is_empty() {
+            kind.label().to_string()
+          } else {
+            label
+          },
+          detail,
+          status: ActivityStatus::Running,
+          line_count: 0,
+          line_range: String::new(),
+          first_line: None,
+          last_line: None,
+        });
+        active_stack.push(id);
+      },
+      Some(Actions::Stop { id }) => {
+        if let Some(idx) = activity_index.get(&id).copied()
+          && activities[idx].status == ActivityStatus::Running
+        {
+          activities[idx].status = ActivityStatus::Success;
+        }
+        while let Some(active_id) = active_stack.pop() {
+          if active_id == id {
+            break;
+          }
+        }
+      },
+      Some(Actions::Message {
+        level,
+        msg,
+        raw_msg,
+        ..
+      }) => {
+        let text = display_log_line(raw_msg.as_deref().unwrap_or(&msg));
+        if text.is_empty() {
+          continue;
+        }
+        let level = Severity::from(classify_verbosity(level));
+        if level == Severity::Error {
+          error_count += 1;
+          if let Some(idx) = active_stack
+            .last()
+            .and_then(|id| activity_index.get(id))
+            .copied()
+          {
+            activities[idx].status = ActivityStatus::Failed;
+          }
+        } else if level == Severity::Warn {
+          warning_count += 1;
+        }
+        if let Some(idx) = active_stack
+          .last()
+          .and_then(|id| activity_index.get(id))
+          .copied()
+        {
+          record_activity_line(&mut activities, idx, lines.len() + 1);
+        }
+        lines.push(BuildLogLineView {
+          number: lines.len() + 1,
+          level,
+          kind: BuildLogLineKind::Message,
+          text,
+        });
+      },
+      Some(Actions::Result {
+        id,
+        result_type: ResultType::BuildLogLine | ResultType::PostBuildLogLine,
+        fields,
+      }) => {
+        let Some(text) = fields.first().and_then(serde_json::Value::as_str)
+        else {
+          continue;
+        };
+        let text = display_log_line(text);
+        if text.is_empty() {
+          continue;
+        }
+        let level = Severity::from(classify_plain_line(&text));
+        if level == Severity::Error {
+          error_count += 1;
+        } else if level == Severity::Warn {
+          warning_count += 1;
+        }
+        if let Some(idx) = activity_index.get(&id).copied() {
+          record_activity_line(&mut activities, idx, lines.len() + 1);
+          if level == Severity::Error {
+            activities[idx].status = ActivityStatus::Failed;
+          }
+        }
+        lines.push(BuildLogLineView {
+          number: lines.len() + 1,
+          level,
+          kind: BuildLogLineKind::Message,
+          text,
+        });
+      },
+      Some(Actions::Result {
+        result_type: ResultType::SetPhase,
+        fields,
+        ..
+      }) => {
+        let phase = first_field(&fields);
+        if !phase.is_empty() {
+          lines.push(BuildLogLineView {
+            number: lines.len() + 1,
+            level:  Severity::Phase,
+            kind:   BuildLogLineKind::Phase,
+            text:   phase,
+          });
+        }
+      },
+      None if !raw_line.starts_with("@nix ") => {
+        let text = display_log_line(raw_line);
+        if text.is_empty() {
+          continue;
+        }
+        let level = Severity::from(classify_plain_line(&text));
+        if level == Severity::Error {
+          error_count += 1;
+        } else if level == Severity::Warn {
+          warning_count += 1;
+        }
+        lines.push(BuildLogLineView {
+          number: lines.len() + 1,
+          level,
+          kind: BuildLogLineKind::Message,
+          text,
+        });
+      },
+      Some(Actions::Result { .. }) | None => {},
+    }
+  }
+
+  for activity in &mut activities {
+    if activity.status == ActivityStatus::Running {
+      activity.status = ActivityStatus::Open;
+    }
+  }
+
+  BuildLogView {
+    summary: BuildLogSummaryView {
+      visible_lines: lines.len(),
+      activity_count: activities.len(),
+      error_count,
+      warning_count,
+    },
+    activities,
+    lines,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_build_log_decodes_internal_json() {
+    let raw = [
+      r#"@nix {"action":"start","id":1}"#,
+      r#"@nix {"action":"result","id":1,"type":101,"fields":["cc -c main.c"]}"#,
+      r#"@nix {"action":"result","id":1,"type":105,"fields":[0,1]}"#,
+      r#"@nix {"action":"msg","level":0,"msg":"error: build failed"}"#,
+      "plain stdout line",
+      r#"@nix {"action":"stop","id":1}"#,
+    ]
+    .join("\n");
+
+    let log = parse_build_log(&raw);
+    assert_eq!(log.summary.visible_lines, 3);
+    assert_eq!(log.summary.error_count, 1);
+    assert_eq!(log.lines[0].text, "cc -c main.c");
+    assert_eq!(log.lines[1].text, "error: build failed");
+    assert_eq!(log.lines[2].text, "plain stdout line");
+  }
+}

--- a/crates/server/src/routes/dashboard/mod.rs
+++ b/crates/server/src/routes/dashboard/mod.rs
@@ -19,6 +19,7 @@ use crate::state::AppState;
 
 mod admin;
 mod auth;
+mod build_log;
 mod pages;
 mod preview;
 mod shared;

--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -13,7 +13,7 @@ use std::{
 
 use axum::{
   extract::{Path, Query, State},
-  http::{StatusCode, header},
+  http::StatusCode,
   response::{Html, IntoResponse, Response},
 };
 use circus_common::models::{Build, BuildStatus};
@@ -21,6 +21,7 @@ use tokio::fs;
 use uuid::Uuid;
 
 use super::{
+  build_log::parse_build_log,
   shared::{
     BuildView,
     DashboardContext,
@@ -36,7 +37,6 @@ use super::{
     WorkerSummaryView,
     build_view,
     build_view_with_context,
-    decode_build_log,
     enforce_page_access,
     eval_badge,
     eval_view,
@@ -45,6 +45,7 @@ use super::{
     status_badge,
   },
   templates::{
+    BuildLogTemplate,
     BuildTemplate,
     BuildsTemplate,
     EvaluationTemplate,
@@ -878,7 +879,7 @@ pub(super) async fn build_page(
   tmpl.render_html_or_500()
 }
 
-/// Serve a build's full log as plain text.
+/// Render a build's full log as a structured dashboard page.
 pub(super) async fn build_log(
   State(state): State<AppState>,
   Path(id): Path<Uuid>,
@@ -900,6 +901,23 @@ pub(super) async fn build_log(
   {
     return Ok((StatusCode::NOT_FOUND, "Build not found").into_response());
   }
+
+  let Ok(eval) =
+    circus_common::repo::evaluations::get(&state.pool, build.evaluation_id)
+      .await
+  else {
+    return Ok((StatusCode::NOT_FOUND, "Evaluation not found").into_response());
+  };
+  let Ok(jobset) =
+    circus_common::repo::jobsets::get(&state.pool, eval.jobset_id).await
+  else {
+    return Ok((StatusCode::NOT_FOUND, "Jobset not found").into_response());
+  };
+  let Ok(project) =
+    circus_common::repo::projects::get(&state.pool, jobset.project_id).await
+  else {
+    return Ok((StatusCode::NOT_FOUND, "Project not found").into_response());
+  };
 
   let Some(path) = build.log_path.as_deref().filter(|p| !p.is_empty()) else {
     return Ok(
@@ -923,13 +941,25 @@ pub(super) async fn build_log(
     );
   };
 
-  Ok(
-    (
-      [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
-      decode_build_log(&raw),
-    )
-      .into_response(),
-  )
+  let eval_commit_short = if eval.commit_hash.len() > 12 {
+    eval.commit_hash[..12].to_string()
+  } else {
+    eval.commit_hash.clone()
+  };
+  let tmpl = BuildLogTemplate {
+    ui: ui_config(&state),
+    build: build_view(&build),
+    log: parse_build_log(&raw),
+    eval_id: eval.id,
+    eval_commit_short,
+    jobset_id: jobset.id,
+    jobset_name: jobset.name,
+    project_id: project.id,
+    project_name: project.name,
+    is_admin: ctx.is_admin,
+    auth_name: ctx.auth_name.clone(),
+  };
+  tmpl.render_html_or_500().map(IntoResponse::into_response)
 }
 
 #[cfg(test)]

--- a/crates/server/src/routes/dashboard/preview/fixtures.rs
+++ b/crates/server/src/routes/dashboard/preview/fixtures.rs
@@ -245,50 +245,12 @@ pub(super) fn build_log_template(build_id: Uuid) -> Option<BuildLogTemplate> {
   })
 }
 
-const PREVIEW_SUCCEEDED_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
-@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
-@nix {"action":"stop","id":2}
-@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/8s69x68y-circus-server-0.12.0.drv'","type":105,"fields":["/nix/store/8s69x68y-circus-server-0.12.0.drv","builder-01",1,1]}
-@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
-@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
-@nix {"action":"result","id":10,"type":104,"fields":["patchPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["applying patch /nix/store/h3ad2x8q-use-workspace-cargo-lock.patch"]}
-@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --release"]}
-@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
-@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
-@nix {"action":"result","id":10,"type":104,"fields":["installPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["installing target/release/circus-server to /nix/store/lq2n7cav-circus-server-0.12.0/bin"]}
-@nix {"action":"stop","id":10}
-@nix {"action":"stop","id":1}"#;
-
-const PREVIEW_FAILED_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
-@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
-@nix {"action":"stop","id":2}
-@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv'","type":105,"fields":["/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv","builder-aarch64-01",1,1]}
-@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
-@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
-@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --target aarch64-unknown-linux-gnu --release"]}
-@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
-@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
-@nix {"action":"msg","level":1,"msg":"warning: cargo is rebuilding the workspace because Cargo.lock changed"}
-@nix {"action":"result","id":10,"type":101,"fields":["error: linking with `aarch64-unknown-linux-gnu-cc` failed: exit status: 1"]}
-@nix {"action":"result","id":10,"type":101,"fields":["  = note: collect2: fatal error: ld terminated with signal 9 [Killed]"]}
-@nix {"action":"result","id":10,"type":101,"fields":["          compilation terminated."]}
-@nix {"action":"result","id":10,"type":101,"fields":["error: could not compile `circus-server` due to previous error; 1 warning emitted"]}
-@nix {"action":"msg","level":0,"msg":"error: builder for '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv' failed with exit code 101"}
-@nix {"action":"stop","id":10}
-@nix {"action":"stop","id":1}"#;
-
-const PREVIEW_RUNNING_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"running integration checks","type":104,"fields":[1]}
-@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/mx19g4kq-circus-integration-check.drv'","type":105,"fields":["/nix/store/mx19g4kq-circus-integration-check.drv","builder-01",1,1]}
-@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
-@nix {"action":"result","id":10,"type":101,"fields":["cargo test --workspace --test integration"]}
-@nix {"action":"result","id":10,"type":101,"fields":["running 12 integration tests"]}
-@nix {"action":"msg","level":3,"msg":"test evaluator_schedules_builds ... ok"}"#;
+const PREVIEW_SUCCEEDED_BUILD_LOG: &str =
+  include_str!("fixtures/build-00000004.internal-json");
+const PREVIEW_FAILED_BUILD_LOG: &str =
+  include_str!("fixtures/build-00000005.internal-json");
+const PREVIEW_RUNNING_BUILD_LOG: &str =
+  include_str!("fixtures/build-00000006.internal-json");
 
 pub(super) fn queue_build(
   n: u128,

--- a/crates/server/src/routes/dashboard/preview/fixtures.rs
+++ b/crates/server/src/routes/dashboard/preview/fixtures.rs
@@ -13,6 +13,7 @@ use sqlx::types::Json as SqlxJson;
 use uuid::Uuid;
 
 use super::super::{
+  build_log::parse_build_log,
   shared::{
     BuildErrorLine,
     BuildView,
@@ -25,7 +26,7 @@ use super::super::{
     QueueBuildView,
     short_uuid,
   },
-  templates::UiTemplateConfig,
+  templates::{BuildLogTemplate, UiTemplateConfig},
 };
 use crate::permissions::UiPermissions;
 
@@ -122,6 +123,7 @@ pub(super) fn build_view(
   class: &str,
 ) -> BuildView {
   let build_id = id(n);
+  let system = job.split('.').nth(1).unwrap_or("x86_64-linux");
   BuildView {
     id:            build_id,
     id_short:      short_uuid(build_id),
@@ -132,7 +134,7 @@ pub(super) fn build_view(
     jobset_name:   "packages".into(),
     status_text:   status.into(),
     status_class:  class.into(),
-    system:        "x86_64-linux".into(),
+    system:        system.into(),
     created_at:    "2026-06-18 11:45".into(),
     started_at:    "2026-06-18 11:46".into(),
     completed_at:  if class == "running" {
@@ -149,8 +151,14 @@ pub(super) fn build_view(
     priority:      100,
     is_aggregate:  false,
     signed:        true,
-    drv_path:      "/nix/store/preview-circus-server.drv".into(),
-    output_path:   "/nix/store/preview-circus-server".into(),
+    drv_path:      format!(
+      "/nix/store/8s69x68y-{}.drv",
+      job.rsplit('.').next().unwrap_or(job)
+    ),
+    output_path:   format!(
+      "/nix/store/lq2n7cav-{}",
+      job.rsplit('.').next().unwrap_or(job)
+    ),
     error_message: if class == "failed" {
       "error: builder failed with exit code 1".into()
     } else {
@@ -168,18 +176,119 @@ pub(super) fn build_view(
   }
 }
 
-pub(super) fn builds_fixture() -> Vec<BuildView> {
-  vec![
-    build_view(
-      4,
-      "packages.x86_64-linux.circus-server",
-      "Succeeded",
-      "completed",
-    ),
-    build_view(5, "packages.aarch64-linux.server", "Failed", "failed"),
-    build_view(6, "checks.x86_64-linux.integration", "Running", "running"),
-  ]
+struct PreviewBuildFixture {
+  n:       u128,
+  job:     &'static str,
+  status:  &'static str,
+  class:   &'static str,
+  raw_log: Option<&'static str>,
 }
+
+impl PreviewBuildFixture {
+  fn build(&self) -> BuildView {
+    build_view(self.n, self.job, self.status, self.class)
+  }
+}
+
+const PREVIEW_BUILDS: &[PreviewBuildFixture] = &[
+  PreviewBuildFixture {
+    n:       4,
+    job:     "packages.x86_64-linux.circus-server",
+    status:  "Succeeded",
+    class:   "completed",
+    raw_log: Some(PREVIEW_SUCCEEDED_BUILD_LOG),
+  },
+  PreviewBuildFixture {
+    n:       5,
+    job:     "packages.aarch64-linux.circus-server",
+    status:  "Failed",
+    class:   "failed",
+    raw_log: Some(PREVIEW_FAILED_BUILD_LOG),
+  },
+  PreviewBuildFixture {
+    n:       6,
+    job:     "checks.x86_64-linux.integration",
+    status:  "Running",
+    class:   "running",
+    raw_log: Some(PREVIEW_RUNNING_BUILD_LOG),
+  },
+];
+
+fn build_fixture_by_id(build_id: Uuid) -> Option<&'static PreviewBuildFixture> {
+  PREVIEW_BUILDS
+    .iter()
+    .find(|fixture| id(fixture.n) == build_id)
+}
+
+pub(super) fn builds_fixture() -> Vec<BuildView> {
+  PREVIEW_BUILDS
+    .iter()
+    .map(PreviewBuildFixture::build)
+    .collect()
+}
+
+pub(super) fn build_log_template(build_id: Uuid) -> Option<BuildLogTemplate> {
+  let fixture = build_fixture_by_id(build_id)?;
+  let raw_log = fixture.raw_log?;
+  Some(BuildLogTemplate {
+    ui:                ui(),
+    build:             fixture.build(),
+    log:               parse_build_log(raw_log),
+    eval_id:           id(3),
+    eval_commit_short: "9f2c7a113bad".into(),
+    jobset_id:         id(2),
+    jobset_name:       "packages".into(),
+    project_id:        id(1),
+    project_name:      "circus".into(),
+    is_admin:          true,
+    auth_name:         "preview-admin".into(),
+  })
+}
+
+const PREVIEW_SUCCEEDED_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
+@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
+@nix {"action":"stop","id":2}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/8s69x68y-circus-server-0.12.0.drv'","type":105,"fields":["/nix/store/8s69x68y-circus-server-0.12.0.drv","builder-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":104,"fields":["patchPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["applying patch /nix/store/h3ad2x8q-use-workspace-cargo-lock.patch"]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --release"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
+@nix {"action":"result","id":10,"type":104,"fields":["installPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["installing target/release/circus-server to /nix/store/lq2n7cav-circus-server-0.12.0/bin"]}
+@nix {"action":"stop","id":10}
+@nix {"action":"stop","id":1}"#;
+
+const PREVIEW_FAILED_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
+@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
+@nix {"action":"stop","id":2}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv'","type":105,"fields":["/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv","builder-aarch64-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --target aarch64-unknown-linux-gnu --release"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
+@nix {"action":"msg","level":1,"msg":"warning: cargo is rebuilding the workspace because Cargo.lock changed"}
+@nix {"action":"result","id":10,"type":101,"fields":["error: linking with `aarch64-unknown-linux-gnu-cc` failed: exit status: 1"]}
+@nix {"action":"result","id":10,"type":101,"fields":["  = note: collect2: fatal error: ld terminated with signal 9 [Killed]"]}
+@nix {"action":"result","id":10,"type":101,"fields":["          compilation terminated."]}
+@nix {"action":"result","id":10,"type":101,"fields":["error: could not compile `circus-server` due to previous error; 1 warning emitted"]}
+@nix {"action":"msg","level":0,"msg":"error: builder for '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv' failed with exit code 101"}
+@nix {"action":"stop","id":10}
+@nix {"action":"stop","id":1}"#;
+
+const PREVIEW_RUNNING_BUILD_LOG: &str = r#"@nix {"action":"start","id":1,"level":3,"parent":0,"text":"running integration checks","type":104,"fields":[1]}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/mx19g4kq-circus-integration-check.drv'","type":105,"fields":["/nix/store/mx19g4kq-circus-integration-check.drv","builder-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo test --workspace --test integration"]}
+@nix {"action":"result","id":10,"type":101,"fields":["running 12 integration tests"]}
+@nix {"action":"msg","level":3,"msg":"test evaluator_schedules_builds ... ok"}"#;
 
 pub(super) fn queue_build(
   n: u128,
@@ -211,16 +320,16 @@ pub(super) fn queue_build(
 
 pub(super) fn eval_view(n: u128, status: &str, class: &str) -> EvalView {
   EvalView {
-    id:            id(n),
-    commit_hash:   "9f2c7a113badf00d7e57c0ffee1234567890abcd".into(),
-    commit_short:  "9f2c7a113bad".into(),
-    status_text:   status.into(),
-    status_class:  class.into(),
-    time:          "2026-06-18 11:42".into(),
-    error_message: None,
-    hidden:        false,
-    jobset_name:   "packages".into(),
-    project_name:  "circus".into(),
+    id:           id(n),
+    commit_hash:  "9f2c7a113badf00d7e57c0ffee1234567890abcd".into(),
+    commit_short: "9f2c7a113bad".into(),
+    status_text:  status.into(),
+    status_class: class.into(),
+    time:         "2026-06-18 11:42".into(),
+    error_lines:  Vec::new(),
+    hidden:       false,
+    jobset_name:  "packages".into(),
+    project_name: "circus".into(),
   }
 }
 

--- a/crates/server/src/routes/dashboard/preview/fixtures/build-00000004.internal-json
+++ b/crates/server/src/routes/dashboard/preview/fixtures/build-00000004.internal-json
@@ -1,0 +1,17 @@
+@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
+@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
+@nix {"action":"stop","id":2}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/8s69x68y-circus-server-0.12.0.drv'","type":105,"fields":["/nix/store/8s69x68y-circus-server-0.12.0.drv","builder-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":104,"fields":["patchPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["applying patch /nix/store/h3ad2x8q-use-workspace-cargo-lock.patch"]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --release"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
+@nix {"action":"result","id":10,"type":104,"fields":["installPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["installing target/release/circus-server to /nix/store/lq2n7cav-circus-server-0.12.0/bin"]}
+@nix {"action":"stop","id":10}
+@nix {"action":"stop","id":1}

--- a/crates/server/src/routes/dashboard/preview/fixtures/build-00000005.internal-json
+++ b/crates/server/src/routes/dashboard/preview/fixtures/build-00000005.internal-json
@@ -1,0 +1,19 @@
+@nix {"action":"start","id":1,"level":3,"parent":0,"text":"building 1 derivations","type":104,"fields":[1]}
+@nix {"action":"start","id":2,"level":3,"parent":1,"text":"copying path '/nix/store/wpl2q3yx-rustc-1.88.0' from 'https://cache.nixos.org'","type":108,"fields":["/nix/store/wpl2q3yx-rustc-1.88.0","https://cache.nixos.org"]}
+@nix {"action":"stop","id":2}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv'","type":105,"fields":["/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv","builder-aarch64-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["unpackPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["unpacking source archive /nix/store/vv1q7x3-circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":101,"fields":["source root is circus-0.12.0-src"]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo build --locked --package circus-server --target aarch64-unknown-linux-gnu --release"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-common v0.12.0 (/build/source/crates/common)"]}
+@nix {"action":"result","id":10,"type":101,"fields":["   Compiling circus-server v0.12.0 (/build/source/crates/server)"]}
+@nix {"action":"msg","level":1,"msg":"warning: cargo is rebuilding the workspace because Cargo.lock changed"}
+@nix {"action":"result","id":10,"type":101,"fields":["error: linking with `aarch64-unknown-linux-gnu-cc` failed: exit status: 1"]}
+@nix {"action":"result","id":10,"type":101,"fields":["  = note: collect2: fatal error: ld terminated with signal 9 [Killed]"]}
+@nix {"action":"result","id":10,"type":101,"fields":["          compilation terminated."]}
+@nix {"action":"result","id":10,"type":101,"fields":["error: could not compile `circus-server` due to previous error; 1 warning emitted"]}
+@nix {"action":"msg","level":0,"msg":"error: builder for '/nix/store/jk42cl7q-circus-server-0.12.0-aarch64-unknown-linux-gnu.drv' failed with exit code 101"}
+@nix {"action":"stop","id":10}
+@nix {"action":"stop","id":1}

--- a/crates/server/src/routes/dashboard/preview/fixtures/build-00000006.internal-json
+++ b/crates/server/src/routes/dashboard/preview/fixtures/build-00000006.internal-json
@@ -1,0 +1,6 @@
+@nix {"action":"start","id":1,"level":3,"parent":0,"text":"running integration checks","type":104,"fields":[1]}
+@nix {"action":"start","id":10,"level":3,"parent":1,"text":"building '/nix/store/mx19g4kq-circus-integration-check.drv'","type":105,"fields":["/nix/store/mx19g4kq-circus-integration-check.drv","builder-01",1,1]}
+@nix {"action":"result","id":10,"type":104,"fields":["buildPhase"]}
+@nix {"action":"result","id":10,"type":101,"fields":["cargo test --workspace --test integration"]}
+@nix {"action":"result","id":10,"type":101,"fields":["running 12 integration tests"]}
+@nix {"action":"msg","level":3,"msg":"test evaluator_schedules_builds ... ok"}

--- a/crates/server/src/routes/dashboard/preview/mod.rs
+++ b/crates/server/src/routes/dashboard/preview/mod.rs
@@ -6,6 +6,7 @@ use askama::Template;
 use axum::{
   Router,
   body::Body,
+  extract::Path,
   http::{StatusCode, header},
   response::{Html, IntoResponse, Redirect, Response},
   routing::{delete, get, post, put},
@@ -155,19 +156,11 @@ async fn preview_news_action() -> Redirect {
   Redirect::to("/news")
 }
 
-async fn build_log() -> Response {
-  Response::builder()
-    .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-    .header(header::CACHE_CONTROL, "no-cache")
-    .body(Body::from(
-      "preview build log\n[1/2] evaluating derivation\n[2/2] build completed\n",
-    ))
-    .unwrap_or_else(|error| {
-      Response::builder()
-        .status(StatusCode::INTERNAL_SERVER_ERROR)
-        .body(Body::from(format!("response builder failed: {error}")))
-        .unwrap_or_else(|_| Response::new(Body::empty()))
-    })
+async fn build_log(Path(id): Path<uuid::Uuid>) -> Response {
+  fixtures::build_log_template(id).map_or_else(
+    || (StatusCode::NOT_FOUND, "Build log not found").into_response(),
+    render,
+  )
 }
 
 async fn product_download() -> Response {

--- a/crates/server/src/routes/dashboard/preview/pages.rs
+++ b/crates/server/src/routes/dashboard/preview/pages.rs
@@ -97,7 +97,7 @@ pub(super) async fn home() -> Response {
     recent_builds:      builds_fixture(),
     failed_builds_list: vec![fixtures::build_view(
       5,
-      "packages.aarch64-linux.server",
+      "packages.aarch64-linux.circus-server",
       "Failed",
       "failed",
     )],

--- a/crates/server/src/routes/dashboard/shared.rs
+++ b/crates/server/src/routes/dashboard/shared.rs
@@ -20,7 +20,7 @@ use circus_common::models::{
   User,
 };
 use circus_config::{Config, PageAccessLevel, ServerConfig, UiConfig};
-use circus_proto::nix_log::{self, LogLine};
+use cognos::internal::json::{self as nix_json, Actions, Verbosity};
 use subtle::ConstantTimeEq;
 use uuid::Uuid;
 
@@ -174,16 +174,16 @@ pub(super) struct QueueBuildView {
 }
 
 pub(super) struct EvalView {
-  pub(super) id:            Uuid,
-  pub(super) commit_hash:   String,
-  pub(super) commit_short:  String,
-  pub(super) status_text:   String,
-  pub(super) status_class:  String,
-  pub(super) time:          String,
-  pub(super) error_message: Option<String>,
-  pub(super) hidden:        bool,
-  pub(super) jobset_name:   String,
-  pub(super) project_name:  String,
+  pub(super) id:           Uuid,
+  pub(super) commit_hash:  String,
+  pub(super) commit_short: String,
+  pub(super) status_text:  String,
+  pub(super) status_class: String,
+  pub(super) time:         String,
+  pub(super) error_lines:  Vec<BuildErrorLine>,
+  pub(super) hidden:       bool,
+  pub(super) jobset_name:  String,
+  pub(super) project_name: String,
 }
 
 pub(super) struct EvalSummaryView {
@@ -538,34 +538,77 @@ pub(super) struct StarredJobView {
   pub(super) latest_build_id: Option<Uuid>,
 }
 
-/// A single parsed line from a nix build error stream, classed for styling.
+/// A single parsed line from a nix diagnostic stream, classed for styling.
 pub(super) struct BuildErrorLine {
   pub(super) text:  String,
   pub(super) level: &'static str,
 }
 
-fn strip_ansi(s: &str) -> String {
-  String::from_utf8_lossy(&strip_ansi_escapes::strip(s)).into_owned()
+pub(super) fn strip_ansi(s: &str) -> String {
+  let stripped =
+    String::from_utf8_lossy(&strip_ansi_escapes::strip(s)).into_owned();
+  strip_bare_csi_fragments(&stripped)
 }
 
-/// Decode a stored `internal-json` build log into plain terminal text.
-pub(super) fn decode_build_log(raw: &str) -> String {
-  let mut out = String::with_capacity(raw.len());
-  for line in raw.lines() {
-    match nix_log::parse_line(line) {
-      Some(LogLine::Message { text, .. } | LogLine::Output { text }) => {
-        out.push_str(&strip_ansi(&text));
-        out.push('\n');
-      },
-      // Plain output is passed through
-      None if !nix_log::is_envelope(line) => {
-        out.push_str(&strip_ansi(line));
-        out.push('\n');
-      },
-      None => {},
+fn strip_bare_csi_fragments(s: &str) -> String {
+  let mut out = String::with_capacity(s.len());
+  let mut chars = s.chars().peekable();
+
+  while let Some(ch) = chars.next() {
+    if ch == '[' {
+      let mut seq = String::from("[");
+      while let Some(next) = chars.peek().copied() {
+        if next.is_ascii_digit() || next == ';' {
+          seq.push(next);
+          chars.next();
+        } else {
+          break;
+        }
+      }
+      if chars.peek() == Some(&'m') && seq.len() > 1 {
+        chars.next();
+        continue;
+      }
+      out.push_str(&seq);
+    } else {
+      out.push(ch);
     }
   }
+
   out
+}
+
+pub(super) const fn classify_verbosity(level: Verbosity) -> &'static str {
+  match level {
+    Verbosity::Error => "error",
+    Verbosity::Warning => "warn",
+    Verbosity::Notice => "notice",
+    Verbosity::Info | Verbosity::Talkative => "info",
+    Verbosity::Chatty | Verbosity::Debug | Verbosity::Vomit => "debug",
+  }
+}
+
+pub(super) fn classify_plain_line(line: &str) -> &'static str {
+  let lower = line.trim_start().to_ascii_lowercase();
+  if lower.starts_with("error:")
+    || lower.starts_with("error ")
+    || lower.contains(" error:")
+  {
+    "error"
+  } else if lower.starts_with("warning:")
+    || lower.starts_with("warn:")
+    || lower.contains(" warning:")
+  {
+    "warn"
+  } else if lower.starts_with("trace:") {
+    "notice"
+  } else {
+    "info"
+  }
+}
+
+pub(super) fn display_log_line(raw: &str) -> String {
+  strip_ansi(raw).trim_end().to_string()
 }
 
 /// Parse a build's `error_message` field into displayable lines.
@@ -577,29 +620,36 @@ pub(super) fn decode_build_log(raw: &str) -> String {
 /// strip ANSI codes, and tag a severity class. Anything that isn't a
 /// recognisable envelope is preserved as a single line.
 pub(super) fn parse_build_error(raw: &str) -> Vec<BuildErrorLine> {
-  const fn classify(level: i64) -> &'static str {
-    match level {
-      0 => "error",
-      1 => "warn",
-      2 | 3 => "notice",
-      _ => "info",
-    }
-  }
-
   let mut lines = Vec::new();
   for line in raw.lines() {
-    let (text, level) = match nix_log::parse_line(line) {
-      Some(LogLine::Message { level, text }) => {
-        (strip_ansi(&text).trim().to_string(), classify(level))
-      },
-      Some(LogLine::Output { .. }) => continue,
-      None if nix_log::is_envelope(line) => continue,
-      None => {
+    let (text, level) = match nix_json::parse_line(line) {
+      Some(Actions::Message {
+        level,
+        msg,
+        raw_msg,
+        ..
+      }) => {
         (
-          // A plain line
-          strip_ansi(line).trim().trim_end_matches(':').trim().into(),
-          "info",
+          display_log_line(raw_msg.as_deref().unwrap_or(&msg))
+            .trim()
+            .to_string(),
+          classify_verbosity(level),
         )
+      },
+      Some(
+        Actions::Result { .. } | Actions::Start { .. } | Actions::Stop { .. },
+      ) => {
+        continue;
+      },
+      None if line.starts_with("@nix ") => continue,
+      None => {
+        let text = display_log_line(line)
+          .trim()
+          .trim_end_matches(':')
+          .trim()
+          .to_string();
+        let level = classify_plain_line(&text);
+        (text, level)
       },
     };
     if !text.is_empty() {
@@ -713,16 +763,20 @@ impl From<&Evaluation> for EvalView {
       e.commit_hash.clone()
     };
     Self {
-      id:            e.id,
-      commit_hash:   e.commit_hash.clone(),
-      commit_short:  short,
-      status_text:   text.to_string(),
-      status_class:  class.to_string(),
-      time:          e.evaluation_time.format("%Y-%m-%d %H:%M").to_string(),
-      error_message: e.error_message.clone(),
-      hidden:        e.hidden,
-      jobset_name:   String::new(),
-      project_name:  String::new(),
+      id:           e.id,
+      commit_hash:  e.commit_hash.clone(),
+      commit_short: short,
+      status_text:  text.to_string(),
+      status_class: class.to_string(),
+      time:         e.evaluation_time.format("%Y-%m-%d %H:%M").to_string(),
+      error_lines:  e
+        .error_message
+        .as_deref()
+        .map(parse_build_error)
+        .unwrap_or_default(),
+      hidden:       e.hidden,
+      jobset_name:  String::new(),
+      project_name: String::new(),
     }
   }
 }
@@ -789,7 +843,7 @@ mod tests {
     assert_eq!(lines[0].text, "error: boom");
     assert_eq!(lines[0].level, "error");
     assert_eq!(lines[1].text, "hello");
-    assert_eq!(lines[1].level, "notice");
+    assert_eq!(lines[1].level, "info");
   }
 
   #[test]
@@ -820,27 +874,5 @@ mod tests {
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].text, "warn line");
     assert_eq!(lines[0].level, "warn");
-  }
-
-  #[test]
-  fn decode_build_log_actually_decodes() {
-    let raw = [
-      r#"@nix {"action":"start","id":1}"#,
-      r#"@nix {"action":"result","id":1,"type":101,"fields":["cc -c main.c"]}"#,
-      r#"@nix {"action":"result","id":1,"type":105,"fields":[0,1]}"#,
-      r#"@nix {"action":"msg","level":0,"msg":"error: build failed"}"#,
-      "plain stdout line",
-      r#"@nix {"action":"stop","id":1}"#,
-    ]
-    .join("\n");
-
-    // 101 + msg kept
-    assert_eq!(
-      decode_build_log(&raw),
-      "cc -c main.c\nerror: build failed\nplain stdout line\n"
-    );
-
-    // ANSI escapes stripped
-    assert_eq!(decode_build_log("\x1b[1mbold\x1b[0m"), "bold\n");
   }
 }

--- a/crates/server/src/routes/dashboard/templates.rs
+++ b/crates/server/src/routes/dashboard/templates.rs
@@ -20,19 +20,22 @@ use circus_common::models::{
 use uuid::Uuid;
 
 pub(super) use super::shared::UiTemplateConfig;
-use super::shared::{
-  ApiKeyView,
-  BuildView,
-  EvalSummaryView,
-  EvalView,
-  JobStatusColumn,
-  JobStatusRow,
-  ProjectSummaryView,
-  QueueBuildView,
-  QueueSystemView,
-  StarredJobView,
-  UserView,
-  WorkerSummaryView,
+use super::{
+  build_log::BuildLogView,
+  shared::{
+    ApiKeyView,
+    BuildView,
+    EvalSummaryView,
+    EvalView,
+    JobStatusColumn,
+    JobStatusRow,
+    ProjectSummaryView,
+    QueueBuildView,
+    QueueSystemView,
+    StarredJobView,
+    UserView,
+    WorkerSummaryView,
+  },
 };
 use crate::permissions::UiPermissions;
 
@@ -179,6 +182,22 @@ pub(super) struct BuildTemplate {
   pub(super) products:          Vec<BuildProduct>,
   pub(super) dependencies:      Vec<BuildView>,
   pub(super) dependents:        Vec<BuildView>,
+  pub(super) eval_id:           Uuid,
+  pub(super) eval_commit_short: String,
+  pub(super) jobset_id:         Uuid,
+  pub(super) jobset_name:       String,
+  pub(super) project_id:        Uuid,
+  pub(super) project_name:      String,
+  pub(super) is_admin:          bool,
+  pub(super) auth_name:         String,
+}
+
+#[derive(Template)]
+#[template(path = "build_log.html")]
+pub(super) struct BuildLogTemplate {
+  pub(super) ui:                UiTemplateConfig,
+  pub(super) build:             BuildView,
+  pub(super) log:               BuildLogView,
   pub(super) eval_id:           Uuid,
   pub(super) eval_commit_short: String,
   pub(super) jobset_id:         Uuid,

--- a/crates/server/static/style.css
+++ b/crates/server/static/style.css
@@ -2010,6 +2010,8 @@ button:disabled {
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 17px;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 29px;
 }
 
 .log-line:last-child {

--- a/crates/server/static/style.css
+++ b/crates/server/static/style.css
@@ -805,6 +805,80 @@ a.stat-card:hover {
   color: var(--status-failed);
 }
 
+.section-heading,
+.page-title-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.section-heading {
+  margin-bottom: 8px;
+}
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.section-heading span,
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.page-subtitle {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.outcome-panel {
+  display: grid;
+  gap: 8px;
+}
+
+.outcome-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.outcome-card {
+  display: grid;
+  gap: 2px;
+  min-height: 62px;
+  padding: 10px 12px;
+  border-right: 1px solid var(--border);
+  border-top: 3px solid var(--border);
+}
+
+.outcome-card:last-child {
+  border-right: 0;
+}
+
+.outcome-success {
+  border-top-color: var(--status-success);
+}
+
+.outcome-failed {
+  border-top-color: var(--status-failed);
+}
+
+.outcome-running {
+  border-top-color: var(--status-running);
+}
+
+.outcome-pending {
+  border-top-color: var(--status-queued);
+}
+
 .health-ledger {
   padding: 0 10px;
 }
@@ -1686,6 +1760,301 @@ button:disabled {
   color: var(--text);
 }
 
+.evaluation-diagnostics {
+  display: grid;
+  gap: 8px;
+}
+
+.build-log-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: end;
+  padding: 14px 0 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.build-log-title {
+  min-width: 0;
+}
+
+.build-log-kicker {
+  margin-bottom: 3px;
+  color: var(--text-subtle);
+  font-size: 11px;
+  line-height: 14px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.build-log-title h1 {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.build-log-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.build-log-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(88px, 1fr));
+  min-width: min(560px, 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.build-log-fact {
+  display: grid;
+  gap: 2px;
+  min-height: 58px;
+  padding: 10px 12px;
+  border-right: 1px solid var(--border);
+}
+
+.build-log-fact:last-child {
+  border-right: 0;
+}
+
+.build-log-fact strong {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.build-log-fact span {
+  color: var(--text-subtle);
+  font-size: 11px;
+  line-height: 14px;
+  font-weight: 650;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.build-log-fact-error strong {
+  color: var(--status-failed);
+}
+
+.build-log-fact-warn strong {
+  color: var(--status-running);
+}
+
+.log-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 34%) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  margin-top: 14px;
+}
+
+.log-activities,
+.log-stream {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  overflow: hidden;
+}
+
+.log-pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 46px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-pane-header h2 {
+  margin: 0;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.log-pane-header span {
+  color: var(--text-subtle);
+  font-size: 11px;
+  line-height: 14px;
+  font-weight: 650;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.activity-list,
+.log-lines {
+  list-style: none;
+}
+
+.activity-list {
+  max-height: 70vh;
+  overflow: auto;
+  padding: 0;
+}
+
+.failure-activity {
+  display: grid;
+  gap: 5px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  box-shadow: inset 3px 0 0 var(--status-failed);
+}
+
+.failure-title {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 17px;
+  overflow-wrap: anywhere;
+}
+
+.failure-meta,
+.activity-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--text-subtle);
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.failure-meta span:not(:last-child)::after,
+.activity-meta span:not(:last-child)::after {
+  content: "·";
+  margin-left: 6px;
+  color: var(--text-subtle);
+}
+
+.activity-context-title {
+  padding: 9px 14px 6px;
+  color: var(--text-subtle);
+  font-size: 10px;
+  line-height: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.activity-item {
+  position: relative;
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 7px 12px 7px calc(14px + var(--activity-depth, 0) * 14px);
+  border-bottom: 1px solid var(--border);
+  border-left: 0;
+  border-radius: 0;
+}
+
+.activity-item:last-child {
+  border-bottom: 0;
+}
+
+.activity-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  margin-top: 5px;
+  background: var(--border-strong);
+  border-radius: 50%;
+}
+
+.activity-body {
+  min-width: 0;
+}
+
+.activity-success .activity-dot {
+  background: var(--status-success);
+}
+
+.activity-failed .activity-dot {
+  background: var(--status-failed);
+}
+
+.activity-running .activity-dot {
+  background: var(--status-running);
+}
+
+.activity-label {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
+.log-lines {
+  max-height: 70vh;
+  overflow: auto;
+  background: var(--surface);
+}
+
+.log-line {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  min-height: 28px;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 17px;
+}
+
+.log-line:last-child {
+  border-bottom: 0;
+}
+
+.log-line-number {
+  color: var(--text-subtle);
+  white-space: nowrap;
+}
+
+.log-line-text {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.log-line-error {
+  color: var(--status-failed);
+  background: color-mix(in srgb, var(--status-failed) 7%, var(--surface));
+  box-shadow: inset 2px 0 0 var(--status-failed);
+}
+
+.log-line-warn {
+  color: var(--status-running);
+  background: color-mix(in srgb, var(--status-running) 7%, var(--surface));
+  box-shadow: inset 2px 0 0 var(--status-running);
+}
+
+.log-line-phase {
+  grid-template-columns: 48px minmax(0, 1fr);
+  align-items: center;
+  min-height: 29px;
+  background: var(--surface-2);
+  border-top: 1px solid var(--border-strong);
+}
+
+.log-phase-label {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 17px;
+  font-weight: 650;
+}
+
 .spinner {
   display: inline-block;
   width: 1em;
@@ -1837,6 +2206,15 @@ pre code {
   .metric-cell:nth-child(3n) {
     border-right: 0;
   }
+
+  .log-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .activity-list,
+  .log-lines {
+    max-height: none;
+  }
 }
 
 @media (max-width: 1060px) {
@@ -1932,9 +2310,27 @@ pre code {
   }
 
   .stats-grid,
+  .outcome-grid,
+  .build-log-hero,
+  .build-log-facts,
   .split-grid,
   .metrics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .outcome-card,
+  .build-log-fact {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .outcome-card:last-child,
+  .build-log-fact:last-child {
+    border-bottom: 0;
+  }
+
+  .log-line {
+    grid-template-columns: 44px minmax(0, 1fr);
   }
 
   th,

--- a/crates/server/templates/base.html
+++ b/crates/server/templates/base.html
@@ -4,7 +4,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="color-scheme" content="light dark">
-        <meta name="description" content="{{ ui.brand_name }} dashboard for Nix CI builds, evaluations, queues, and binary caches.">
+        <meta name="description"
+              content="{{ ui.brand_name }} dashboard for Nix CI builds, evaluations, queues, and binary caches.">
         <title>{% block title %}{{ ui.brand_name }}{% endblock %}</title>
         {% if ui.has_favicon %}<link rel="icon" href="{{ ui.favicon_url }}">{% endif %}
         <link rel="stylesheet" href="/static/style.css?v=graphite-dashboard-v7">

--- a/crates/server/templates/base.html
+++ b/crates/server/templates/base.html
@@ -8,7 +8,7 @@
               content="{{ ui.brand_name }} dashboard for Nix CI builds, evaluations, queues, and binary caches.">
         <title>{% block title %}{{ ui.brand_name }}{% endblock %}</title>
         {% if ui.has_favicon %}<link rel="icon" href="{{ ui.favicon_url }}">{% endif %}
-        <link rel="stylesheet" href="/static/style.css?v=graphite-dashboard-v7">
+        <link rel="stylesheet" href="/static/style.css?v=graphite-dashboard-v8">
         <link rel="stylesheet" href="/static/theme.css">
         {% if ui.has_custom_css %}
             <link rel="stylesheet" href="/static/custom.css">{% endif %}</head>

--- a/crates/server/templates/build_log.html
+++ b/crates/server/templates/build_log.html
@@ -1,0 +1,143 @@
+{% extends "base.html" %}
+{% block title %}Build {{ build.job_name }} log - circus{% endblock %}
+{% block auth %}
+    {% if !auth_name.is_empty() %}
+        <span class="auth-user">{{ auth_name }}</span>
+        <form method="POST" action="/logout">
+            <button class="btn-ghost" type="submit">Logout</button>
+        </form>
+    {% else %}
+        <a class="btn btn-secondary" href="/login">Login</a>
+    {% endif %}
+{% endblock %}
+{% block breadcrumbs %}
+    <nav class="breadcrumbs">
+        <a href="/projects">Projects</a>
+        <span class="sep">/</span>
+        <a href="/project/{{ project_id }}">{{ project_name }}</a>
+        <span class="sep">/</span>
+        <a href="/jobset/{{ jobset_id }}">{{ jobset_name }}</a>
+        <span class="sep">/</span>
+        <a href="/evaluation/{{ eval_id }}">{{ eval_commit_short }}</a>
+        <span class="sep">/</span>
+        <a href="/build/{{ build.id }}">{{ build.job_name }}</a>
+        <span class="sep">/</span>
+        <span class="current">Log</span>
+    </nav>
+{% endblock %}
+{% block content %}
+    <section class="build-log-hero">
+        <div class="build-log-title">
+            <div class="build-log-kicker">Build log</div>
+            <h1>{{ build.job_name }}</h1>
+            <div class="build-log-meta">
+                <span class="status status-{{ build.status_class }}">{{ build.status_text }}</span>
+                <span>{{ build.system }}</span>
+                {% if !build.duration.is_empty() %}<span>{{ build.duration }}</span>{% endif %}
+                <a href="/build/{{ build.id }}">Build #{{ build.id_short }}</a>
+            </div>
+        </div>
+        <div class="build-log-facts" aria-label="Build log summary">
+            <div class="build-log-fact">
+                <strong>{{ log.summary.visible_lines }}</strong>
+                <span>lines</span>
+            </div>
+            <div class="build-log-fact">
+                <strong>{{ log.summary.activity_count }}</strong>
+                <span>activities</span>
+            </div>
+            <div class="build-log-fact build-log-fact-error">
+                <strong>{{ log.summary.error_count }}</strong>
+                <span>errors</span>
+            </div>
+            <div class="build-log-fact build-log-fact-warn">
+                <strong>{{ log.summary.warning_count }}</strong>
+                <span>warnings</span>
+            </div>
+        </div>
+    </section>
+
+    <div class="log-layout">
+        <aside class="log-activities" aria-label="Build failure summary">
+            <div class="log-pane-header">
+                {% if build.status_class == "failed" %}
+                    <h2>Failure</h2>
+                {% else %}
+                    <h2>Activity</h2>
+                {% endif %}
+                <span>{{ log.summary.activity_count }} activities</span>
+            </div>
+            {% if log.activities.is_empty() %}
+                <div class="empty compact-empty">
+                    <div class="empty-title">No Nix activity events.</div>
+                </div>
+            {% else %}
+                {% if build.status_class == "failed" %}
+                    {% for activity in log.activities %}
+                        {% if activity.is_failed() %}
+                            <section class="failure-activity">
+                                <div class="failure-title">{{ activity.label }}</div>
+                                <div class="failure-meta">
+                                    <span>{{ activity.kind() }}</span>
+                                    {% if !activity.line_range.is_empty() %}
+                                        <span>{{ activity.line_range }}</span>
+                                    {% endif %}
+                                    {% if !activity.detail.is_empty() %}<span>{{ activity.detail }}</span>{% endif %}
+                                </div>
+                            </section>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="activity-context-title">Context</div>
+                {% endif %}
+                <ol class="activity-list">
+                    {% for activity in log.activities %}
+                        {% if !activity.is_failed() %}
+                            <li class="activity-item activity-{{ activity.status_class() }}"
+                                style="--activity-depth: {{ activity.depth }}">
+                                <span class="activity-dot"></span>
+                                <div class="activity-body">
+                                    <span class="activity-label">{{ activity.label }}</span>
+                                    <div class="activity-meta">
+                                        <span>{{ activity.kind() }}</span>
+                                        <span>{{ activity.status() }}</span>
+                                        {% if !activity.detail.is_empty() %}
+                                            <span>{{ activity.detail }}</span>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ol>
+            {% endif %}
+        </aside>
+
+        <section class="log-stream" aria-label="Build log lines">
+            <div class="log-pane-header">
+                <h2>Log Stream</h2>
+                <span>Nix output</span>
+            </div>
+            {% if log.lines.is_empty() %}
+                <div class="empty compact-empty">
+                    <div class="empty-title">No displayable log lines.</div>
+                </div>
+            {% else %}
+                <ol class="log-lines">
+                    {% for line in log.lines %}
+                        {% if line.is_phase() %}
+                            <li class="log-line log-line-phase">
+                                <span class="log-line-number">{{ line.number }}</span>
+                                <span class="log-phase-label">{{ line.text }}</span>
+                            </li>
+                        {% else %}
+                            <li class="log-line log-line-{{ line.level_class() }}">
+                                <span class="log-line-number">{{ line.number }}</span>
+                                <span class="log-line-text">{{ line.text }}</span>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ol>
+            {% endif %}
+        </section>
+    </div>
+{% endblock %}

--- a/crates/server/templates/builds.html
+++ b/crates/server/templates/builds.html
@@ -58,9 +58,9 @@
                     {% for b in builds %}
                         <tr>
                             <td class="mono">
-                                <a href="/build/{{ b.id }}"
-                                   title="{{ b.id }}"
-                                   aria-label="Build {{ b.id }}">#{{ b.id_short }}</a>
+                                <a href="/build/{{ b.id }}" title="{{ b.id }}" aria-label="Build {{ b.id }}">
+                                    #{{ b.id_short }}
+                                </a>
                             </td>
                             <td class="truncate" title="{{ b.project_name }}">
                                 {% match b.project_id %}

--- a/crates/server/templates/cache_detail.html
+++ b/crates/server/templates/cache_detail.html
@@ -131,7 +131,9 @@
             {% if has_snippet %}
                 <label class="copy-label" for="cache-nix-conf-snippet">nix.conf snippet</label>
                 <div class="copy-field copy-field-block">
-                    <textarea id="cache-nix-conf-snippet" readonly rows="2">{{ nix_conf_snippet }}</textarea>
+                    <textarea id="cache-nix-conf-snippet" readonly rows="2">
+                        {{ nix_conf_snippet }}
+                    </textarea>
                     <button type="button" class="btn btn-small btn-secondary" data-copy>Copy</button>
                 </div>
             {% endif %}

--- a/crates/server/templates/evaluation.html
+++ b/crates/server/templates/evaluation.html
@@ -51,34 +51,44 @@
     <p>
         <strong>Time:</strong> {{ eval.time }}
     </p>
-    {% match eval.error_message %}
-        {% when Some with (err) %}
-            <div class="flash-message flash-error">
-                <strong>Evaluation error</strong>
-                <pre class="error-detail">
-{{ err }}</pre>
+    {% if !eval.error_lines.is_empty() %}
+        <section class="evaluation-diagnostics">
+            <div class="section-heading">
+                <h2>Evaluation Error</h2>
+                <span>Nix diagnostics</span>
             </div>
-        {% when None %}
-    {% endmatch %}
+            <ul class="error-log">
+                {% for line in eval.error_lines %}
+                    <li class="error-log-line error-log-{{ line.level }}">{{ line.text }}</li>
+                {% endfor %}
+            </ul>
+        </section>
+    {% endif %}
 
-    <div class="stats-grid">
-        <div class="stat-card">
-            <div class="stat-value">{{ succeeded_count }}</div>
-            <div class="stat-label">Succeeded</div>
+    <section class="outcome-panel">
+        <div class="section-heading">
+            <h2>Build Outcomes</h2>
+            <span>This evaluation</span>
         </div>
-        <div class="stat-card">
-            <div class="stat-value">{{ failed_count }}</div>
-            <div class="stat-label">Failed</div>
+        <div class="outcome-grid">
+            <div class="outcome-card outcome-success">
+                <div class="stat-value">{{ succeeded_count }}</div>
+                <div class="stat-label">Succeeded</div>
+            </div>
+            <div class="outcome-card outcome-failed">
+                <div class="stat-value">{{ failed_count }}</div>
+                <div class="stat-label">Failed</div>
+            </div>
+            <div class="outcome-card outcome-running">
+                <div class="stat-value">{{ running_count }}</div>
+                <div class="stat-label">Running</div>
+            </div>
+            <div class="outcome-card outcome-pending">
+                <div class="stat-value">{{ pending_count }}</div>
+                <div class="stat-label">Pending</div>
+            </div>
         </div>
-        <div class="stat-card">
-            <div class="stat-value">{{ running_count }}</div>
-            <div class="stat-label">Running</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-value">{{ pending_count }}</div>
-            <div class="stat-label">Pending</div>
-        </div>
-    </div>
+    </section>
 
     <h2>Builds</h2>
     {% if builds.is_empty() %}

--- a/crates/server/templates/home.html
+++ b/crates/server/templates/home.html
@@ -30,9 +30,7 @@
                    aria-label="Filter builds by job name">
             <select class="dashboard-system" name="system" aria-label="Filter builds by system">
                 <option value="">All systems</option>
-                {% for system in system_filters %}
-                    <option value="{{ system }}">{{ system }}</option>
-                {% endfor %}
+                {% for system in system_filters %}<option value="{{ system }}">{{ system }}</option>{% endfor %}
             </select>
             <button class="btn btn-small btn-secondary" type="submit">View builds</button>
         </form>
@@ -220,7 +218,9 @@
                                         <td class="mono">
                                             <a href="/build/{{ b.id }}"
                                                title="{{ b.id }}"
-                                               aria-label="Build {{ b.id }}">#{{ b.id_short }}</a>
+                                               aria-label="Build {{ b.id }}">
+                                                #{{ b.id_short }}
+                                            </a>
                                         </td>
                                         <td class="truncate" title="{{ b.project_name }}">
                                             {% match b.project_id %}
@@ -345,144 +345,144 @@
 {% endblock %}
 {% block scripts %}
     <script>
-        (function() {
-            function rowsFor(table) {
-                return Array.prototype.slice.call(
-                    table.querySelectorAll('tbody tr[data-href]')
-                );
-            }
+(function() {
+function rowsFor(table) {
+return Array.prototype.slice.call(
+table.querySelectorAll('tbody tr[data-href]')
+);
+}
 
-            function rowText(row) {
-                return [
-                    row.getAttribute('data-project') || '',
-                    row.getAttribute('data-job') || '',
-                    row.getAttribute('data-system') || '',
-                    row.textContent || ''
-                ].join(' ').toLowerCase();
-            }
+function rowText(row) {
+return [
+row.getAttribute('data-project') || '',
+row.getAttribute('data-job') || '',
+row.getAttribute('data-system') || '',
+row.textContent || ''
+].join(' ').toLowerCase();
+}
 
-            function statusMatches(rowStatus, wanted) {
-                if (!wanted) return true;
-                if (wanted === rowStatus) return true;
-                return wanted === 'succeeded' && rowStatus === 'completed';
-            }
+function statusMatches(rowStatus, wanted) {
+if (!wanted) return true;
+if (wanted === rowStatus) return true;
+return wanted === 'succeeded' && rowStatus === 'completed';
+}
 
-            function selectedRow(table) {
-                return table.querySelector('tbody tr[aria-selected="true"]');
-            }
+function selectedRow(table) {
+return table.querySelector('tbody tr[aria-selected="true"]');
+}
 
-            function visibleRows(table) {
-                return rowsFor(table).filter(function(row) {
-                    return !row.hidden;
-                });
-            }
+function visibleRows(table) {
+return rowsFor(table).filter(function(row) {
+return !row.hidden;
+});
+}
 
-            function selectRow(table, row, shouldFocus) {
-                rowsFor(table).forEach(function(item) {
-                    item.removeAttribute('aria-selected');
-                });
+function selectRow(table, row, shouldFocus) {
+rowsFor(table).forEach(function(item) {
+item.removeAttribute('aria-selected');
+});
 
-                if (!row) return;
+if (!row) return;
 
-                row.setAttribute('aria-selected', 'true');
-                if (shouldFocus) row.focus();
-                updateOpenSelected(table);
-            }
+row.setAttribute('aria-selected', 'true');
+if (shouldFocus) row.focus();
+updateOpenSelected(table);
+}
 
-            function updateOpenSelected(table) {
-                var form = document.querySelector('[data-table-filter="' + table.id + '"]');
-                if (!form) return;
+function updateOpenSelected(table) {
+var form = document.querySelector('[data-table-filter="' + table.id + '"]');
+if (!form) return;
 
-                var openLink = form.querySelector('[data-open-selected]');
-                if (!openLink) return;
+var openLink = form.querySelector('[data-open-selected]');
+if (!openLink) return;
 
-                var row = selectedRow(table);
-                if (row) {
-                    openLink.href = row.getAttribute('data-href');
-                    openLink.removeAttribute('aria-disabled');
-                } else {
-                    openLink.href = '/builds';
-                    openLink.setAttribute('aria-disabled', 'true');
-                }
-            }
+var row = selectedRow(table);
+if (row) {
+openLink.href = row.getAttribute('data-href');
+openLink.removeAttribute('aria-disabled');
+} else {
+openLink.href = '/builds';
+openLink.setAttribute('aria-disabled', 'true');
+}
+}
 
-            function applyFilter(form) {
-                var table = document.getElementById(form.getAttribute('data-table-filter'));
-                if (!table) return;
+function applyFilter(form) {
+var table = document.getElementById(form.getAttribute('data-table-filter'));
+if (!table) return;
 
-                var textInput = form.querySelector('[data-filter-text]');
-                var statusInput = form.querySelector('[data-filter-status]');
-                var query = textInput ? textInput.value.trim().toLowerCase() : '';
-                var status = statusInput ? statusInput.value : '';
+var textInput = form.querySelector('[data-filter-text]');
+var statusInput = form.querySelector('[data-filter-status]');
+var query = textInput ? textInput.value.trim().toLowerCase() : '';
+var status = statusInput ? statusInput.value : '';
 
-                rowsFor(table).forEach(function(row) {
-                    var matchesText = !query || rowText(row).indexOf(query) !== -1;
-                    var matchesStatus = statusMatches(
-                        row.getAttribute('data-status') || '',
-                        status
-                    );
-                    row.hidden = !(matchesText && matchesStatus);
-                });
+rowsFor(table).forEach(function(row) {
+var matchesText = !query || rowText(row).indexOf(query) !== -1;
+var matchesStatus = statusMatches(
+row.getAttribute('data-status') || '',
+status
+);
+row.hidden = !(matchesText && matchesStatus);
+});
 
-                var current = selectedRow(table);
-                if (!current || current.hidden) {
-                    selectRow(table, visibleRows(table)[0], false);
-                }
-                updateOpenSelected(table);
-            }
+var current = selectedRow(table);
+if (!current || current.hidden) {
+selectRow(table, visibleRows(table)[0], false);
+}
+updateOpenSelected(table);
+}
 
-            document.querySelectorAll('[data-keyboard-table]').forEach(function(table) {
-                var rows = rowsFor(table);
-                selectRow(table, rows[0], false);
+document.querySelectorAll('[data-keyboard-table]').forEach(function(table) {
+var rows = rowsFor(table);
+selectRow(table, rows[0], false);
 
-                rows.forEach(function(row) {
-                    row.addEventListener('click', function(event) {
-                        if (event.target.closest('a, button, input, select, textarea, label')) {
-                            return;
-                        }
+rows.forEach(function(row) {
+row.addEventListener('click', function(event) {
+if (event.target.closest('a, button, input, select, textarea, label')) {
+return;
+}
 
-                        selectRow(table, row, false);
-                        window.location.href = row.getAttribute('data-href');
-                    });
+selectRow(table, row, false);
+window.location.href = row.getAttribute('data-href');
+});
 
-                    row.addEventListener('focus', function() {
-                        selectRow(table, row, false);
-                    });
+row.addEventListener('focus', function() {
+selectRow(table, row, false);
+});
 
-                    row.addEventListener('keydown', function(event) {
-                        var visible = visibleRows(table);
-                        var index = visible.indexOf(row);
+row.addEventListener('keydown', function(event) {
+var visible = visibleRows(table);
+var index = visible.indexOf(row);
 
-                        if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault();
-                            window.location.href = row.getAttribute('data-href');
-                        } else if (event.key === 'ArrowDown' && index < visible.length - 1) {
-                            event.preventDefault();
-                            selectRow(table, visible[index + 1], true);
-                        } else if (event.key === 'ArrowUp' && index > 0) {
-                            event.preventDefault();
-                            selectRow(table, visible[index - 1], true);
-                        }
-                    });
-                });
-            });
+if (event.key === 'Enter' || event.key === ' ') {
+event.preventDefault();
+window.location.href = row.getAttribute('data-href');
+} else if (event.key === 'ArrowDown' && index < visible.length - 1) {
+event.preventDefault();
+selectRow(table, visible[index + 1], true);
+} else if (event.key === 'ArrowUp' && index > 0) {
+event.preventDefault();
+selectRow(table, visible[index - 1], true);
+}
+});
+});
+});
 
-            document.querySelectorAll('[data-table-filter]').forEach(function(form) {
-                form.addEventListener('submit', function(event) {
-                    event.preventDefault();
-                    applyFilter(form);
-                });
+document.querySelectorAll('[data-table-filter]').forEach(function(form) {
+form.addEventListener('submit', function(event) {
+event.preventDefault();
+applyFilter(form);
+});
 
-                form.addEventListener('input', function() {
-                    applyFilter(form);
-                });
+form.addEventListener('input', function() {
+applyFilter(form);
+});
 
-                form.addEventListener('change', function() {
-                    applyFilter(form);
-                });
+form.addEventListener('change', function() {
+applyFilter(form);
+});
 
-                applyFilter(form);
-            });
-        })();
+applyFilter(form);
+});
+})();
     </script>
 {% endblock %}

--- a/crates/server/templates/login.html
+++ b/crates/server/templates/login.html
@@ -11,7 +11,9 @@
             <p style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
                 Authentication required to access this instance.
             </p>
-            <button type="button" class="btn" onclick="document.getElementById('login-dialog').showModal()">Sign in</button>
+            <button type="button" class="btn" onclick="document.getElementById('login-dialog').showModal()">
+                Sign in
+            </button>
         </div>
     </div>
 

--- a/crates/server/templates/private.html
+++ b/crates/server/templates/private.html
@@ -5,7 +5,9 @@
         <div style="text-align:center;max-width:320px">
             <p style="font-size:14px;font-weight:650;color:var(--text);margin-bottom:6px">This page is private</p>
             <p style="font-size:12px;color:var(--text-muted);margin-bottom:16px">Sign in to access this content.</p>
-            <button type="button" class="btn" onclick="document.getElementById('login-dialog').showModal()">Sign in</button>
+            <button type="button" class="btn" onclick="document.getElementById('login-dialog').showModal()">
+                Sign in
+            </button>
         </div>
     </div>
 


### PR DESCRIPTION
We had previously written [Cognos](https://crates.io/crates/cognos) for parsing Nix's ATerm formatted logs. We can now use it to parse build logs in Circus and render them at <build-id>/log instead of plaintext router endpoints.

Sorry for the diff it's mostly the preview fixtures.