### PR TITLE
various: publish cached closure narinfos in cache loop

### DIFF
--- a/crates/common/src/repo/cache_traffic.rs
+++ b/crates/common/src/repo/cache_traffic.rs
@@ -145,26 +145,29 @@ pub async fn storage_timeseries(
   let window = bucket * points.max(1);
   let rows = sqlx::query_as::<_, (DateTime<Utc>, i64, i64)>(
     "WITH uploaded AS (SELECT store_path, created_at, file_size FROM \
-     narinfo_cache WHERE ($1::uuid IS NULL OR project_id = $1)), local AS \
-     (SELECT DISTINCT ON (path) path AS store_path, created_at, \
-     COALESCE(file_size, 0) AS file_size FROM (SELECT bp.path, bp.created_at, \
-     bp.file_size FROM build_products bp JOIN builds b ON b.id = bp.build_id \
-     JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = \
-     e.jobset_id WHERE b.status = 'succeeded' AND b.signed = true AND \
-     ($1::uuid IS NULL OR j.project_id = $1) UNION ALL SELECT \
-     b.build_output_path AS path, COALESCE(b.completed_at, b.created_at) AS \
-     created_at, NULL::bigint AS file_size FROM builds b JOIN evaluations e \
+     narinfo_cache n WHERE ($1::uuid IS NULL OR n.project_id = $1 OR EXISTS \
+     (SELECT 1 FROM narinfo_cache_projects ncp WHERE ncp.store_path = \
+     n.store_path AND ncp.project_id = $1))), local AS (SELECT DISTINCT ON \
+     (path) path AS store_path, created_at, COALESCE(file_size, 0) AS \
+     file_size FROM (SELECT bp.path, bp.created_at, bp.file_size FROM \
+     build_products bp JOIN builds b ON b.id = bp.build_id JOIN evaluations e \
      ON e.id = b.evaluation_id JOIN jobsets j ON j.id = e.jobset_id WHERE \
-     b.status = 'succeeded' AND b.signed = true AND b.build_output_path IS \
-     NOT NULL AND ($1::uuid IS NULL OR j.project_id = $1)) candidates WHERE \
-     NOT EXISTS (SELECT 1 FROM narinfo_cache n WHERE n.store_path = \
-     candidates.path AND ($1::uuid IS NULL OR n.project_id = $1)) ORDER BY \
-     path, created_at DESC), inventory AS (SELECT * FROM uploaded UNION ALL \
-     SELECT * FROM local) SELECT to_timestamp(floor(extract(epoch FROM \
-     created_at) / $2) * $2) AS bucket_time, COUNT(*), \
-     COALESCE(SUM(file_size), 0)::bigint FROM inventory WHERE created_at > \
-     NOW() - ($3 * INTERVAL '1 second') GROUP BY bucket_time ORDER BY \
-     bucket_time ASC",
+     b.status = 'succeeded' AND b.signed = true AND ($1::uuid IS NULL OR \
+     j.project_id = $1) UNION ALL SELECT b.build_output_path AS path, \
+     COALESCE(b.completed_at, b.created_at) AS created_at, NULL::bigint AS \
+     file_size FROM builds b JOIN evaluations e ON e.id = b.evaluation_id \
+     JOIN jobsets j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND \
+     b.signed = true AND b.build_output_path IS NOT NULL AND ($1::uuid IS \
+     NULL OR j.project_id = $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM \
+     narinfo_cache n WHERE n.store_path = candidates.path AND ($1::uuid IS \
+     NULL OR n.project_id = $1 OR EXISTS (SELECT 1 FROM \
+     narinfo_cache_projects ncp WHERE ncp.store_path = n.store_path AND \
+     ncp.project_id = $1))) ORDER BY path, created_at DESC), inventory AS \
+     (SELECT * FROM uploaded UNION ALL SELECT * FROM local) SELECT \
+     to_timestamp(floor(extract(epoch FROM created_at) / $2) * $2) AS \
+     bucket_time, COUNT(*), COALESCE(SUM(file_size), 0)::bigint FROM \
+     inventory WHERE created_at > NOW() - ($3 * INTERVAL '1 second') GROUP BY \
+     bucket_time ORDER BY bucket_time ASC",
   )
   .bind(project_id)
   .bind(bucket)

--- a/crates/common/src/repo/narinfo_cache.rs
+++ b/crates/common/src/repo/narinfo_cache.rs
@@ -55,6 +55,8 @@ pub struct UpsertNarInfo<'a> {
 ///
 /// Returns the underlying sqlx error.
 pub async fn upsert(pool: &PgPool, info: UpsertNarInfo<'_>) -> Result<()> {
+  // One transaction so a row never lands without its project association.
+  let mut tx = pool.begin().await?;
   sqlx::query(
     "INSERT INTO narinfo_cache (store_path, nar_hash, nar_size, file_hash, \
      file_size, compression, url, deriver, \"references\", sig, ca, build_id, \
@@ -64,8 +66,9 @@ pub async fn upsert(pool: &PgPool, info: UpsertNarInfo<'_>) -> Result<()> {
      EXCLUDED.file_hash, file_size = EXCLUDED.file_size, compression = \
      EXCLUDED.compression, url = EXCLUDED.url, deriver = EXCLUDED.deriver, \
      \"references\" = EXCLUDED.\"references\", sig = EXCLUDED.sig, ca = \
-     EXCLUDED.ca, build_id = EXCLUDED.build_id, project_id = \
-     EXCLUDED.project_id, updated_at = NOW()",
+     EXCLUDED.ca, build_id = COALESCE(narinfo_cache.build_id, \
+     EXCLUDED.build_id), project_id = COALESCE(narinfo_cache.project_id, \
+     EXCLUDED.project_id), updated_at = NOW()",
   )
   .bind(info.store_path)
   .bind(info.nar_hash)
@@ -80,8 +83,23 @@ pub async fn upsert(pool: &PgPool, info: UpsertNarInfo<'_>) -> Result<()> {
   .bind(info.ca)
   .bind(info.build_id)
   .bind(info.project_id)
-  .execute(pool)
+  .execute(&mut *tx)
   .await?;
+
+  if let Some(project_id) = info.project_id {
+    sqlx::query(
+      "INSERT INTO narinfo_cache_projects (store_path, project_id, build_id, \
+       updated_at) VALUES ($1, $2, $3, NOW()) ON CONFLICT (store_path, \
+       project_id) DO UPDATE SET build_id = COALESCE(EXCLUDED.build_id, \
+       narinfo_cache_projects.build_id), updated_at = NOW()",
+    )
+    .bind(info.store_path)
+    .bind(project_id)
+    .bind(info.build_id)
+    .execute(&mut *tx)
+    .await?;
+  }
+  tx.commit().await?;
   Ok(())
 }
 
@@ -115,8 +133,10 @@ pub async fn get_by_hash_part(
   // Nix store paths are `/nix/store/<32-chars>-<name>`; we match on the
   // 32-char hash part right after the prefix.
   sqlx::query_as::<_, NarInfo>(
-    "SELECT * FROM narinfo_cache WHERE store_path LIKE $1 AND ($2::uuid IS \
-     NULL OR project_id = $2)",
+    "SELECT * FROM narinfo_cache n WHERE n.store_path LIKE $1 AND ($2::uuid \
+     IS NULL OR n.project_id = $2 OR EXISTS (SELECT 1 FROM \
+     narinfo_cache_projects ncp WHERE ncp.store_path = n.store_path AND \
+     ncp.project_id = $2)) ORDER BY n.updated_at DESC LIMIT 1",
   )
   .bind(format!("/nix/store/{hash_part}-%"))
   .bind(project_id)
@@ -139,8 +159,10 @@ pub async fn get_by_url(
   project_id: Option<Uuid>,
 ) -> Result<NarInfo> {
   sqlx::query_as::<_, NarInfo>(
-    "SELECT * FROM narinfo_cache WHERE url = $1 AND ($2::uuid IS NULL OR \
-     project_id = $2) ORDER BY updated_at DESC LIMIT 1",
+    "SELECT * FROM narinfo_cache n WHERE n.url = $1 AND ($2::uuid IS NULL OR \
+     n.project_id = $2 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp \
+     WHERE ncp.store_path = n.store_path AND ncp.project_id = $2)) ORDER BY \
+     n.updated_at DESC LIMIT 1",
   )
   .bind(url)
   .bind(project_id)
@@ -182,8 +204,8 @@ pub struct CacheStorageSummary {
   pub compressed_bytes:   i64,
 }
 
-/// Storage totals for a cache scope. `project_id = None` covers the global
-/// cache (rows with no project), a concrete id scopes to one project.
+/// Storage totals for a cache scope. `project_id = None` covers the unscoped
+/// global view, a concrete id scopes to one project.
 ///
 /// # Errors
 ///
@@ -195,24 +217,27 @@ pub async fn storage_summary(
   let (nar_count, uncompressed_bytes, compressed_bytes) =
     sqlx::query_as::<_, (i64, i64, i64)>(
       "WITH uploaded AS (SELECT store_path, nar_size, file_size FROM \
-       narinfo_cache WHERE ($1::uuid IS NULL OR project_id = $1)), local AS \
-       (SELECT DISTINCT ON (path) path AS store_path, COALESCE(file_size, 0) \
-       AS nar_size, NULL::bigint AS file_size FROM (SELECT bp.path, \
-       bp.file_size, bp.created_at FROM build_products bp JOIN builds b ON \
-       b.id = bp.build_id JOIN evaluations e ON e.id = b.evaluation_id JOIN \
-       jobsets j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND \
-       b.signed = true AND ($1::uuid IS NULL OR j.project_id = $1) UNION ALL \
-       SELECT b.build_output_path AS path, NULL::bigint AS file_size, \
+       narinfo_cache n WHERE ($1::uuid IS NULL OR n.project_id = $1 OR EXISTS \
+       (SELECT 1 FROM narinfo_cache_projects ncp WHERE ncp.store_path = \
+       n.store_path AND ncp.project_id = $1))), local AS (SELECT DISTINCT ON \
+       (path) path AS store_path, COALESCE(file_size, 0) AS nar_size, \
+       NULL::bigint AS file_size FROM (SELECT bp.path, bp.file_size, \
+       bp.created_at FROM build_products bp JOIN builds b ON b.id = \
+       bp.build_id JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets \
+       j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND b.signed = \
+       true AND ($1::uuid IS NULL OR j.project_id = $1) UNION ALL SELECT \
+       b.build_output_path AS path, NULL::bigint AS file_size, \
        COALESCE(b.completed_at, b.created_at) AS created_at FROM builds b \
        JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = \
        e.jobset_id WHERE b.status = 'succeeded' AND b.signed = true AND \
        b.build_output_path IS NOT NULL AND ($1::uuid IS NULL OR j.project_id \
        = $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM narinfo_cache n \
        WHERE n.store_path = candidates.path AND ($1::uuid IS NULL OR \
-       n.project_id = $1)) ORDER BY path, created_at DESC), inventory AS \
-       (SELECT * FROM uploaded UNION ALL SELECT * FROM local) SELECT \
-       COUNT(*), COALESCE(SUM(nar_size), 0)::bigint, COALESCE(SUM(file_size), \
-       0)::bigint FROM inventory",
+       n.project_id = $1 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp \
+       WHERE ncp.store_path = n.store_path AND ncp.project_id = $1))) ORDER \
+       BY path, created_at DESC), inventory AS (SELECT * FROM uploaded UNION \
+       ALL SELECT * FROM local) SELECT COUNT(*), COALESCE(SUM(nar_size), \
+       0)::bigint, COALESCE(SUM(file_size), 0)::bigint FROM inventory",
     )
     .bind(project_id)
     .fetch_one(pool)
@@ -237,22 +262,26 @@ pub async fn storage_extremes(
   let (last_uploaded, oldest_fetched) =
     sqlx::query_as::<_, (Option<DateTime<Utc>>, Option<DateTime<Utc>>)>(
       "WITH uploaded AS (SELECT store_path, created_at, last_fetched_at FROM \
-       narinfo_cache WHERE ($1::uuid IS NULL OR project_id = $1)), local AS \
-       (SELECT DISTINCT ON (path) path AS store_path, created_at, \
-       NULL::timestamptz AS last_fetched_at FROM (SELECT bp.path, \
-       bp.created_at FROM build_products bp JOIN builds b ON b.id = \
-       bp.build_id JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets \
-       j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND b.signed = \
-       true AND ($1::uuid IS NULL OR j.project_id = $1) UNION ALL SELECT \
-       b.build_output_path AS path, COALESCE(b.completed_at, b.created_at) AS \
-       created_at FROM builds b JOIN evaluations e ON e.id = b.evaluation_id \
-       JOIN jobsets j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND \
-       b.signed = true AND b.build_output_path IS NOT NULL AND ($1::uuid IS \
-       NULL OR j.project_id = $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM \
-       narinfo_cache n WHERE n.store_path = candidates.path AND ($1::uuid IS \
-       NULL OR n.project_id = $1)) ORDER BY path, created_at DESC), inventory \
-       AS (SELECT * FROM uploaded UNION ALL SELECT * FROM local) SELECT \
-       MAX(created_at), MIN(last_fetched_at) FROM inventory",
+       narinfo_cache n WHERE ($1::uuid IS NULL OR n.project_id = $1 OR EXISTS \
+       (SELECT 1 FROM narinfo_cache_projects ncp WHERE ncp.store_path = \
+       n.store_path AND ncp.project_id = $1))), local AS (SELECT DISTINCT ON \
+       (path) path AS store_path, created_at, NULL::timestamptz AS \
+       last_fetched_at FROM (SELECT bp.path, bp.created_at FROM \
+       build_products bp JOIN builds b ON b.id = bp.build_id JOIN evaluations \
+       e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = e.jobset_id WHERE \
+       b.status = 'succeeded' AND b.signed = true AND ($1::uuid IS NULL OR \
+       j.project_id = $1) UNION ALL SELECT b.build_output_path AS path, \
+       COALESCE(b.completed_at, b.created_at) AS created_at FROM builds b \
+       JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = \
+       e.jobset_id WHERE b.status = 'succeeded' AND b.signed = true AND \
+       b.build_output_path IS NOT NULL AND ($1::uuid IS NULL OR j.project_id \
+       = $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM narinfo_cache n \
+       WHERE n.store_path = candidates.path AND ($1::uuid IS NULL OR \
+       n.project_id = $1 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp \
+       WHERE ncp.store_path = n.store_path AND ncp.project_id = $1))) ORDER \
+       BY path, created_at DESC), inventory AS (SELECT * FROM uploaded UNION \
+       ALL SELECT * FROM local) SELECT MAX(created_at), MIN(last_fetched_at) \
+       FROM inventory",
     )
     .bind(project_id)
     .fetch_one(pool)
@@ -315,24 +344,27 @@ pub async fn list_filtered(
 ) -> Result<Vec<NarListItem>> {
   let rows = sqlx::query_as::<_, NarListItem>(
     "WITH uploaded AS (SELECT store_path, nar_size, file_size, compression, \
-     created_at, last_fetched_at FROM narinfo_cache WHERE ($1::uuid IS NULL \
-     OR project_id = $1)), local AS (SELECT DISTINCT ON (path) path AS \
-     store_path, COALESCE(file_size, 0) AS nar_size, NULL::bigint AS \
-     file_size, 'none' AS compression, created_at, NULL::timestamptz AS \
-     last_fetched_at FROM (SELECT bp.path, bp.file_size, bp.created_at FROM \
-     build_products bp JOIN builds b ON b.id = bp.build_id JOIN evaluations e \
-     ON e.id = b.evaluation_id JOIN jobsets j ON j.id = e.jobset_id WHERE \
-     b.status = 'succeeded' AND b.signed = true AND ($1::uuid IS NULL OR \
-     j.project_id = $1) UNION ALL SELECT b.build_output_path AS path, \
-     NULL::bigint AS file_size, COALESCE(b.completed_at, b.created_at) AS \
-     created_at FROM builds b JOIN evaluations e ON e.id = b.evaluation_id \
-     JOIN jobsets j ON j.id = e.jobset_id WHERE b.status = 'succeeded' AND \
-     b.signed = true AND b.build_output_path IS NOT NULL AND ($1::uuid IS \
-     NULL OR j.project_id = $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM \
-     narinfo_cache n WHERE n.store_path = candidates.path AND ($1::uuid IS \
-     NULL OR n.project_id = $1)) ORDER BY path, created_at DESC), inventory \
-     AS (SELECT * FROM uploaded UNION ALL SELECT * FROM local) SELECT \
-     store_path, COALESCE(substring(store_path from \
+     created_at, last_fetched_at FROM narinfo_cache n WHERE ($1::uuid IS NULL \
+     OR n.project_id = $1 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp \
+     WHERE ncp.store_path = n.store_path AND ncp.project_id = $1))), local AS \
+     (SELECT DISTINCT ON (path) path AS store_path, COALESCE(file_size, 0) AS \
+     nar_size, NULL::bigint AS file_size, 'none' AS compression, created_at, \
+     NULL::timestamptz AS last_fetched_at FROM (SELECT bp.path, bp.file_size, \
+     bp.created_at FROM build_products bp JOIN builds b ON b.id = bp.build_id \
+     JOIN evaluations e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = \
+     e.jobset_id WHERE b.status = 'succeeded' AND b.signed = true AND \
+     ($1::uuid IS NULL OR j.project_id = $1) UNION ALL SELECT \
+     b.build_output_path AS path, NULL::bigint AS file_size, \
+     COALESCE(b.completed_at, b.created_at) AS created_at FROM builds b JOIN \
+     evaluations e ON e.id = b.evaluation_id JOIN jobsets j ON j.id = \
+     e.jobset_id WHERE b.status = 'succeeded' AND b.signed = true AND \
+     b.build_output_path IS NOT NULL AND ($1::uuid IS NULL OR j.project_id = \
+     $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM narinfo_cache n WHERE \
+     n.store_path = candidates.path AND ($1::uuid IS NULL OR n.project_id = \
+     $1 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp WHERE \
+     ncp.store_path = n.store_path AND ncp.project_id = $1))) ORDER BY path, \
+     created_at DESC), inventory AS (SELECT * FROM uploaded UNION ALL SELECT \
+     * FROM local) SELECT store_path, COALESCE(substring(store_path from \
      '^/nix/store/[^-]+-(.*)$'), store_path) AS package_name, nar_size, \
      file_size, compression, created_at, last_fetched_at FROM inventory WHERE \
      ($2::text IS NULL OR store_path LIKE '/nix/store/' || $2 || '%') AND \
@@ -361,9 +393,11 @@ pub async fn count_filtered(
   package_query: Option<&str>,
 ) -> Result<i64> {
   let (n,) = sqlx::query_as::<_, (i64,)>(
-    "WITH uploaded AS (SELECT store_path FROM narinfo_cache WHERE ($1::uuid \
-     IS NULL OR project_id = $1)), local AS (SELECT DISTINCT ON (path) path \
-     AS store_path FROM (SELECT bp.path, bp.created_at FROM build_products bp \
+    "WITH uploaded AS (SELECT store_path FROM narinfo_cache n WHERE ($1::uuid \
+     IS NULL OR n.project_id = $1 OR EXISTS (SELECT 1 FROM \
+     narinfo_cache_projects ncp WHERE ncp.store_path = n.store_path AND \
+     ncp.project_id = $1))), local AS (SELECT DISTINCT ON (path) path AS \
+     store_path FROM (SELECT bp.path, bp.created_at FROM build_products bp \
      JOIN builds b ON b.id = bp.build_id JOIN evaluations e ON e.id = \
      b.evaluation_id JOIN jobsets j ON j.id = e.jobset_id WHERE b.status = \
      'succeeded' AND b.signed = true AND ($1::uuid IS NULL OR j.project_id = \
@@ -374,10 +408,12 @@ pub async fn count_filtered(
      b.build_output_path IS NOT NULL AND ($1::uuid IS NULL OR j.project_id = \
      $1)) candidates WHERE NOT EXISTS (SELECT 1 FROM narinfo_cache n WHERE \
      n.store_path = candidates.path AND ($1::uuid IS NULL OR n.project_id = \
-     $1)) ORDER BY path, created_at DESC), inventory AS (SELECT * FROM \
-     uploaded UNION ALL SELECT * FROM local) SELECT COUNT(*) FROM inventory \
-     WHERE ($2::text IS NULL OR store_path LIKE '/nix/store/' || $2 || '%') \
-     AND ($3::text IS NULL OR store_path LIKE '%-%' || $3 || '%')",
+     $1 OR EXISTS (SELECT 1 FROM narinfo_cache_projects ncp WHERE \
+     ncp.store_path = n.store_path AND ncp.project_id = $1))) ORDER BY path, \
+     created_at DESC), inventory AS (SELECT * FROM uploaded UNION ALL SELECT \
+     * FROM local) SELECT COUNT(*) FROM inventory WHERE ($2::text IS NULL OR \
+     store_path LIKE '/nix/store/' || $2 || '%') AND ($3::text IS NULL OR \
+     store_path LIKE '%-%' || $3 || '%')",
   )
   .bind(project_id)
   .bind(hash_prefix)

--- a/crates/migrations/migrations/0028_narinfo_cache_project_owners.sql
+++ b/crates/migrations/migrations/0028_narinfo_cache_project_owners.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS narinfo_cache_projects (
+  store_path TEXT NOT NULL REFERENCES narinfo_cache (store_path) ON DELETE CASCADE,
+  project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+  build_id UUID REFERENCES builds (id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (store_path, project_id)
+);
+
+INSERT INTO
+  narinfo_cache_projects (
+    store_path,
+    project_id,
+    build_id,
+    created_at,
+    updated_at
+  )
+SELECT
+  store_path,
+  project_id,
+  build_id,
+  created_at,
+  updated_at
+FROM
+  narinfo_cache
+WHERE
+  project_id IS NOT NULL
+ON CONFLICT (store_path, project_id) DO UPDATE
+SET
+  build_id = COALESCE(
+    EXCLUDED.build_id,
+    narinfo_cache_projects.build_id
+  ),
+  updated_at = GREATEST(
+    narinfo_cache_projects.updated_at,
+    EXCLUDED.updated_at
+  );
+
+CREATE INDEX IF NOT EXISTS idx_narinfo_cache_projects_project_id ON narinfo_cache_projects (project_id);
+
+CREATE INDEX IF NOT EXISTS idx_narinfo_cache_projects_build_id ON narinfo_cache_projects (build_id);

--- a/crates/nix/src/base32.rs
+++ b/crates/nix/src/base32.rs
@@ -1,0 +1,107 @@
+//! Nix base32 encoding for sha256 hashes (the `0-9a-z` minus `eotu` alphabet
+//! Nix uses for store-path and NAR hashes).
+
+const ALPHABET: &[u8; 32] = b"0123456789abcdfghijklmnpqrsvwxyz";
+
+/// Whether `byte` is a valid Nix base32 character.
+#[must_use]
+pub const fn is_base32_byte(byte: u8) -> bool {
+  matches!(
+    byte,
+    b'0'
+      ..=b'9'
+        | b'a'
+        | b'b'
+        | b'c'
+        | b'd'
+        | b'f'
+        | b'g'
+        | b'h'
+        | b'i'
+        | b'j'
+        | b'k'
+        | b'l'
+        | b'm'
+        | b'n'
+        | b'p'
+        | b'q'
+        | b'r'
+        | b's'
+        | b'v'
+        | b'w'
+        | b'x'
+        | b'y'
+        | b'z'
+  )
+}
+
+/// Encode a 32-byte sha256 digest as its 52-character Nix base32 string.
+#[must_use]
+pub fn encode_sha256(bytes: &[u8]) -> String {
+  let len = 52;
+  let mut out = String::with_capacity(len);
+  for pos in 0..len {
+    let n = len - 1 - pos;
+    let bit = n * 5;
+    let byte = bit / 8;
+    let offset = bit % 8;
+    let mut value = u16::from(bytes[byte]) >> offset;
+    if byte + 1 < bytes.len() {
+      value |= u16::from(bytes[byte + 1]) << (8 - offset);
+    }
+    out.push(ALPHABET[(value & 0x1F) as usize] as char);
+  }
+  out
+}
+
+/// Decode a 52-character Nix base32 sha256 string into its 32 bytes.
+///
+/// # Errors
+///
+/// Returns an error when the input is not 52 valid Nix base32 characters.
+pub fn decode_sha256(text: &str) -> Result<Vec<u8>, String> {
+  if text.len() != 52 {
+    return Err(format!(
+      "Nix base32 sha256 hash has {} chars, expected 52",
+      text.len()
+    ));
+  }
+  let mut out = vec![0u8; 32];
+  for (pos, c) in text.bytes().enumerate() {
+    let value = ALPHABET
+      .iter()
+      .position(|b| *b == c)
+      .ok_or_else(|| format!("invalid Nix base32 character {}", c as char))?
+      as u16;
+    let n = text.len() - 1 - pos;
+    let bit = n * 5;
+    let byte = bit / 8;
+    let offset = bit % 8;
+    out[byte] |= (value << offset) as u8;
+    if byte + 1 < out.len() && offset > 3 {
+      out[byte + 1] |= (value >> (8 - offset)) as u8;
+    }
+  }
+  Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn sha256_roundtrip() {
+    let bytes: Vec<u8> = (0..32).collect();
+    let encoded = encode_sha256(&bytes);
+    assert_eq!(encoded.len(), 52);
+    assert!(encoded.bytes().all(is_base32_byte));
+    assert_eq!(decode_sha256(&encoded).expect("decode"), bytes);
+  }
+
+  #[test]
+  fn rejects_non_alphabet_and_wrong_length() {
+    assert!(!is_base32_byte(b'e'));
+    assert!(decode_sha256("tooshort").is_err());
+    assert!(decode_sha256(&"e".repeat(52)).is_err());
+  }
+}

--- a/crates/nix/src/lib.rs
+++ b/crates/nix/src/lib.rs
@@ -1,6 +1,7 @@
 //! Nix integration: flake references, store paths, derivation features, and
 //! flake probing.
 
+pub mod base32;
 pub mod derivation;
 pub mod error;
 pub mod flake;

--- a/crates/nix/src/store.rs
+++ b/crates/nix/src/store.rs
@@ -61,13 +61,11 @@ impl NixHash {
   ///
   /// # Errors
   ///
-  /// Returns error if the hash is not exactly 32 lowercase alphanumeric
-  /// characters.
+  /// Returns error if the hash is not exactly 32 Nix base32 characters.
   pub fn parse(hash: &str) -> Result<Self, String> {
     if !Self::is_valid(hash) {
       return Err(
-        "nix hash must be exactly 32 lowercase alphanumeric characters"
-          .to_string(),
+        "nix hash must be exactly 32 Nix base32 characters".to_string(),
       );
     }
     Ok(Self(hash.to_string()))
@@ -76,10 +74,7 @@ impl NixHash {
   /// Check validity without constructing.
   #[must_use]
   pub fn is_valid(hash: &str) -> bool {
-    hash.len() == 32
-      && hash
-        .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    hash.len() == 32 && hash.bytes().all(crate::base32::is_base32_byte)
   }
 
   #[must_use]
@@ -178,7 +173,7 @@ mod tests {
 
   #[test]
   fn valid_nix_hash_lowercase_alpha() {
-    assert!(NixHash::is_valid("abcdefghijklmnopqrstuvwxyzabcdef"));
+    assert!(NixHash::is_valid("0123456789abcdfghijklmnpqrsvwxyz"));
   }
 
   #[test]
@@ -188,7 +183,7 @@ mod tests {
 
   #[test]
   fn valid_nix_hash_mixed() {
-    assert!(NixHash::is_valid("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"));
+    assert!(NixHash::is_valid("a1b2c3d4f5g6a7b8c9d0f1g2a3b4c5d6"));
   }
 
   #[test]
@@ -250,10 +245,10 @@ mod tests {
 
   #[test]
   fn nix_hash_parse_returns_validated_type() {
-    let h = NixHash::parse("abcdefghijklmnopqrstuvwxyzabcdef");
+    let h = NixHash::parse("0123456789abcdfghijklmnpqrsvwxyz");
     assert_eq!(
       h.expect("valid nix hash").as_str(),
-      "abcdefghijklmnopqrstuvwxyzabcdef"
+      "0123456789abcdfghijklmnpqrsvwxyz"
     );
   }
 }

--- a/crates/queue-runner/src/rpc/upload_verify.rs
+++ b/crates/queue-runner/src/rpc/upload_verify.rs
@@ -139,7 +139,10 @@ pub async fn verify(req: VerifyRequest) -> color_eyre::Result<UploadedNar> {
 
   // Store and sign in Nix sha256 base32, the form a client re-encodes the
   // nar hash to before verifying.
-  let nar_hash = format!("sha256:{}", encode_nix_base32_sha256(&computed_nar));
+  let nar_hash = format!(
+    "sha256:{}",
+    circus_nix::base32::encode_sha256(&computed_nar)
+  );
 
   Ok(UploadedNar {
     nar_hash,
@@ -210,55 +213,11 @@ fn parse_sha256_hash(text: &str) -> color_eyre::Result<Vec<u8>> {
     return hex::decode(hex).context("decode sha256 hex hash");
   }
   if let Some(nix32) = text.strip_prefix("sha256:") {
-    return decode_nix_base32_sha256(nix32)
+    return circus_nix::base32::decode_sha256(nix32)
+      .map_err(|e| eyre!("{e}"))
       .with_context(|| format!("decode Nix base32 sha256 hash {text}"));
   }
   bail!("unsupported sha256 hash format: {text}")
-}
-
-fn encode_nix_base32_sha256(bytes: &[u8]) -> String {
-  const ALPHABET: &[u8; 32] = b"0123456789abcdfghijklmnpqrsvwxyz";
-  let len = 52;
-  let mut out = String::with_capacity(len);
-  for pos in 0..len {
-    let n = len - 1 - pos;
-    let bit = n * 5;
-    let byte = bit / 8;
-    let offset = bit % 8;
-    let mut value = u16::from(bytes[byte]) >> offset;
-    if byte + 1 < bytes.len() {
-      value |= u16::from(bytes[byte + 1]) << (8 - offset);
-    }
-    out.push(ALPHABET[(value & 0x1F) as usize] as char);
-  }
-  out
-}
-
-fn decode_nix_base32_sha256(text: &str) -> color_eyre::Result<Vec<u8>> {
-  const ALPHABET: &[u8; 32] = b"0123456789abcdfghijklmnpqrsvwxyz";
-  if text.len() != 52 {
-    bail!(
-      "Nix base32 sha256 hash has {} chars, expected 52",
-      text.len()
-    );
-  }
-  let mut out = vec![0u8; 32];
-  for (pos, c) in text.bytes().enumerate() {
-    let value = ALPHABET
-      .iter()
-      .position(|b| *b == c)
-      .ok_or_else(|| eyre!("invalid Nix base32 character {}", c as char))?
-      as u16;
-    let n = text.len() - 1 - pos;
-    let bit = n * 5;
-    let byte = bit / 8;
-    let offset = bit % 8;
-    out[byte] |= (value << offset) as u8;
-    if byte + 1 < out.len() && offset > 3 {
-      out[byte + 1] |= (value >> (8 - offset)) as u8;
-    }
-  }
-  Ok(out)
 }
 
 #[cfg(test)]
@@ -280,16 +239,5 @@ mod tests {
     let bytes = [0u8; 32];
     let text = format!("sha256-{}", B64.encode(bytes));
     assert!(hash_matches(&text, &bytes).expect("SRI hash should parse"));
-  }
-
-  #[test]
-  fn nix_base32_roundtrip() {
-    for bytes in [[0u8; 32], [0xFF; 32], core::array::from_fn(|i| i as u8)] {
-      let encoded = super::encode_nix_base32_sha256(&bytes);
-      assert_eq!(encoded.len(), 52);
-      let decoded =
-        super::decode_nix_base32_sha256(&encoded).expect("re-decode");
-      assert_eq!(decoded, bytes);
-    }
   }
 }

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -7,7 +7,10 @@ use circus_common::{
 };
 use circus_config::HotConfig;
 use sqlx::PgPool;
-use tokio::sync::{Notify, RwLock};
+use tokio::{
+  sync::{Notify, RwLock},
+  task::JoinSet,
+};
 use uuid::Uuid;
 
 use crate::{
@@ -136,6 +139,7 @@ async fn publish_succeeded_output_closure(
     .await;
 }
 
+/// Collects the build's output paths from the first source that has any.
 async fn completed_build_output_paths(
   pool: &PgPool,
   build: &Build,
@@ -183,6 +187,36 @@ async fn completed_build_output_paths(
   output_paths
 }
 
+fn spawn_succeeded_output_closure_publication(
+  tasks: &mut JoinSet<()>,
+  pool: &PgPool,
+  worker_pool: &Arc<WorkerPool>,
+  build_id: Uuid,
+  output_paths: Vec<String>,
+) {
+  let pool = pool.clone();
+  let worker_pool = Arc::clone(worker_pool);
+  // Published off the scheduler loop, but tracked so a panic surfaces in
+  // reap_closure_publications.
+  tasks.spawn(async move {
+    publish_succeeded_output_closure(
+      &pool,
+      &worker_pool,
+      build_id,
+      &output_paths,
+    )
+    .await;
+  });
+}
+
+fn reap_closure_publications(tasks: &mut JoinSet<()>) {
+  while let Some(result) = tasks.try_join_next() {
+    if let Err(e) = result {
+      tracing::warn!("closure narinfo publication task failed: {e}");
+    }
+  }
+}
+
 /// Main queue runner loop. Polls for pending builds and dispatches them to
 /// workers.
 ///
@@ -200,10 +234,12 @@ pub async fn run(
 ) -> color_eyre::Result<()> {
   let mut last_orphan_reset = tokio::time::Instant::now();
   let orphan_reset_interval = Duration::from_mins(1);
+  let mut closure_publications: JoinSet<()> = JoinSet::new();
   reset_orphaned_builds(&pool, worker_pool.active_builds()).await;
   prune_stale_ephemeral_sessions(&pool).await;
 
   loop {
+    reap_closure_publications(&mut closure_publications);
     if last_orphan_reset.elapsed() >= orphan_reset_interval {
       reset_orphaned_builds(&pool, worker_pool.active_builds()).await;
       prune_stale_ephemeral_sessions(&pool).await;
@@ -346,13 +382,13 @@ pub async fn run(
                 } else {
                   let output_paths =
                     completed_build_output_paths(&pool, &existing).await;
-                  publish_succeeded_output_closure(
+                  spawn_succeeded_output_closure_publication(
+                    &mut closure_publications,
                     &pool,
                     &worker_pool,
                     build.id,
-                    &output_paths,
-                  )
-                  .await;
+                    output_paths,
+                  );
                 }
                 continue;
               },
@@ -401,13 +437,13 @@ pub async fn run(
               {
                 tracing::warn!(build_id = %build.id, "Failed to complete FOD build: {e}");
               } else {
-                publish_succeeded_output_closure(
+                spawn_succeeded_output_closure_publication(
+                  &mut closure_publications,
                   &pool,
                   &worker_pool,
                   build.id,
-                  std::slice::from_ref(&output_path),
-                )
-                .await;
+                  vec![output_path.clone()],
+                );
               }
               continue;
             }

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -453,7 +453,7 @@ fn canonical_nix_sha256_hash(text: &str) -> Option<String> {
   }
 
   let rest = text.strip_prefix("sha256:")?;
-  if rest.len() == 52 && rest.bytes().all(is_nix_base32_byte) {
+  if rest.len() == 52 && rest.bytes().all(circus_nix::base32::is_base32_byte) {
     return Some(text.to_owned());
   }
   if rest.len() == 64 && rest.bytes().all(|b| b.is_ascii_hexdigit()) {
@@ -467,55 +467,10 @@ fn canonical_sha256_bytes(bytes: &[u8]) -> Option<String> {
   if bytes.len() != 32 {
     return None;
   }
-  Some(format!("sha256:{}", encode_nix_base32_sha256(bytes)))
-}
-
-const fn is_nix_base32_byte(byte: u8) -> bool {
-  matches!(
-    byte,
-    b'0'
-      ..=b'9'
-        | b'a'
-        | b'b'
-        | b'c'
-        | b'd'
-        | b'f'
-        | b'g'
-        | b'h'
-        | b'i'
-        | b'j'
-        | b'k'
-        | b'l'
-        | b'm'
-        | b'n'
-        | b'p'
-        | b'q'
-        | b'r'
-        | b's'
-        | b'v'
-        | b'w'
-        | b'x'
-        | b'y'
-        | b'z'
-  )
-}
-
-fn encode_nix_base32_sha256(bytes: &[u8]) -> String {
-  const ALPHABET: &[u8; 32] = b"0123456789abcdfghijklmnpqrsvwxyz";
-  let len = 52;
-  let mut out = String::with_capacity(len);
-  for pos in 0..len {
-    let n = len - 1 - pos;
-    let bit = n * 5;
-    let byte = bit / 8;
-    let offset = bit % 8;
-    let mut value = u16::from(bytes[byte]) >> offset;
-    if byte + 1 < bytes.len() {
-      value |= u16::from(bytes[byte + 1]) << (8 - offset);
-    }
-    out.push(ALPHABET[(value & 0x1F) as usize] as char);
-  }
-  out
+  Some(format!(
+    "sha256:{}",
+    circus_nix::base32::encode_sha256(bytes)
+  ))
 }
 
 fn nar_url_for_path(info: &ClosurePathInfo) -> Option<String> {
@@ -1746,7 +1701,7 @@ mod tests {
   #[test]
   fn test_canonical_nix_sha256_hash_accepts_common_formats() {
     let bytes = [7u8; 32];
-    let nix32 = encode_nix_base32_sha256(&bytes);
+    let nix32 = circus_nix::base32::encode_sha256(&bytes);
     let expected = format!("sha256:{nix32}");
 
     assert_eq!(
@@ -1775,7 +1730,8 @@ mod tests {
       use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
       format!("sha256-{}", B64.encode(bytes))
     };
-    let expected_hash = format!("sha256:{}", encode_nix_base32_sha256(&bytes));
+    let expected_hash =
+      format!("sha256:{}", circus_nix::base32::encode_sha256(&bytes));
     let parsed = serde_json::json!({
       "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-linux-6.18.33-valve2": {
         "narHash": sri_hash,
@@ -1906,10 +1862,14 @@ mod tests {
       use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
       format!("sha256-{}", B64.encode(dep_nar_bytes))
     };
-    let output_nar_hash =
-      format!("sha256:{}", encode_nix_base32_sha256(&output_nar_bytes));
-    let dep_nar_hash =
-      format!("sha256:{}", encode_nix_base32_sha256(&dep_nar_bytes));
+    let output_nar_hash = format!(
+      "sha256:{}",
+      circus_nix::base32::encode_sha256(&output_nar_bytes)
+    );
+    let dep_nar_hash = format!(
+      "sha256:{}",
+      circus_nix::base32::encode_sha256(&dep_nar_bytes)
+    );
     let path_info = serde_json::json!({
       output_path.clone(): {
         "narHash": output_sri,

--- a/crates/queue-runner/src/worker.rs
+++ b/crates/queue-runner/src/worker.rs
@@ -1785,6 +1785,11 @@ mod tests {
         ],
         "deriver": "/nix/store/cccccccccccccccccccccccccccccccc-linux.drv",
         "ca": null
+      },
+      "/nix/store/dddddddddddddddddddddddddddddddd-bad-hash": {
+        "narHash": "md5:0123456789abcdef0123456789abcdef",
+        "narSize": 99,
+        "references": []
       }
     });
 
@@ -1879,12 +1884,10 @@ mod tests {
     let key_file = temp_dir.join("signing.key");
     let fake_nix = temp_dir.join("nix");
 
-    // A real Ed25519 key (seed + matching public half); the signer now
-    // verifies the public key against the seed, so a placeholder is rejected.
-    let signing_key = "circus-test-1:\
-                       OlzHrxDxaOpPjkL5uNXF77Xq4VRiz6Zy0LqlK6GCNqRX90gxFy2HSr/\
-                       hxqdpc2VMU2UIlDOAEBv842MCsbPfgQ=="
-      .to_string();
+    let signing_key = {
+      use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+      format!("circus-test-1:{}", B64.encode([1u8; 64]))
+    };
     tokio::fs::write(&key_file, signing_key)
       .await
       .expect("write signing key");
@@ -1969,7 +1972,7 @@ mod tests {
         "nar/{}.nar?hash={output_store_hash}",
         output_nar_hash
           .strip_prefix("sha256:")
-          .expect("canonical nar hash should have sha256 prefix")
+          .expect("test nar hash should use sha256 prefix")
       )
     );
     assert_eq!(output_row.references, vec![dep_path.clone()]);
@@ -1977,23 +1980,14 @@ mod tests {
       sig.starts_with("circus-test-1:") && sig.len() > "circus-test-1:".len()
     }));
 
-    // The transitive dependency is cached and signed too, not just the output.
+    assert_eq!(dep_row.build_id, Some(build.id));
+    assert_eq!(dep_row.project_id, Some(project.id));
     assert_eq!(dep_row.nar_hash, dep_nar_hash);
+    assert!(dep_row.references.is_empty());
     assert!(dep_row.sig.as_deref().is_some_and(|sig| {
       sig.starts_with("circus-test-1:") && sig.len() > "circus-test-1:".len()
     }));
 
-    let cleanup_paths = [output_path, dep_path];
-    let _ = sqlx::query("DELETE FROM narinfo_cache WHERE store_path = ANY($1)")
-      .bind(&cleanup_paths[..])
-      .execute(&pool)
-      .await;
-    let _ = repo::builds::delete(&pool, build.id).await;
-    let _ = sqlx::query("DELETE FROM evaluations WHERE id = $1")
-      .bind(evaluation.id)
-      .execute(&pool)
-      .await;
-    let _ = repo::jobsets::delete(&pool, jobset.id).await;
     let _ = repo::projects::delete(&pool, project.id).await;
     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
   }

--- a/crates/server/src/cli.rs
+++ b/crates/server/src/cli.rs
@@ -8,6 +8,7 @@ use tokio::net::TcpListener;
 
 use crate::{
   routes,
+  signing,
   state::{AppState, NixStore},
 };
 
@@ -159,6 +160,24 @@ where
   let nix_store = NixStore::new(config.nix.store_dir.clone())
     .map_err(|e| color_eyre::eyre::eyre!(e))?;
 
+  // Fail fast on a signing config whose key cannot be used.
+  let cache_public_key = match signing::signing_public_key(&config) {
+    Some(key) => {
+      Some(Arc::new(key.parse().map_err(|e| {
+        color_eyre::eyre::eyre!(
+          "signing.key_file yields an unusable public key: {e:?}"
+        )
+      })?))
+    },
+    None if config.signing.enabled && config.signing.key_file.is_some() => {
+      return Err(color_eyre::eyre::eyre!(
+        "signing is enabled but no public key could be derived from \
+         signing.key_file"
+      ));
+    },
+    None => None,
+  };
+
   let state = AppState {
     pool: db.pool().clone(),
     nix_store,
@@ -169,6 +188,7 @@ where
     csrf_secret: Arc::new(csrf_secret),
     email_regex,
     cache_traffic: Arc::new(dashmap::DashMap::new()),
+    cache_public_key,
   };
 
   // Start background session cleanup to prevent memory leaks

--- a/crates/server/src/routes/cache.rs
+++ b/crates/server/src/routes/cache.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeSet, num::NonZero, path::PathBuf, time::Duration};
+use std::{
+  collections::BTreeSet,
+  num::NonZero,
+  path::{self, PathBuf},
+  time::Duration,
+};
 
 use axum::{
   Router,
@@ -14,6 +19,8 @@ use circus_binary_cache::{
   HashFormat as _,
   NarByteStream,
   NarHash,
+  PublicKey,
+  Signature,
   StoreDir,
   StorePath,
   StorePathHash,
@@ -129,6 +136,86 @@ fn narinfo_has_signature(
   row.sig.as_ref().is_some_and(|sig| !sig.trim().is_empty())
 }
 
+/// Whether a persisted narinfo row may be served.
+///
+/// With a loaded public key the signature must verify cryptographically.
+/// Without one we cannot verify anything, so fall back to the historical
+/// non-empty signature check.
+fn persisted_row_is_trusted(
+  row: &circus_common::repo::narinfo_cache::NarInfo,
+  public_key: Option<&PublicKey>,
+) -> bool {
+  let Some(public_key) = public_key else {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+      tracing::warn!(
+        "serving persisted narinfos without signature verification because no \
+         signing public key is loaded"
+      );
+    });
+    return narinfo_has_signature(row);
+  };
+  let sig_row = PersistedNarinfoSig {
+    nar_hash:   row.nar_hash.clone(),
+    nar_size:   row.nar_size,
+    references: row.references.clone(),
+    sig:        row.sig.clone(),
+  };
+  narinfo_signature_verifies(&row.store_path, &sig_row, public_key)
+}
+
+fn narinfo_row_uses_local_nar_route(
+  row: &circus_common::repo::narinfo_cache::NarInfo,
+) -> bool {
+  if row.compression != "none" {
+    return false;
+  }
+  let Some(path) = row.url.strip_prefix("nar/") else {
+    return false;
+  };
+  let Some((object, query)) = path.split_once('?') else {
+    return false;
+  };
+  let object = path::Path::new(object);
+  let has_nar_ext = object
+    .extension()
+    .is_some_and(|ext| ext.eq_ignore_ascii_case("nar"));
+  let stem_nonempty = object
+    .file_stem()
+    .and_then(|s| s.to_str())
+    .is_some_and(|s| !s.is_empty());
+  // Require a real store hash in `hash=`, not just the URL shape.
+  let has_valid_output_hash = query
+    .split('&')
+    .filter_map(|part| part.strip_prefix("hash="))
+    .any(circus_nix::NixHash::is_valid);
+  has_nar_ext && stem_nonempty && has_valid_output_hash
+}
+
+async fn local_narinfo_row_is_servable(
+  state: &AppState,
+  hash: &str,
+  scope: CacheScope,
+) -> Result<bool, ApiError> {
+  let Some(nix_store_db) = open_nix_store_db(state).await else {
+    return Ok(false);
+  };
+  let store_dir = state.nix_store.store_dir();
+  let Some(info) =
+    query_binary_cache_path_info(hash, &store_dir, nix_store_db).await?
+  else {
+    return Ok(false);
+  };
+  is_servable_binary_cache_path(
+    &state.pool,
+    nix_store_db,
+    &info,
+    scope,
+    state.cache_public_key.as_deref(),
+  )
+  .await
+}
+
 async fn query_binary_cache_path_info(
   hash: &str,
   store_dir: &StoreDir,
@@ -229,21 +316,65 @@ async fn has_circus_build_product(
   .map_err(|e| ApiError(circus_common::CiError::Database(e)))
 }
 
+#[derive(FromRow)]
+struct PersistedNarinfoSig {
+  nar_hash:   String,
+  nar_size:   i64,
+  references: Vec<String>,
+  sig:        Option<String>,
+}
+
+/// Whether a persisted narinfo's signature verifies under our own public key.
+///
+/// Without a loaded key this falls back to the historical non-empty signature
+/// check the query already applies.
 async fn has_signed_persisted_narinfo(
   pool: &PgPool,
   store_path: &str,
   project_id: Option<Uuid>,
+  public_key: Option<&PublicKey>,
 ) -> Result<bool, ApiError> {
-  sqlx::query_scalar::<_, bool>(
-    "SELECT EXISTS(SELECT 1 FROM narinfo_cache WHERE store_path = $1 AND sig \
-     IS NOT NULL AND btrim(sig) != '' AND ($2::uuid IS NULL OR project_id = \
-     $2))",
+  let row = sqlx::query_as::<_, PersistedNarinfoSig>(
+    "SELECT nar_hash, nar_size, \"references\", sig FROM narinfo_cache n \
+     WHERE n.store_path = $1 AND n.sig IS NOT NULL AND btrim(n.sig) != '' AND \
+     ($2::uuid IS NULL OR n.project_id = $2 OR EXISTS (SELECT 1 FROM \
+     narinfo_cache_projects ncp WHERE ncp.store_path = n.store_path AND \
+     ncp.project_id = $2))",
   )
   .bind(store_path)
   .bind(project_id)
-  .fetch_one(pool)
+  .fetch_optional(pool)
   .await
-  .map_err(|e| ApiError(circus_common::CiError::Database(e)))
+  .map_err(|e| ApiError(circus_common::CiError::Database(e)))?;
+  let Some(public_key) = public_key else {
+    return Ok(row.is_some());
+  };
+  Ok(row.is_some_and(|row| {
+    narinfo_signature_verifies(store_path, &row, public_key)
+  }))
+}
+
+/// Verify a persisted narinfo signature against the same fingerprint the runner
+/// signed.
+fn narinfo_signature_verifies(
+  store_path: &str,
+  row: &PersistedNarinfoSig,
+  public_key: &PublicKey,
+) -> bool {
+  let Some(signature) =
+    row.sig.as_deref().and_then(|s| s.parse::<Signature>().ok())
+  else {
+    return false;
+  };
+  let mut references = row.references.clone();
+  references.sort();
+  let fingerprint = format!(
+    "1;{store_path};{};{};{}",
+    row.nar_hash,
+    row.nar_size,
+    references.join(",")
+  );
+  public_key.verify(fingerprint.as_bytes(), &signature)
 }
 
 /// As [`has_circus_build_product`], but additionally requires that the build
@@ -323,21 +454,29 @@ async fn is_servable_binary_cache_path(
   nix_store_db: &SqlitePool,
   info: &ValidPathInfo,
   scope: CacheScope,
+  public_key: Option<&PublicKey>,
 ) -> Result<bool, ApiError> {
   // The unauthenticated cache only rebroadcasts paths Circus built, never
   // arbitrary store paths.
   let store_path = info.info.store_dir.display(&info.path).to_string();
-
-  // A dispatched build's own .drv, which agents substitute from this cache to
-  // start the build.
+  if has_signed_persisted_narinfo(
+    pool,
+    &store_path,
+    scope.project_id(),
+    public_key,
+  )
+  .await?
+  {
+    return Ok(true);
+  }
+  // A dispatched build's own .drv: agents substitute it from this cache to
+  // start the build. Derivations are content-addressed, so this must be
+  // checked before the generic CA branch below, which only covers build
+  // outputs and their direct inputs, never the derivation file itself.
   if PathBuf::from(&store_path)
     .extension()
     .is_some_and(|ext| ext.eq_ignore_ascii_case("drv"))
     && has_circus_derivation_path(pool, &store_path, scope.project_id()).await?
-  {
-    return Ok(true);
-  }
-  if has_signed_persisted_narinfo(pool, &store_path, scope.project_id()).await?
   {
     return Ok(true);
   }
@@ -420,10 +559,18 @@ async fn narinfo_for_settings(
   )
   .await;
   if let Ok(row) = row
-    && narinfo_has_signature(&row)
+    && persisted_row_is_trusted(&row, state.cache_public_key.as_deref())
   {
+    let local_nar_route = narinfo_row_uses_local_nar_route(&row);
+    if local_nar_route
+      && !local_narinfo_row_is_servable(&state, hash, settings.scope).await?
+    {
+      return Ok(StatusCode::NOT_FOUND.into_response());
+    }
     let body = render_narinfo_row(&row);
-    state.narinfo_cache.insert(cache_key, body.clone());
+    if !local_nar_route {
+      state.narinfo_cache.insert(cache_key, body.clone());
+    }
     state.record_cache_serve(&settings.cache_name, body.len() as u64);
     return Ok(
       (
@@ -450,6 +597,7 @@ async fn narinfo_for_settings(
     nix_store_db,
     &info,
     settings.scope,
+    state.cache_public_key.as_deref(),
   )
   .await?
   {
@@ -759,6 +907,7 @@ async fn serve_nar_for_settings(
     nix_store_db,
     &info,
     settings.scope,
+    state.cache_public_key.as_deref(),
   )
   .await?
   {
@@ -893,5 +1042,62 @@ mod tests {
 
     let unsigned = NarInfo { sig: None, ..row };
     assert!(!persisted_local_nar_row_matches(&unsigned, hash, nar));
+  }
+
+  #[test]
+  fn persisted_narinfo_signature_must_verify_against_our_key() {
+    use circus_binary_cache::SecretKey;
+
+    let secret = "circus-test-1:\
+                  OlzHrxDxaOpPjkL5uNXF77Xq4VRiz6Zy0LqlK6GCNqRX90gxFy2HSr/\
+                  hxqdpc2VMU2UIlDOAEBv842MCsbPfgQ=="
+      .parse::<SecretKey>()
+      .expect("valid test secret key");
+    let public = secret.to_public_key();
+    let store_path = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-cache-test";
+    let nar_hash =
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let references = vec![
+      "/nix/store/dddddddddddddddddddddddddddddddd-glibc".to_owned(),
+      "/nix/store/cccccccccccccccccccccccccccccccc-zlib".to_owned(),
+    ];
+    let mut sorted = references.clone();
+    sorted.sort();
+    let fingerprint =
+      format!("1;{store_path};{nar_hash};42;{}", sorted.join(","));
+    let sig = secret.sign(fingerprint.as_bytes()).to_string();
+
+    let signed = PersistedNarinfoSig {
+      nar_hash: nar_hash.to_owned(),
+      nar_size: 42,
+      references,
+      sig: Some(sig),
+    };
+    assert!(narinfo_signature_verifies(store_path, &signed, &public));
+
+    let tampered = PersistedNarinfoSig {
+      nar_size: 43,
+      ..signed
+    };
+    assert!(!narinfo_signature_verifies(store_path, &tampered, &public));
+  }
+
+  #[test]
+  fn persisted_row_trust_requires_verification_only_with_a_key() {
+    use circus_binary_cache::SecretKey;
+
+    let secret = "circus-test-1:\
+                  OlzHrxDxaOpPjkL5uNXF77Xq4VRiz6Zy0LqlK6GCNqRX90gxFy2HSr/\
+                  hxqdpc2VMU2UIlDOAEBv842MCsbPfgQ=="
+      .parse::<SecretKey>()
+      .expect("valid test secret key");
+    let public = secret.to_public_key();
+    let row = NarInfo {
+      sig: Some("circus-test-1:bm90IGEgcmVhbCBzaWduYXR1cmU=".to_owned()),
+      ..test_narinfo_row()
+    };
+
+    assert!(persisted_row_is_trusted(&row, None));
+    assert!(!persisted_row_is_trusted(&row, Some(&public)));
   }
 }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -183,22 +183,24 @@ impl NixStore {
 
 #[derive(Clone)]
 pub struct AppState {
-  pub pool:          PgPool,
-  pub nix_store:     NixStore,
-  pub config:        Config,
-  pub sessions:      Arc<DashMap<String, SessionData>>,
-  pub narinfo_cache: NarinfoCache,
-  pub http_client:   reqwest::Client,
+  pub pool:             PgPool,
+  pub nix_store:        NixStore,
+  pub config:           Config,
+  pub sessions:         Arc<DashMap<String, SessionData>>,
+  pub narinfo_cache:    NarinfoCache,
+  pub http_client:      reqwest::Client,
   /// Per-process key used to derive CSRF tokens from session IDs via HMAC.
   /// Regenerated on every restart, which invalidates outstanding tokens; the
   /// dashboard re-issues them on the next page render so this is benign.
-  pub csrf_secret:   Arc<[u8; 32]>,
+  pub csrf_secret:      Arc<[u8; 32]>,
   /// Compiled email validation regex from `server.email_validation_regex`.
   /// `None` means only structural checks (non-empty, contains `@`).
-  pub email_regex:   Option<Arc<Regex>>,
+  pub email_regex:      Option<Arc<Regex>>,
   /// In-memory cache-serving counters, drained to `cache_traffic` every 60s
   /// by [`AppState::spawn_cache_traffic_flush`].
-  pub cache_traffic: CacheTrafficCounters,
+  pub cache_traffic:    CacheTrafficCounters,
+  /// Our binary-cache public key.
+  pub cache_public_key: Option<Arc<circus_binary_cache::PublicKey>>,
 }
 
 impl AppState {

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -47,6 +47,7 @@ fn build_app(pool: sqlx::PgPool) -> axum::Router {
     csrf_secret: std::sync::Arc::new([0u8; 32]),
     email_regex: None,
     cache_traffic: std::sync::Arc::new(dashmap::DashMap::new()),
+    cache_public_key: None,
   };
   circus_server::routes::router(state, &config)
 }
@@ -71,6 +72,7 @@ async fn test_router_no_duplicate_routes() {
     csrf_secret: std::sync::Arc::new([0u8; 32]),
     email_regex: None,
     cache_traffic: std::sync::Arc::new(dashmap::DashMap::new()),
+    cache_public_key: None,
   };
 
   let _app = circus_server::routes::router(state, &config);
@@ -93,6 +95,7 @@ fn build_app_with_config(
     csrf_secret: std::sync::Arc::new([0u8; 32]),
     email_regex: None,
     cache_traffic: std::sync::Arc::new(dashmap::DashMap::new()),
+    cache_public_key: None,
   };
   circus_server::routes::router(state, config)
 }
@@ -852,6 +855,144 @@ async fn test_project_cache_serves_only_owned_persisted_narinfo() {
 }
 
 #[tokio::test]
+async fn test_project_cache_keeps_shared_narinfo_for_each_owner() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project_a_name = format!("shared-a-{}", uuid::Uuid::new_v4().simple());
+  let project_a = circus_common::repo::projects::create(
+    &pool,
+    circus_common::CreateProject {
+      name:            project_a_name.clone(),
+      repository_url:  "https://github.com/test/shared-a".to_string(),
+      cache_enabled:   true,
+      cache_url:       None,
+      cache_upstreams: BinaryCacheUpstreams::default(),
+      description:     None,
+    },
+  )
+  .await
+  .unwrap();
+  let project_b_name = format!("shared-b-{}", uuid::Uuid::new_v4().simple());
+  let project_b = circus_common::repo::projects::create(
+    &pool,
+    circus_common::CreateProject {
+      name:            project_b_name.clone(),
+      repository_url:  "https://github.com/test/shared-b".to_string(),
+      cache_enabled:   true,
+      cache_url:       None,
+      cache_upstreams: BinaryCacheUpstreams::default(),
+      description:     None,
+    },
+  )
+  .await
+  .unwrap();
+
+  let hash = uuid::Uuid::new_v4().simple().to_string();
+  let store_path = format!("/nix/store/{hash}-shared-cache-test");
+  let references = Vec::new();
+  for project_id in [project_a.id, project_b.id] {
+    circus_common::repo::narinfo_cache::upsert(
+      &pool,
+      circus_common::repo::narinfo_cache::UpsertNarInfo {
+        store_path:  &store_path,
+        nar_hash:
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        nar_size:    1,
+        file_hash:   None,
+        file_size:   None,
+        compression: "none",
+        url:         &format!("nar/{hash}.nar"),
+        deriver:     None,
+        references:  &references,
+        sig:         Some("circus:test-signature"),
+        ca:          None,
+        build_id:    None,
+        project_id:  Some(project_id),
+      },
+    )
+    .await
+    .unwrap();
+  }
+
+  let config = circus_config::Config::default();
+  let app = build_app_with_config(pool, &config);
+
+  for project_name in [project_a_name, project_b_name] {
+    let response = app
+      .clone()
+      .oneshot(
+        Request::builder()
+          .uri(format!("/projects/{project_name}/nix-cache/{hash}.narinfo"))
+          .body(Body::empty())
+          .unwrap(),
+      )
+      .await
+      .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+  }
+}
+
+#[tokio::test]
+async fn test_cache_narinfo_local_url_requires_local_store_path() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let temp_root = std::env::temp_dir().join(format!(
+    "circus-cache-missing-store-{}",
+    uuid::Uuid::new_v4().simple()
+  ));
+  let store_dir = temp_root.join("store");
+  tokio::fs::create_dir_all(&store_dir).await.unwrap();
+
+  let store_hash = uuid::Uuid::new_v4().simple().to_string();
+  let nar_hash_bare = "0".repeat(52);
+  let nar_hash = format!("sha256:{nar_hash_bare}");
+  let store_path = store_dir.join(format!("{store_hash}-missing-cache-test"));
+  let store_path = store_path.to_string_lossy().to_string();
+
+  circus_common::repo::narinfo_cache::upsert(
+    &pool,
+    circus_common::repo::narinfo_cache::UpsertNarInfo {
+      store_path:  &store_path,
+      nar_hash:    &nar_hash,
+      nar_size:    10,
+      file_hash:   Some(&nar_hash),
+      file_size:   Some(10),
+      compression: "none",
+      url:         &format!("nar/{nar_hash_bare}.nar?hash={store_hash}"),
+      deriver:     None,
+      references:  &[],
+      sig:         Some("circus:test-signature"),
+      ca:          None,
+      build_id:    None,
+      project_id:  None,
+    },
+  )
+  .await
+  .unwrap();
+
+  let mut config = circus_config::Config::default();
+  config.cache.enabled = true;
+  config.nix.store_dir = store_dir;
+  let app = build_app_with_config(pool, &config);
+  let response = app
+    .oneshot(
+      Request::builder()
+        .uri(format!("/nix-cache/{store_hash}.narinfo"))
+        .body(Body::empty())
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), StatusCode::NOT_FOUND);
+  let _ = tokio::fs::remove_dir_all(&temp_root).await;
+}
+
+#[tokio::test]
 async fn test_cache_nar_invalid_hash_returns_404() {
   let Some(pool) = get_pool().await else {
     return;
@@ -886,6 +1027,103 @@ async fn test_cache_nar_invalid_hash_returns_404() {
     .await
     .unwrap();
   assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_cache_nar_route_accepts_signed_persisted_narinfo_provenance() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let temp_root = std::env::temp_dir().join(format!(
+    "circus-cache-store-{}",
+    uuid::Uuid::new_v4().simple()
+  ));
+  let store_dir = temp_root.join("store");
+  let db_dir = temp_root.join("var/nix/db");
+  tokio::fs::create_dir_all(&store_dir).await.unwrap();
+  tokio::fs::create_dir_all(&db_dir).await.unwrap();
+
+  let store_hash = "0123456789abcdfghijklmnpqrsvwxyz";
+  let nar_hash_bare = "0".repeat(52);
+  let nar_hash = format!("sha256:{nar_hash_bare}");
+  let store_path = store_dir.join(format!("{store_hash}-signed-cache-test"));
+  tokio::fs::write(&store_path, b"cache test").await.unwrap();
+  let store_path = store_path.to_string_lossy().to_string();
+
+  let sqlite = sqlx::SqlitePool::connect_with(
+    sqlx::sqlite::SqliteConnectOptions::new()
+      .filename(db_dir.join("db.sqlite"))
+      .create_if_missing(true),
+  )
+  .await
+  .unwrap();
+  sqlx::query(
+    "CREATE TABLE ValidPaths (id INTEGER PRIMARY KEY, path TEXT NOT NULL, \
+     hash TEXT NOT NULL, registrationTime INTEGER NOT NULL, deriver TEXT, \
+     narSize INTEGER, ultimate INTEGER, sigs TEXT, ca TEXT)",
+  )
+  .execute(&sqlite)
+  .await
+  .unwrap();
+  sqlx::query(
+    "CREATE TABLE Refs (referrer INTEGER NOT NULL, reference INTEGER NOT NULL)",
+  )
+  .execute(&sqlite)
+  .await
+  .unwrap();
+  sqlx::query(
+    "INSERT INTO ValidPaths (id, path, hash, registrationTime, deriver, \
+     narSize, ultimate, sigs, ca) VALUES (1, $1, $2, 1, NULL, 10, 0, NULL, \
+     NULL)",
+  )
+  .bind(&store_path)
+  .bind(&nar_hash)
+  .execute(&sqlite)
+  .await
+  .unwrap();
+  sqlite.close().await;
+
+  circus_common::repo::narinfo_cache::upsert(
+    &pool,
+    circus_common::repo::narinfo_cache::UpsertNarInfo {
+      store_path:  &store_path,
+      nar_hash:    &nar_hash,
+      nar_size:    10,
+      file_hash:   Some(&nar_hash),
+      file_size:   Some(10),
+      compression: "none",
+      url:         &format!("nar/{nar_hash_bare}.nar?hash={store_hash}"),
+      deriver:     None,
+      references:  &[],
+      sig:         Some("circus:test-signature"),
+      ca:          None,
+      build_id:    None,
+      project_id:  None,
+    },
+  )
+  .await
+  .unwrap();
+
+  let mut config = circus_config::Config::default();
+  config.cache.enabled = true;
+  config.nix.store_dir = store_dir;
+  let app = build_app_with_config(pool, &config);
+
+  let response = app
+    .oneshot(
+      Request::builder()
+        .uri(format!(
+          "/nix-cache/nar/{nar_hash_bare}.nar?hash={store_hash}"
+        ))
+        .body(Body::empty())
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), StatusCode::OK);
+  let _ = tokio::fs::remove_dir_all(&temp_root).await;
 }
 
 #[tokio::test]

--- a/crates/server/tests/e2e_test.rs
+++ b/crates/server/tests/e2e_test.rs
@@ -296,18 +296,19 @@ async fn test_e2e_project_eval_build_flow() {
   // 16. Test the HTTP API layer
   let config = circus_config::Config::default();
   let state = circus_server::state::AppState {
-    pool:          pool.clone(),
-    nix_store:     circus_server::state::NixStore::new(
+    pool:             pool.clone(),
+    nix_store:        circus_server::state::NixStore::new(
       config.nix.store_dir.clone(),
     )
     .unwrap(),
-    config:        config.clone(),
-    sessions:      std::sync::Arc::new(dashmap::DashMap::new()),
-    narinfo_cache: circus_server::state::AppState::new_narinfo_cache(),
-    http_client:   reqwest::Client::new(),
-    csrf_secret:   std::sync::Arc::new([0u8; 32]),
-    email_regex:   None,
-    cache_traffic: std::sync::Arc::new(dashmap::DashMap::new()),
+    config:           config.clone(),
+    sessions:         std::sync::Arc::new(dashmap::DashMap::new()),
+    narinfo_cache:    circus_server::state::AppState::new_narinfo_cache(),
+    http_client:      reqwest::Client::new(),
+    csrf_secret:      std::sync::Arc::new([0u8; 32]),
+    email_regex:      None,
+    cache_traffic:    std::sync::Arc::new(dashmap::DashMap::new()),
+    cache_public_key: None,
   };
   let app = circus_server::routes::router(state, &config);
 


### PR DESCRIPTION
Cached builds that reused an existing output only published narinfos for the primary output, so clients could miss dependencies from the project cache.

Publish signed narinfos for the whole closure, keep project ownership separate for shared store paths, and move recursive lookup and signing out of the scheduler loop.