### PR TITLE
various: skip dependency builds in commit statuses

### DIFF
--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -201,6 +201,12 @@ impl JobsetTriggerMode {
   }
 }
 
+/// Job-name prefix marking an intermediate dependency build synthesized by the
+/// evaluator from the derivation graph, as opposed to a top-level jobset job.
+/// These builds are internal scheduling artifacts and are excluded from
+/// user-facing notifications (commit statuses, webhooks, ...).
+pub const DEPENDENCY_JOB_PREFIX: &str = "drv:";
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 #[expect(
   clippy::struct_excessive_bools,
@@ -257,6 +263,14 @@ impl Build {
       .effective_features
       .as_deref()
       .unwrap_or(&self.required_features)
+  }
+
+  /// Whether this is an intermediate dependency build synthesized from the
+  /// derivation graph rather than a top-level jobset job. See
+  /// [`DEPENDENCY_JOB_PREFIX`].
+  #[must_use]
+  pub fn is_dependency(&self) -> bool {
+    self.job_name.starts_with(DEPENDENCY_JOB_PREFIX)
   }
 }
 

--- a/crates/evaluator/src/builds.rs
+++ b/crates/evaluator/src/builds.rs
@@ -143,7 +143,7 @@ fn dependency_job_name(drv_path: &str) -> String {
     .and_then(|name| name.to_str())
     .unwrap_or(drv_path)
     .trim_end_matches(".drv");
-  format!("drv:{basename}")
+  format!("{}{basename}", circus_common::models::DEPENDENCY_JOB_PREFIX)
 }
 
 async fn expand_derivation_graph(

--- a/crates/notification/src/event.rs
+++ b/crates/notification/src/event.rs
@@ -50,6 +50,16 @@ impl BuildEvent {
     !self.status.is_success()
   }
 
+  /// Whether this event is an intermediate dependency build synthesized from
+  /// the derivation graph rather than a top-level jobset job. Such builds are
+  /// excluded from notification dispatch to avoid polluting commit statuses.
+  #[must_use]
+  pub fn is_dependency(&self) -> bool {
+    self
+      .job_name
+      .starts_with(circus_common::models::DEPENDENCY_JOB_PREFIX)
+  }
+
   /// Coarse status string for generic webhook payloads.
   #[must_use]
   pub const fn generic_status(&self) -> &'static str {
@@ -137,5 +147,33 @@ impl BuildEvent {
       BuildStatus::UnsupportedSystem => "UNSUPPORTED",
       BuildStatus::Pending | BuildStatus::Running => "PENDING",
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn event_with_job(job_name: &str) -> BuildEvent {
+    BuildEvent {
+      build_id:     Uuid::nil(),
+      status:       BuildStatus::Succeeded,
+      job_name:     job_name.to_string(),
+      drv_path:     "/nix/store/x.drv".to_string(),
+      build_output: None,
+      project_name: "proj".to_string(),
+      project_url:  "https://github.com/owner/repo".to_string(),
+      commit_hash:  "abc".to_string(),
+    }
+  }
+
+  #[test]
+  fn top_level_job_is_not_a_dependency() {
+    assert!(!event_with_job("hello").is_dependency());
+  }
+
+  #[test]
+  fn drv_prefixed_job_is_a_dependency() {
+    assert!(event_with_job("drv:abc-foo-1.0").is_dependency());
   }
 }

--- a/crates/notification/src/lib.rs
+++ b/crates/notification/src/lib.rs
@@ -434,6 +434,9 @@ pub async fn process_notification_task(
     .map_err(|e| format!("Invalid stored notification channel: {e}"))?;
     let event: BuildEvent = serde_json::from_value(event.clone())
       .map_err(|e| format!("Invalid stored build event: {e}"))?;
+    if event.is_dependency() {
+      return Ok(());
+    }
     if channel.is_commit_status()
       && stale_commit_status_event(pool, &event).await?
     {

--- a/crates/notification/src/lib.rs
+++ b/crates/notification/src/lib.rs
@@ -244,6 +244,14 @@ async fn dispatch(
   commit_status_only: bool,
 ) {
   let event = BuildEvent::from_build(build, project, commit_hash);
+
+  // Intermediate dependency builds are internal scheduling artifacts; their
+  // status is rolled up into the top-level job. Forwarding them would pollute
+  // commit statuses (and every other channel) with one entry per dependency.
+  if event.is_dependency() {
+    return;
+  }
+
   let channels =
     resolve_channels(pool, build, project, commit_hash, config, encryption_key)
       .await;


### PR DESCRIPTION
Introduces a tiny lil' mechanism to distinguish and filter out intermediate dependency builds—those synthesized by the evaluator from the derivation graph—from user-facing notifications (e.g., commit statuses and webhooks). These builds are now identified by a special job-name prefix and are excluded from notification dispatch to avoid polluting user-visible channels with internal scheduling artifacts.

Change-Id: If7b61a8e555261e179341a7c208dc0296a6a6964