### PR TITLE
circus-evaluator: migrate evix 0.3.3 -> 2.0.1; eval fixes

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -28,6 +28,9 @@ exceptions = [
   ], crate = "evix" },
   { allow = [
     "EUPL-1.2",
+  ], crate = "evix-protocol" },
+  { allow = [
+    "EUPL-1.2",
   ], crate = "cognos" },
   { allow = [
     "EUPL-1.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1729,14 +1729,15 @@ dependencies = [
 
 [[package]]
 name = "evix"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4030df65e962fe275aab24379b46f8a4b097aacfe8e641bfdcd93c1ce99951"
+checksum = "b14b02c0f041de4779200d3a51007ae0c64c84b114eee5754e8d1f7e72580b3a"
 dependencies = [
  "anyhow",
  "capnp",
  "capnp-futures",
  "capnpc",
+ "evix-protocol",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1748,6 +1749,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "evix-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40af0e69ca801a5d0d9352e2626e43c1ce994f9b001aef5febc5de795603bce6"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2896,18 +2907,18 @@ dependencies = [
 
 [[package]]
 name = "nix-bindings"
-version = "0.2347.5"
+version = "0.2347.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d826e02d271ca63883bee7e842423beb54a4f65c768f0a657bb1cb6ee3a3ba"
+checksum = "31c8f8f43b9ef4af066624a4e88c757c8a424ec8bea8f98e1ae759e944be4c40"
 dependencies = [
  "nix-bindings-sys",
 ]
 
 [[package]]
 name = "nix-bindings-sys"
-version = "0.2347.5"
+version = "0.2347.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e282076948fe9ad31c76acd5ee320b66500666bba8b2c09cdadf5b1cd4f5a057"
+checksum = "6364bad7b8e6de37db8a382e2225e7719302b5b1f8638160e09ddb7e6e79e929"
 dependencies = [
  "bindgen",
  "cc",
@@ -3438,7 +3449,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3812,7 +3823,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3870,7 +3881,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4510,7 +4521,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5290,7 +5301,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,18 +1729,25 @@ dependencies = [
 
 [[package]]
 name = "evix"
-version = "0.3.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f684521a2733493f3dd4370a81f132af8d9fa4f93db6e6c69e04568e72aa9e"
+checksum = "8b4030df65e962fe275aab24379b46f8a4b097aacfe8e641bfdcd93c1ce99951"
 dependencies = [
  "anyhow",
+ "capnp",
+ "capnp-futures",
+ "capnpc",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "libc",
  "nix-bindings",
- "pound",
+ "notify",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-util",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1832,6 +1839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2418,6 +2434,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2574,26 @@ dependencies = [
  "serde_json",
  "signature",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -2804,6 +2860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2839,18 +2896,18 @@ dependencies = [
 
 [[package]]
 name = "nix-bindings"
-version = "0.2347.4"
+version = "0.2347.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d95cd74fb0801ccf0457c3d6512abfa09abbc0889df43454c178cae744dd5ac"
+checksum = "48d826e02d271ca63883bee7e842423beb54a4f65c768f0a657bb1cb6ee3a3ba"
 dependencies = [
  "nix-bindings-sys",
 ]
 
 [[package]]
 name = "nix-bindings-sys"
-version = "0.2347.4"
+version = "0.2347.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ce1e5f49bf0a18225345f434c619e3b3a3b17e094b3e5b13dba5e5ae598a6"
+checksum = "e282076948fe9ad31c76acd5ee320b66500666bba8b2c09cdadf5b1cd4f5a057"
 dependencies = [
  "bindgen",
  "cc",
@@ -2875,6 +2932,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3207,26 +3291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "pound"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29188deca8885da40aaafd27d756c5d94420fb8ba8a569663c7a87fef6d28ad"
-dependencies = [
- "pound-derive",
-]
-
-[[package]]
-name = "pound-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215966bbf23c9af48d9014a71bc426ecf9be95ffb04b5f1ae3e64f8d8a2a920c"
-dependencies = [
- "proc-macro2",
- "quote",
- "venial",
 ]
 
 [[package]]
@@ -5008,16 +5072,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "venial"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a42528baceab6c7784446df2a10f4185078c39bf73dc614f154353f1a6b1229"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "evix"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b02c0f041de4779200d3a51007ae0c64c84b114eee5754e8d1f7e72580b3a"
+checksum = "2a93f2e9bf3ed581c8a179f32b81b973391800565ff29c2ff7fda746204dcdeb"
 dependencies = [
  "anyhow",
  "capnp",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "evix-protocol"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40af0e69ca801a5d0d9352e2626e43c1ce994f9b001aef5febc5de795603bce6"
+checksum = "842c32b892c4a3a06f3f716ab519c1808d783c295e7b4760e63610f64f0d75d8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2908,18 +2908,18 @@ dependencies = [
 
 [[package]]
 name = "nix-bindings"
-version = "0.2347.7"
+version = "0.2347.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c8f8f43b9ef4af066624a4e88c757c8a424ec8bea8f98e1ae759e944be4c40"
+checksum = "b94a1f3782853a75651147aa9c8778a567d61489db5e4cbc1eb69d59a6caeef8"
 dependencies = [
  "nix-bindings-sys",
 ]
 
 [[package]]
 name = "nix-bindings-sys"
-version = "0.2347.7"
+version = "0.2347.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6364bad7b8e6de37db8a382e2225e7719302b5b1f8638160e09ddb7e6e79e929"
+checksum = "91fc9f8ca434646c9dd69a54145d3805c6690479bf17f848da33ade89073b168"
 dependencies = [
  "bindgen",
  "cc",
@@ -3450,7 +3450,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3824,7 +3824,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3882,7 +3882,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4522,7 +4522,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5302,7 +5302,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ jsonwebtoken = { version = "10.4.0", default-features = false }
 
 # In-house crates and Nix utilities
 cognos = "1.0.0"
-evix   = { version = "0.3.3", features = [ "flake" ] }
+evix   = { version = "1.0.2", features = [ "flake" ] }
 
 # Workspace Clippy lints. All workspace crates must inherit them in individual
 # manifests for subcrates. The below list is a rather pedantic list of lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ jsonwebtoken = { version = "10.4.0", default-features = false }
 
 # In-house crates and Nix utilities
 cognos = "1.0.0"
-evix   = { version = "2.0.0", features = [ "flake" ] }
+evix   = { version = "2.0.1", features = [ "flake" ] }
 
 # Workspace Clippy lints. All workspace crates must inherit them in individual
 # manifests for subcrates. The below list is a rather pedantic list of lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ jsonwebtoken = { version = "10.4.0", default-features = false }
 
 # In-house crates and Nix utilities
 cognos = "1.0.0"
-evix   = { version = "1.0.2", features = [ "flake" ] }
+evix   = { version = "2.0.0", features = [ "flake" ] }
 
 # Workspace Clippy lints. All workspace crates must inherit them in individual
 # manifests for subcrates. The below list is a rather pedantic list of lints

--- a/circus.example.toml
+++ b/circus.example.toml
@@ -38,10 +38,11 @@ enabled        = true
 # text   = "#0f172a"
 
 [evaluator]
-allow_ifd            = false
-auto_allowed_uris    = true
-git_timeout          = 600
-nix_timeout          = 1800
+allow_ifd         = false
+auto_allowed_uris = true
+git_timeout       = 600
+nix_timeout       = 1800
+# max_eval_time      = 3600
 poll_interval        = 60
 require_locked_flake = false
 restrict_eval        = true

--- a/crates/circus/build.rs
+++ b/crates/circus/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+  // Keep the vendored git2 copy from interposing nix-bindings' libgit2.so.
+  if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+    println!("cargo:rustc-link-arg-bins=-Wl,--exclude-libs,ALL");
+  }
+}

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -74,6 +74,8 @@ pub enum EvaluationStatus {
   Running,
   Completed,
   Failed,
+  Cancelled,
+  TimedOut,
 }
 
 impl EvaluationStatus {
@@ -82,6 +84,8 @@ impl EvaluationStatus {
     match self {
       Self::Completed => ("Completed", "completed"),
       Self::Failed => ("Failed", "failed"),
+      Self::Cancelled => ("Cancelled", "cancelled"),
+      Self::TimedOut => ("Timed out", "timed-out"),
       Self::Running => ("Running", "running"),
       Self::Pending => ("Pending", "pending"),
     }

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -67,8 +67,8 @@ pub struct Evaluation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
-#[serde(rename_all = "lowercase")]
-#[sqlx(type_name = "text", rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
 pub enum EvaluationStatus {
   Pending,
   Running,
@@ -513,7 +513,7 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for BuildStatus {
 
 #[cfg(test)]
 mod build_status_tests {
-  use super::BuildStatus;
+  use super::{BuildStatus, EvaluationStatus};
 
   #[test]
   fn build_status_i32_round_trips() {
@@ -543,6 +543,15 @@ mod build_status_tests {
   fn build_status_from_i32_preserves_unknown_fallback() {
     assert_eq!(BuildStatus::from_i32(-1), None);
     assert_eq!(BuildStatus::from_i32(15), None);
+  }
+
+  #[test]
+  fn timed_out_status_uses_database_spelling() {
+    assert_eq!(
+      serde_json::to_string(&EvaluationStatus::TimedOut)
+        .expect("EvaluationStatus serializes"),
+      "\"timed_out\""
+    );
   }
 }
 

--- a/crates/common/src/repo/build_dependencies.rs
+++ b/crates/common/src/repo/build_dependencies.rs
@@ -1,4 +1,4 @@
-use sqlx::PgPool;
+use sqlx::{Executor, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::{
@@ -17,13 +17,37 @@ pub async fn create(
   build_id: Uuid,
   dependency_build_id: Uuid,
 ) -> Result<BuildDependency> {
+  create_with(pool, build_id, dependency_build_id).await
+}
+
+/// Create a build dependency relationship within an existing transaction.
+///
+/// # Errors
+///
+/// Returns an error if database insert fails or dependency already exists.
+pub async fn create_in_transaction(
+  tx: &mut Transaction<'_, Postgres>,
+  build_id: Uuid,
+  dependency_build_id: Uuid,
+) -> Result<BuildDependency> {
+  create_with(&mut **tx, build_id, dependency_build_id).await
+}
+
+async fn create_with<'e, E>(
+  executor: E,
+  build_id: Uuid,
+  dependency_build_id: Uuid,
+) -> Result<BuildDependency>
+where
+  E: Executor<'e, Database = Postgres>,
+{
   sqlx::query_as::<_, BuildDependency>(
     "INSERT INTO build_dependencies (build_id, dependency_build_id) VALUES \
      ($1, $2) RETURNING *",
   )
   .bind(build_id)
   .bind(dependency_build_id)
-  .fetch_one(pool)
+  .fetch_one(executor)
   .await
   .on_unique_violation(|| {
     format!(

--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use sqlx::PgPool;
+use sqlx::{Executor, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::{
@@ -14,6 +14,25 @@ use crate::{
 ///
 /// Returns error if database insert fails or job already exists.
 pub async fn create(pool: &PgPool, input: CreateBuild) -> Result<Build> {
+  create_with(pool, input).await
+}
+
+/// Create a new build record within an existing transaction.
+///
+/// # Errors
+///
+/// Returns an error if database insert fails or job already exists.
+pub async fn create_in_transaction(
+  tx: &mut Transaction<'_, Postgres>,
+  input: CreateBuild,
+) -> Result<Build> {
+  create_with(&mut **tx, input).await
+}
+
+async fn create_with<'e, E>(executor: E, input: CreateBuild) -> Result<Build>
+where
+  E: Executor<'e, Database = Postgres>,
+{
   let is_aggregate = input.is_aggregate.unwrap_or(false);
   let is_fod = input.is_fod.unwrap_or(false);
   sqlx::query_as::<_, Build>(
@@ -37,7 +56,7 @@ pub async fn create(pool: &PgPool, input: CreateBuild) -> Result<Build> {
   .bind(&input.meta_homepage)
   .bind(&input.meta_maintainers)
   .bind(&input.required_features)
-  .fetch_one(pool)
+  .fetch_one(executor)
   .await
   .on_unique_violation(|| {
     format!(

--- a/crates/common/src/repo/evaluations.rs
+++ b/crates/common/src/repo/evaluations.rs
@@ -366,7 +366,8 @@ pub async fn cancel(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
 }
 
 /// Requeue a cancelled, failed, or timed-out evaluation after discarding its
-/// stale builds. One-shot jobsets are re-enabled for the new attempt.
+/// stale builds. A disabled jobset rejects the restart; a retained one-shot
+/// jobset is re-enabled for its new attempt.
 ///
 /// # Errors
 ///
@@ -374,9 +375,11 @@ pub async fn cancel(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
 pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
   let mut tx = pool.begin().await?;
   let evaluation = sqlx::query_as::<_, Evaluation>(
-    "UPDATE evaluations SET status = 'pending', evaluation_time = NOW(), \
-     error_message = NULL, inputs_hash = NULL WHERE id = $1 AND status IN \
-     ('cancelled', 'failed', 'timed_out') RETURNING *",
+    "UPDATE evaluations e SET status = 'pending', evaluation_time = NOW(), \
+     error_message = NULL, inputs_hash = NULL FROM jobsets j WHERE e.id = $1 \
+     AND e.jobset_id = j.id AND e.status IN ('cancelled', 'failed', \
+     'timed_out') AND (j.state = 'one_shot' OR (j.enabled AND j.state IN \
+     ('enabled', 'one_at_a_time'))) RETURNING e.*",
   )
   .bind(id)
   .fetch_optional(&mut *tx)

--- a/crates/common/src/repo/evaluations.rs
+++ b/crates/common/src/repo/evaluations.rs
@@ -1,4 +1,4 @@
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::{
@@ -365,7 +365,8 @@ pub async fn cancel(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
   )
 }
 
-/// Requeue a cancelled or failed evaluation after discarding its stale builds.
+/// Requeue a cancelled, failed, or timed-out evaluation after discarding its
+/// stale builds. One-shot jobsets are re-enabled for the new attempt.
 ///
 /// # Errors
 ///
@@ -373,9 +374,9 @@ pub async fn cancel(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
 pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
   let mut tx = pool.begin().await?;
   let evaluation = sqlx::query_as::<_, Evaluation>(
-    "UPDATE evaluations SET status = 'pending', error_message = NULL, \
-     inputs_hash = NULL WHERE id = $1 AND status IN ('cancelled', 'failed') \
-     RETURNING *",
+    "UPDATE evaluations SET status = 'pending', evaluation_time = NOW(), \
+     error_message = NULL, inputs_hash = NULL WHERE id = $1 AND status IN \
+     ('cancelled', 'failed', 'timed_out') RETURNING *",
   )
   .bind(id)
   .fetch_optional(&mut *tx)
@@ -386,9 +387,62 @@ pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
       .bind(id)
       .execute(&mut *tx)
       .await?;
+    sqlx::query(
+      "UPDATE jobsets SET enabled = true WHERE id = (SELECT jobset_id FROM \
+       evaluations WHERE id = $1) AND state = 'one_shot'",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
   }
   tx.commit().await?;
   Ok(evaluation)
+}
+
+/// Lock a running evaluation before atomically persisting its result.
+///
+/// # Errors
+///
+/// Returns an error if the database query fails.
+pub async fn lock_running(
+  tx: &mut Transaction<'_, Postgres>,
+  id: Uuid,
+) -> Result<bool> {
+  Ok(
+    sqlx::query_scalar::<_, Uuid>(
+      "SELECT id FROM evaluations WHERE id = $1 AND status = 'running' FOR \
+       UPDATE",
+    )
+    .bind(id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .is_some(),
+  )
+}
+
+/// Finish a locked running evaluation within its result transaction.
+///
+/// # Errors
+///
+/// Returns an error if the database query fails.
+pub async fn finish_running_in_transaction(
+  tx: &mut Transaction<'_, Postgres>,
+  id: Uuid,
+  status: EvaluationStatus,
+  error_message: Option<&str>,
+) -> Result<bool> {
+  Ok(
+    sqlx::query_scalar::<_, Uuid>(
+      "UPDATE evaluations SET status = $1, error_message = $2 WHERE id = $3 \
+       AND status = 'running' RETURNING id",
+    )
+    .bind(status)
+    .bind(error_message)
+    .bind(id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .is_some(),
+  )
 }
 
 /// Return whether an evaluator should cancel its currently-running work.

--- a/crates/common/src/repo/evaluations.rs
+++ b/crates/common/src/repo/evaluations.rs
@@ -324,6 +324,88 @@ pub async fn update_status(
   .ok_or_else(|| CiError::NotFound(format!("Evaluation {id} not found")))
 }
 
+/// Finish an evaluation only while this evaluator still owns its running state.
+///
+/// # Errors
+///
+/// Returns an error if the database query fails.
+pub async fn finish_running(
+  pool: &PgPool,
+  id: Uuid,
+  status: EvaluationStatus,
+  error_message: Option<&str>,
+) -> Result<Option<Evaluation>> {
+  Ok(
+    sqlx::query_as::<_, Evaluation>(
+      "UPDATE evaluations SET status = $1, error_message = $2 WHERE id = $3 \
+       AND status = 'running' RETURNING *",
+    )
+    .bind(status)
+    .bind(error_message)
+    .bind(id)
+    .fetch_optional(pool)
+    .await?,
+  )
+}
+
+/// Cancel an evaluation that has not reached a terminal state.
+///
+/// # Errors
+///
+/// Returns an error if the database query fails.
+pub async fn cancel(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
+  Ok(
+    sqlx::query_as::<_, Evaluation>(
+      "UPDATE evaluations SET status = 'cancelled', error_message = NULL \
+       WHERE id = $1 AND status IN ('pending', 'running') RETURNING *",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?,
+  )
+}
+
+/// Requeue a cancelled or failed evaluation after discarding its stale builds.
+///
+/// # Errors
+///
+/// Returns an error if the database transaction fails.
+pub async fn restart(pool: &PgPool, id: Uuid) -> Result<Option<Evaluation>> {
+  let mut tx = pool.begin().await?;
+  let evaluation = sqlx::query_as::<_, Evaluation>(
+    "UPDATE evaluations SET status = 'pending', error_message = NULL, \
+     inputs_hash = NULL WHERE id = $1 AND status IN ('cancelled', 'failed') \
+     RETURNING *",
+  )
+  .bind(id)
+  .fetch_optional(&mut *tx)
+  .await?;
+
+  if evaluation.is_some() {
+    sqlx::query("DELETE FROM builds WHERE evaluation_id = $1")
+      .bind(id)
+      .execute(&mut *tx)
+      .await?;
+  }
+  tx.commit().await?;
+  Ok(evaluation)
+}
+
+/// Return whether an evaluator should cancel its currently-running work.
+///
+/// # Errors
+///
+/// Returns an error if the database query fails.
+pub async fn is_cancelled(pool: &PgPool, id: Uuid) -> Result<bool> {
+  let status = sqlx::query_scalar::<_, EvaluationStatus>(
+    "SELECT status FROM evaluations WHERE id = $1",
+  )
+  .bind(id)
+  .fetch_optional(pool)
+  .await?;
+  Ok(status.is_some_and(|status| status == EvaluationStatus::Cancelled))
+}
+
 /// Get the latest completed evaluation for a jobset.
 ///
 /// Only completed evaluations are returned. Failed or running evaluations are

--- a/crates/common/src/repo/jobsets.rs
+++ b/crates/common/src/repo/jobsets.rs
@@ -269,15 +269,14 @@ pub async fn list_active(pool: &PgPool) -> Result<Vec<ActiveJobset>> {
   )
 }
 
-/// Mark a one-shot jobset as complete (set state to disabled).
+/// Mark a one-shot jobset as complete without losing its one-shot state.
 ///
 /// # Errors
 ///
 /// Returns error if database update fails.
 pub async fn mark_one_shot_complete(pool: &PgPool, id: Uuid) -> Result<()> {
   sqlx::query(
-    "UPDATE jobsets SET state = 'disabled', enabled = false WHERE id = $1 AND \
-     state = 'one_shot'",
+    "UPDATE jobsets SET enabled = false WHERE id = $1 AND state = 'one_shot'",
   )
   .bind(id)
   .execute(pool)

--- a/crates/common/tests/repo_tests.rs
+++ b/crates/common/tests/repo_tests.rs
@@ -594,6 +594,44 @@ async fn test_restarting_one_shot_evaluation_resets_its_attempt() {
 }
 
 #[tokio::test]
+async fn test_restart_rejects_a_manually_disabled_jobset() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "restart-disabled").await;
+  let jobset = create_test_jobset(&pool, project.id).await;
+  let eval = create_test_eval(&pool, jobset.id).await;
+  repo::evaluations::update_status(
+    &pool,
+    eval.id,
+    EvaluationStatus::Failed,
+    Some("failed"),
+  )
+  .await
+  .expect("fail evaluation");
+  sqlx::query("UPDATE jobsets SET enabled = false WHERE id = $1")
+    .bind(jobset.id)
+    .execute(&pool)
+    .await
+    .expect("disable jobset");
+
+  assert!(
+    repo::evaluations::restart(&pool, eval.id)
+      .await
+      .expect("attempt restart")
+      .is_none()
+  );
+  assert_eq!(
+    repo::evaluations::get(&pool, eval.id)
+      .await
+      .expect("get failed evaluation")
+      .status,
+    EvaluationStatus::Failed
+  );
+}
+
+#[tokio::test]
 async fn test_cancellation_cannot_interleave_build_persistence() {
   let Some(pool) = get_pool().await else {
     return;

--- a/crates/common/tests/repo_tests.rs
+++ b/crates/common/tests/repo_tests.rs
@@ -535,6 +535,170 @@ async fn test_evaluation_and_build_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_restarting_one_shot_evaluation_resets_its_attempt() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "restart-one-shot").await;
+  let jobset = repo::jobsets::create(&pool, CreateJobset {
+    project_id:        project.id,
+    name:              format!("one-shot-{}", uuid::Uuid::new_v4()),
+    nix_expression:    "packages".to_string(),
+    enabled:           Some(true),
+    flake_mode:        None,
+    check_interval:    None,
+    trigger_mode:      None,
+    branch:            None,
+    branch_pattern:    None,
+    tag_pattern:       None,
+    scheduling_shares: None,
+    state:             Some(JobsetState::OneShot),
+    keep_nr:           None,
+  })
+  .await
+  .expect("create one-shot jobset");
+  let eval = create_test_eval(&pool, jobset.id).await;
+  repo::evaluations::update_status(
+    &pool,
+    eval.id,
+    EvaluationStatus::Failed,
+    Some("failed"),
+  )
+  .await
+  .expect("fail evaluation");
+  sqlx::query(
+    "UPDATE evaluations SET evaluation_time = NOW() - INTERVAL '1 hour' WHERE \
+     id = $1",
+  )
+  .bind(eval.id)
+  .execute(&pool)
+  .await
+  .expect("backdate evaluation");
+  repo::jobsets::mark_one_shot_complete(&pool, jobset.id)
+    .await
+    .expect("complete one-shot");
+
+  let restarted = repo::evaluations::restart(&pool, eval.id)
+    .await
+    .expect("restart evaluation")
+    .expect("failed evaluation can restart");
+  let restarted_jobset = repo::jobsets::get(&pool, jobset.id)
+    .await
+    .expect("get restarted jobset");
+
+  assert_eq!(restarted.status, EvaluationStatus::Pending);
+  assert!(restarted.evaluation_time > eval.evaluation_time);
+  assert!(restarted_jobset.enabled);
+  assert_eq!(restarted_jobset.state, JobsetState::OneShot);
+}
+
+#[tokio::test]
+async fn test_cancellation_cannot_interleave_build_persistence() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "cancel-persistence").await;
+  let jobset = create_test_jobset(&pool, project.id).await;
+  let eval = create_test_eval(&pool, jobset.id).await;
+  repo::evaluations::update_status(
+    &pool,
+    eval.id,
+    EvaluationStatus::Running,
+    None,
+  )
+  .await
+  .expect("start evaluation");
+
+  let mut tx = pool.begin().await.expect("begin result transaction");
+  assert!(
+    repo::evaluations::lock_running(&mut tx, eval.id)
+      .await
+      .expect("lock evaluation")
+  );
+  let cancel_pool = pool.clone();
+  let mut cancel = tokio::spawn(async move {
+    repo::evaluations::cancel(&cancel_pool, eval.id).await
+  });
+  assert!(
+    tokio::time::timeout(std::time::Duration::from_millis(25), &mut cancel)
+      .await
+      .is_err(),
+    "cancellation must wait for the result transaction"
+  );
+  repo::builds::create_in_transaction(&mut tx, CreateBuild {
+    evaluation_id: eval.id,
+    job_name: "build".to_string(),
+    drv_path: format!("/nix/store/{}.drv", uuid::Uuid::new_v4()),
+    ..Default::default()
+  })
+  .await
+  .expect("persist build");
+  assert!(
+    repo::evaluations::finish_running_in_transaction(
+      &mut tx,
+      eval.id,
+      EvaluationStatus::Completed,
+      None,
+    )
+    .await
+    .expect("finish evaluation")
+  );
+  tx.commit().await.expect("commit result transaction");
+
+  assert!(
+    cancel
+      .await
+      .expect("join cancellation")
+      .expect("cancel evaluation")
+      .is_none()
+  );
+  assert_eq!(
+    repo::builds::count_filtered(&pool, Some(eval.id), None, None, None)
+      .await
+      .expect("count persisted builds"),
+    1
+  );
+  assert_eq!(
+    repo::evaluations::get(&pool, eval.id)
+      .await
+      .expect("get completed evaluation")
+      .status,
+    EvaluationStatus::Completed
+  );
+
+  let cancelled = create_test_eval(&pool, jobset.id).await;
+  repo::evaluations::update_status(
+    &pool,
+    cancelled.id,
+    EvaluationStatus::Running,
+    None,
+  )
+  .await
+  .expect("start cancelled evaluation");
+  assert!(
+    repo::evaluations::cancel(&pool, cancelled.id)
+      .await
+      .expect("cancel before persistence")
+      .is_some()
+  );
+  let mut cancelled_tx =
+    pool.begin().await.expect("begin cancelled transaction");
+  assert!(
+    !repo::evaluations::lock_running(&mut cancelled_tx, cancelled.id)
+      .await
+      .expect("check cancelled evaluation")
+  );
+  assert_eq!(
+    repo::builds::count_filtered(&pool, Some(cancelled.id), None, None, None)
+      .await
+      .expect("count cancelled builds"),
+    0
+  );
+}
+
+#[tokio::test]
 async fn test_start_blocks_duplicate_running_drv_path() {
   let Some(pool) = get_pool().await else {
     return;

--- a/crates/config/src/structs.rs
+++ b/crates/config/src/structs.rs
@@ -250,6 +250,11 @@ pub struct EvaluatorConfig {
   /// Whether to abort on the first evaluation cycle error instead of logging
   /// and retrying.
   pub strict_errors: bool,
+
+  /// Number of evix worker subprocesses spawned per evaluation. Each worker
+  /// initializes a full Nix evaluator, so higher counts increase parallelism
+  /// at the cost of memory. Reduce this on memory-constrained hosts.
+  pub eval_workers: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -795,6 +800,7 @@ impl Default for EvaluatorConfig {
       auto_allowed_uris:    true,
       require_locked_flake: false,
       strict_errors:        false,
+      eval_workers:         4,
     }
   }
 }

--- a/crates/config/src/structs.rs
+++ b/crates/config/src/structs.rs
@@ -233,6 +233,8 @@ pub struct EvaluatorConfig {
   pub poll_interval:        u64,
   pub git_timeout:          u64,
   pub nix_timeout:          u64,
+  /// Optional wall-clock limit for an entire evaluation. `None` disables it.
+  pub max_eval_time:        Option<u64>,
   pub max_concurrent_evals: usize,
   pub work_dir:             PathBuf,
   pub restrict_eval:        bool,
@@ -792,6 +794,7 @@ impl Default for EvaluatorConfig {
       poll_interval:        60,
       git_timeout:          600,
       nix_timeout:          1800,
+      max_eval_time:        None,
       max_concurrent_evals: 4,
       work_dir:             PathBuf::from("/tmp/circus-evaluator"),
       restrict_eval:        true,

--- a/crates/evaluator/Cargo.toml
+++ b/crates/evaluator/Cargo.toml
@@ -21,6 +21,7 @@ sha2.workspace               = true
 sqlx.workspace               = true
 thiserror.workspace          = true
 tokio.workspace              = true
+tokio-util.workspace         = true
 toml.workspace               = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true

--- a/crates/evaluator/Cargo.toml
+++ b/crates/evaluator/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util.workspace         = true
 toml.workspace               = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true
+url.workspace                = true
 uuid.workspace               = true
 
 # Our crates

--- a/crates/evaluator/build.rs
+++ b/crates/evaluator/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+  // Keep the vendored git2 copy from interposing nix-bindings' libgit2.so.
+  if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+    println!("cargo:rustc-link-arg-bins=-Wl,--exclude-libs,ALL");
+  }
+}

--- a/crates/evaluator/src/builds.rs
+++ b/crates/evaluator/src/builds.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use circus_common::{
-  models::{CreateBuild, JobsetInput},
+  models::{CreateBuild, EvaluationStatus, JobsetInput},
   repo,
 };
 use sqlx::PgPool;
@@ -226,15 +226,16 @@ fn detect_fod(drv_path: &str) -> (bool, Option<String>) {
   }
 }
 
-/// Create build records from evaluation results, resolving dependencies.
+/// Create build records and finish the evaluation while it is still running.
 pub(crate) async fn create_builds_from_eval(
   pool: &PgPool,
   eval_id: Uuid,
   eval_result: &crate::nix::EvalResult,
-) -> color_eyre::Result<()> {
+) -> color_eyre::Result<bool> {
   let mut drv_to_build: HashMap<String, Uuid> = HashMap::new();
   let mut name_to_build: HashMap<String, Uuid> = HashMap::new();
   let jobs = expand_derivation_graph(&eval_result.jobs).await;
+  let mut builds = Vec::with_capacity(jobs.len());
 
   for job in &jobs {
     let outputs_json = job
@@ -249,7 +250,7 @@ pub(crate) async fn create_builds_from_eval(
 
     let (is_fod, fod_hash) = detect_fod(&job.drv_path);
     let required_features = read_required_features(&job.drv_path).await;
-    let build = repo::builds::create(pool, CreateBuild {
+    builds.push(CreateBuild {
       evaluation_id: eval_id,
       job_name: job.name.clone(),
       drv_path: job.drv_path.clone(),
@@ -264,11 +265,23 @@ pub(crate) async fn create_builds_from_eval(
       meta_homepage: job.meta.homepage.clone(),
       meta_maintainers: job.meta.maintainers.clone(),
       required_features,
-    })
-    .await?;
+    });
+  }
 
-    drv_to_build.insert(job.drv_path.clone(), build.id);
-    name_to_build.insert(job.name.clone(), build.id);
+  let mut tx = pool.begin().await?;
+  if !repo::evaluations::lock_running(&mut tx, eval_id).await? {
+    return Ok(false);
+  }
+
+  for build in builds {
+    let drv_path = build.drv_path.clone();
+    let job_name = build.job_name.clone();
+    let id = repo::builds::create_in_transaction(&mut tx, build)
+      .await?
+      .id;
+
+    drv_to_build.insert(drv_path, id);
+    name_to_build.insert(job_name, id);
   }
 
   // Resolve dependencies
@@ -283,10 +296,13 @@ pub(crate) async fn create_builds_from_eval(
       for dep_drv in input_drvs.keys() {
         if let Some(&dep_build_id) = drv_to_build.get(dep_drv)
           && dep_build_id != build_id
-          && let Err(e) =
-            repo::build_dependencies::create(pool, build_id, dep_build_id).await
         {
-          tracing::warn!(build_id = %build_id, dep = %dep_build_id, "Failed to create build dependency: {e}");
+          repo::build_dependencies::create_in_transaction(
+            &mut tx,
+            build_id,
+            dep_build_id,
+          )
+          .await?;
         }
       }
     }
@@ -296,16 +312,32 @@ pub(crate) async fn create_builds_from_eval(
       for constituent_name in constituents {
         if let Some(&dep_build_id) = name_to_build.get(constituent_name)
           && dep_build_id != build_id
-          && let Err(e) =
-            repo::build_dependencies::create(pool, build_id, dep_build_id).await
         {
-          tracing::warn!(build_id = %build_id, dep = %dep_build_id, "Failed to create constituent dependency: {e}");
+          repo::build_dependencies::create_in_transaction(
+            &mut tx,
+            build_id,
+            dep_build_id,
+          )
+          .await?;
         }
       }
     }
   }
 
-  Ok(())
+  if !repo::evaluations::finish_running_in_transaction(
+    &mut tx,
+    eval_id,
+    EvaluationStatus::Completed,
+    None,
+  )
+  .await?
+  {
+    return Err(color_eyre::eyre::eyre!(
+      "evaluation {eval_id} lost its running state while locked"
+    ));
+  }
+  tx.commit().await?;
+  Ok(true)
 }
 
 /// Compute a deterministic hash over the commit and all jobset inputs.

--- a/crates/evaluator/src/cli.rs
+++ b/crates/evaluator/src/cli.rs
@@ -34,6 +34,13 @@ where
   I: IntoIterator<Item = T>,
   T: Into<OsString> + Clone,
 {
+  // Cap Nix's GC heap. By default it sizes from total RAM and the reservation
+  // fails on swapless low-memory hosts, killing the evix worker.
+  if std::env::var_os("GC_INITIAL_HEAP_SIZE").is_none() {
+    // SAFETY: set at process start, before any threads spawn.
+    unsafe { std::env::set_var("GC_INITIAL_HEAP_SIZE", "268435456") };
+  }
+
   // evix evaluates Nix in worker subprocesses that re-execute this binary with
   // `EVIX_WORKER` set. When invoked that way, act purely as an evix worker and
   // do not start the evaluator service (tokio runtime, database, etc.).

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -420,6 +420,7 @@ async fn run_nix_and_record_builds(
   ));
   let result = crate::nix::evaluate(
     repo_path,
+    &eval.commit_hash,
     &jobset.nix_expression,
     jobset.flake_mode,
     nix_timeout,

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -24,7 +24,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use uuid::Uuid;
 
-use crate::builds::{compute_inputs_hash, create_builds_from_eval};
+use crate::{
+  builds::{compute_inputs_hash, create_builds_from_eval},
+  evaluation_state::{ExistingEvaluationClaim, claim_existing},
+};
 
 /// Main evaluator loop. Polls jobsets and runs nix evaluations.
 ///
@@ -434,11 +437,6 @@ async fn run_nix_and_record_builds(
     tracing::warn!(eval_id = %eval.id, "Evaluation cancellation watcher stopped: {error}");
   }
 
-  if repo::evaluations::is_cancelled(pool, eval.id).await? {
-    tracing::info!(eval_id = %eval.id, "Evaluation was cancelled");
-    return Ok(());
-  }
-
   match result {
     Ok(eval_result) => {
       tracing::debug!(jobset = %jobset.name, job_count = eval_result.jobs.len(), "Nix evaluation returned");
@@ -449,7 +447,10 @@ async fn run_nix_and_record_builds(
           "Evaluation discovered jobs"
       );
 
-      create_builds_from_eval(pool, eval.id, &eval_result).await?;
+      if !create_builds_from_eval(pool, eval.id, &eval_result).await? {
+        tracing::info!(eval_id = %eval.id, "Evaluation was cancelled");
+        return Ok(());
+      }
 
       if notifications_config.enable_retry_queue {
         if let Ok(project) = repo::projects::get(pool, jobset.project_id).await
@@ -483,14 +484,6 @@ async fn run_nix_and_record_builds(
           );
         }
       }
-
-      repo::evaluations::finish_running(
-        pool,
-        eval.id,
-        EvaluationStatus::Completed,
-        None,
-      )
-      .await?;
     },
     Err(e) => {
       let msg = e.to_string();
@@ -727,25 +720,9 @@ async fn evaluate_jobset(
         )
       })?;
 
-      if existing.status == EvaluationStatus::Pending {
-        repo::evaluations::update_status(
-          pool,
-          existing.id,
-          EvaluationStatus::Running,
-          None,
-        )
-        .await?;
-      } else if existing.status == EvaluationStatus::Completed {
-        let build_count = repo::builds::count_filtered(
-          pool,
-          Some(existing.id),
-          None,
-          None,
-          None,
-        )
-        .await?;
-
-        if build_count > 0 {
+      match claim_existing(pool, existing).await? {
+        ExistingEvaluationClaim::Claimed(eval) => eval,
+        ExistingEvaluationClaim::Completed { build_count } => {
           info!(
             "Evaluation already completed with {} builds, skipping nix \
              evaluation jobset={} commit={}",
@@ -760,30 +737,29 @@ async fn evaluate_jobset(
             );
           }
           return Ok(());
-        }
-        info!(
-          "Evaluation completed but has 0 builds, re-running nix evaluation \
-           jobset={} commit={}",
-          jobset.name, commit_hash
-        );
-      } else if existing.status == EvaluationStatus::Running {
-        tracing::info!(
-          jobset = %jobset.name,
-          commit = %commit_hash,
-          eval_id = %existing.id,
-          "Evaluation is already running, skipping duplicate poll"
-        );
-        if let Err(e) =
-          repo::jobsets::update_last_checked(pool, jobset.id).await
-        {
-          tracing::warn!(
+        },
+        ExistingEvaluationClaim::Running => {
+          tracing::info!(
             jobset = %jobset.name,
-            "Failed to update last_checked_at: {e}"
+            commit = %commit_hash,
+            "Evaluation is already running, skipping duplicate poll"
           );
-        }
-        return Ok(());
+          if let Err(e) =
+            repo::jobsets::update_last_checked(pool, jobset.id).await
+          {
+            tracing::warn!(jobset = %jobset.name, "Failed to update last_checked_at: {e}");
+          }
+          return Ok(());
+        },
+        ExistingEvaluationClaim::Cancelled => {
+          tracing::info!(
+            jobset = %jobset.name,
+            commit = %commit_hash,
+            "Evaluation was cancelled, skipping duplicate poll"
+          );
+          return Ok(());
+        },
       }
-      existing
     },
     Err(e) => {
       return Err(color_eyre::eyre::eyre!(e)).with_context(|| {

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -20,6 +20,7 @@ use color_eyre::eyre::Context;
 use futures::stream::{self, StreamExt};
 use sqlx::PgPool;
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 use uuid::Uuid;
 
@@ -298,6 +299,11 @@ async fn evaluate_pending_eval(
     color_eyre::eyre::eyre!("Git operation timed out after {git_timeout:?}")
   })???;
 
+  if repo::evaluations::is_cancelled(pool, claimed.id).await? {
+    tracing::info!(eval_id = %claimed.id, "Evaluation cancelled during checkout");
+    return Ok(());
+  }
+
   let inputs = repo::jobset_inputs::list_for_jobset(pool, jobset.id)
     .await
     .unwrap_or_default();
@@ -388,16 +394,51 @@ async fn run_nix_and_record_builds(
   notification_secret_key: Option<&str>,
   nix_timeout: Duration,
 ) -> color_eyre::Result<()> {
-  match crate::nix::evaluate(
+  let max_eval_time = config.max_eval_time.map(Duration::from_secs);
+  let nix_timeout = max_eval_time.map_or(nix_timeout, |limit| {
+    let elapsed = (Utc::now() - eval.evaluation_time)
+      .to_std()
+      .unwrap_or_default();
+    limit.saturating_sub(elapsed).min(nix_timeout)
+  });
+  if max_eval_time.is_some_and(|_| nix_timeout.is_zero()) {
+    repo::evaluations::finish_running(
+      pool,
+      eval.id,
+      EvaluationStatus::TimedOut,
+      Some("Evaluation exceeded max_eval_time"),
+    )
+    .await?;
+    return Ok(());
+  }
+
+  let cancel = CancellationToken::new();
+  let watcher = tokio::spawn(watch_evaluation_cancellation(
+    pool.clone(),
+    eval.id,
+    cancel.clone(),
+  ));
+  let result = crate::nix::evaluate(
     repo_path,
     &jobset.nix_expression,
     jobset.flake_mode,
     nix_timeout,
     config,
     inputs,
+    &cancel,
   )
-  .await
-  {
+  .await;
+  cancel.cancel();
+  if let Err(error) = watcher.await {
+    tracing::warn!(eval_id = %eval.id, "Evaluation cancellation watcher stopped: {error}");
+  }
+
+  if repo::evaluations::is_cancelled(pool, eval.id).await? {
+    tracing::info!(eval_id = %eval.id, "Evaluation was cancelled");
+    return Ok(());
+  }
+
+  match result {
     Ok(eval_result) => {
       tracing::debug!(jobset = %jobset.name, job_count = eval_result.jobs.len(), "Nix evaluation returned");
       tracing::info!(
@@ -442,7 +483,7 @@ async fn run_nix_and_record_builds(
         }
       }
 
-      repo::evaluations::update_status(
+      repo::evaluations::finish_running(
         pool,
         eval.id,
         EvaluationStatus::Completed,
@@ -453,17 +494,42 @@ async fn run_nix_and_record_builds(
     Err(e) => {
       let msg = e.to_string();
       tracing::error!(jobset = %jobset.name, "Evaluation failed: {msg}");
-      repo::evaluations::update_status(
-        pool,
-        eval.id,
-        EvaluationStatus::Failed,
-        Some(&msg),
-      )
-      .await?;
+      let status = if max_eval_time.is_some_and(|limit| {
+        (Utc::now() - eval.evaluation_time)
+          .to_std()
+          .is_ok_and(|elapsed| elapsed >= limit)
+      }) {
+        EvaluationStatus::TimedOut
+      } else {
+        EvaluationStatus::Failed
+      };
+      repo::evaluations::finish_running(pool, eval.id, status, Some(&msg))
+        .await?;
     },
   }
 
   Ok(())
+}
+
+async fn watch_evaluation_cancellation(
+  pool: PgPool,
+  evaluation_id: Uuid,
+  cancel: CancellationToken,
+) {
+  let mut interval = tokio::time::interval(Duration::from_millis(500));
+  loop {
+    tokio::select! {
+      () = cancel.cancelled() => return,
+      _ = interval.tick() => match repo::evaluations::is_cancelled(&pool, evaluation_id).await {
+        Ok(true) => {
+          cancel.cancel();
+          return;
+        },
+        Ok(false) => {},
+        Err(error) => tracing::warn!(%evaluation_id, "Failed to check evaluation cancellation: {error}"),
+      },
+    }
+  }
 }
 
 async fn evaluate_jobset(

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -9,6 +9,7 @@ use circus_common::{
     CreateJobset,
     Evaluation,
     EvaluationStatus,
+    EvaluationTriggerKind,
     JobsetInput,
     JobsetState,
     JobsetTriggerMode,
@@ -103,7 +104,7 @@ async fn run_cycle(
       continue;
     };
 
-    if jobset.trigger_mode.accepts_source_triggers() {
+    if accepts_pending_evaluation(jobset.trigger_mode, eval.trigger_kind) {
       pending_jobset_ids.insert(eval.jobset_id);
       pending_tasks.push((eval, jobset.clone()));
     } else {
@@ -219,6 +220,14 @@ async fn run_cycle(
   discover_projects_without_jobsets(pool, config, git_timeout).await;
 
   Ok(())
+}
+
+fn accepts_pending_evaluation(
+  trigger_mode: JobsetTriggerMode,
+  trigger_kind: EvaluationTriggerKind,
+) -> bool {
+  trigger_mode.accepts_source_triggers()
+    || trigger_kind == EvaluationTriggerKind::Interval
 }
 
 fn warn_on_disk_pressure(msg: &str) {
@@ -968,5 +977,24 @@ async fn discover_projects_without_jobsets(
     };
 
     sync_repo_declarative_config(pool, &repo_path, project.id).await;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use circus_common::models::{EvaluationTriggerKind, JobsetTriggerMode};
+
+  use super::accepts_pending_evaluation;
+
+  #[test]
+  fn interval_restarts_are_accepted_by_pending_queue() {
+    assert!(accepts_pending_evaluation(
+      JobsetTriggerMode::Interval,
+      EvaluationTriggerKind::Interval,
+    ));
+    assert!(!accepts_pending_evaluation(
+      JobsetTriggerMode::Interval,
+      EvaluationTriggerKind::Manual,
+    ));
   }
 }

--- a/crates/evaluator/src/evaluation_state.rs
+++ b/crates/evaluator/src/evaluation_state.rs
@@ -1,0 +1,66 @@
+use circus_common::{
+  models::{Evaluation, EvaluationStatus},
+  repo,
+};
+use sqlx::PgPool;
+
+pub enum ExistingEvaluationClaim {
+  Claimed(Evaluation),
+  Completed { build_count: i64 },
+  Running,
+  Cancelled,
+}
+
+/// Claim an existing evaluation for a fresh attempt when its state permits it.
+pub async fn claim_existing(
+  pool: &PgPool,
+  existing: Evaluation,
+) -> color_eyre::Result<ExistingEvaluationClaim> {
+  match existing.status {
+    EvaluationStatus::Pending => {
+      Ok(
+        repo::evaluations::try_claim_pending(pool, existing.id)
+          .await?
+          .map_or(
+            ExistingEvaluationClaim::Running,
+            ExistingEvaluationClaim::Claimed,
+          ),
+      )
+    },
+    EvaluationStatus::Failed | EvaluationStatus::TimedOut => {
+      if repo::evaluations::restart(pool, existing.id)
+        .await?
+        .is_none()
+      {
+        return Ok(ExistingEvaluationClaim::Running);
+      }
+      Ok(
+        repo::evaluations::try_claim_pending(pool, existing.id)
+          .await?
+          .map_or(
+            ExistingEvaluationClaim::Running,
+            ExistingEvaluationClaim::Claimed,
+          ),
+      )
+    },
+    EvaluationStatus::Completed => {
+      let build_count =
+        repo::builds::count_filtered(pool, Some(existing.id), None, None, None)
+          .await?;
+      if build_count > 0 {
+        return Ok(ExistingEvaluationClaim::Completed { build_count });
+      }
+      Ok(ExistingEvaluationClaim::Claimed(
+        repo::evaluations::update_status(
+          pool,
+          existing.id,
+          EvaluationStatus::Running,
+          None,
+        )
+        .await?,
+      ))
+    },
+    EvaluationStatus::Running => Ok(ExistingEvaluationClaim::Running),
+    EvaluationStatus::Cancelled => Ok(ExistingEvaluationClaim::Cancelled),
+  }
+}

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod builds;
 pub mod cli;
 pub mod eval_loop;
+mod evaluation_state;
 pub mod git;
 pub mod nix;

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -9,8 +9,6 @@ mod flake_lock;
 
 use eval_command::NixEvalPolicy;
 
-/// Number of evix worker processes spawned per evaluation.
-const EVAL_WORKERS: usize = 4;
 /// Per-worker memory ceiling in MB; evix restarts a worker once it is exceeded.
 const EVAL_MAX_MEMORY_MB: usize = 4096;
 
@@ -314,7 +312,7 @@ async fn evaluate_flake(
     auto_args: Vec::new(),
     force_recurse: true,
     gc_roots_dir: None,
-    workers: EVAL_WORKERS,
+    workers: config.eval_workers,
     max_memory_size: EVAL_MAX_MEMORY_MB,
     meta: true,
     show_input_drvs: true,
@@ -499,7 +497,7 @@ async fn evaluate_legacy(
     auto_args,
     force_recurse: true,
     gc_roots_dir: None,
-    workers: EVAL_WORKERS,
+    workers: config.eval_workers,
     max_memory_size: EVAL_MAX_MEMORY_MB,
     meta: true,
     show_input_drvs: true,

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use circus_common::{CiError, InputType, error::Result, models::JobsetInput};
 use circus_config::EvaluatorConfig;
 use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 
 mod eval_command;
 mod flake_lock;
@@ -180,6 +181,7 @@ pub async fn evaluate(
   timeout: Duration,
   config: &EvaluatorConfig,
   inputs: &[JobsetInput],
+  cancel: &CancellationToken,
 ) -> Result<EvalResult> {
   // Validate nix expression before constructing any commands
   circus_nix::validate::validate_nix_expression(nix_expression)
@@ -199,9 +201,11 @@ pub async fn evaluate(
   };
 
   if flake_mode {
-    evaluate_flake(repo_path, nix_expression, timeout, config, inputs).await
+    evaluate_flake(repo_path, nix_expression, timeout, config, inputs, cancel)
+      .await
   } else {
-    evaluate_legacy(repo_path, nix_expression, timeout, config, inputs).await
+    evaluate_legacy(repo_path, nix_expression, timeout, config, inputs, cancel)
+      .await
   }
 }
 
@@ -270,10 +274,13 @@ async fn evaluate_flake(
   timeout: Duration,
   config: &EvaluatorConfig,
   inputs: &[JobsetInput],
+  cancel: &CancellationToken,
 ) -> Result<EvalResult> {
   if nix_expression == "nixosConfigurations" {
-    return evaluate_all_nixos_configs(repo_path, timeout, config, inputs)
-      .await;
+    return evaluate_all_nixos_configs(
+      repo_path, timeout, config, inputs, cancel,
+    )
+    .await;
   }
 
   let effective_expr = rewrite_nixos_config_expr(nix_expression)
@@ -323,7 +330,7 @@ async fn evaluate_flake(
     ..evix::Config::default()
   };
 
-  eval_command::run_eval(evix_config, timeout, "flake").await
+  eval_command::run_eval(evix_config, timeout, "flake", cancel).await
 }
 
 /// Resolve all toplevels in one nix eval.
@@ -332,6 +339,7 @@ async fn evaluate_all_nixos_configs(
   _timeout: Duration,
   config: &EvaluatorConfig,
   _inputs: &[JobsetInput],
+  cancel: &CancellationToken,
 ) -> Result<EvalResult> {
   let flake_ref = format!("{}#nixosConfigurations", repo_path.display());
 
@@ -351,7 +359,10 @@ async fn evaluate_all_nixos_configs(
   NixEvalPolicy::from(config)
     .with_extra_allowed_uris(derived_uris)
     .apply_to(&mut cmd);
-  let output = cmd.output().await.map_err(|e| {
+  let output = tokio::select! {
+    output = cmd.output() => output,
+    () = cancel.cancelled() => return Err(CiError::NixEval("Nix evaluation was cancelled".to_string())),
+  }.map_err(|e| {
     CiError::NixEval(format!("Failed to evaluate nixosConfigurations: {e}"))
   })?;
 
@@ -443,6 +454,7 @@ async fn evaluate_legacy(
   timeout: Duration,
   config: &EvaluatorConfig,
   inputs: &[JobsetInput],
+  cancel: &CancellationToken,
 ) -> Result<EvalResult> {
   let repo_path = repo_path.canonicalize().map_err(|e| {
     CiError::NixEval(format!("Failed to canonicalize repository path: {e}"))
@@ -508,7 +520,7 @@ async fn evaluate_legacy(
     ..evix::Config::default()
   };
 
-  eval_command::run_eval(evix_config, timeout, "legacy").await
+  eval_command::run_eval(evix_config, timeout, "legacy", cancel).await
 }
 
 /// Recursively flatten a nix eval --json value into (`attr_path`, `drv_path`)

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -4,6 +4,7 @@ use circus_common::{CiError, InputType, error::Result, models::JobsetInput};
 use circus_config::EvaluatorConfig;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
+use url::Url;
 
 mod eval_command;
 mod flake_lock;
@@ -176,6 +177,7 @@ pub struct EvalResult {
 #[tracing::instrument(skip(config, inputs), fields(flake_mode, nix_expression))]
 pub async fn evaluate(
   repo_path: &Path,
+  commit_hash: &str,
   nix_expression: &str,
   flake_mode: bool,
   timeout: Duration,
@@ -201,8 +203,16 @@ pub async fn evaluate(
   };
 
   if flake_mode {
-    evaluate_flake(repo_path, nix_expression, timeout, config, inputs, cancel)
-      .await
+    evaluate_flake(
+      repo_path,
+      commit_hash,
+      nix_expression,
+      timeout,
+      config,
+      inputs,
+      cancel,
+    )
+    .await
   } else {
     evaluate_legacy(repo_path, nix_expression, timeout, config, inputs, cancel)
       .await
@@ -270,6 +280,7 @@ fn lock_derived_allowed_uris(
 #[tracing::instrument(skip(config, inputs))]
 async fn evaluate_flake(
   repo_path: &Path,
+  commit_hash: &str,
   nix_expression: &str,
   timeout: Duration,
   config: &EvaluatorConfig,
@@ -294,7 +305,7 @@ async fn evaluate_flake(
     );
   }
 
-  let flake_ref = format!("{}#{effective_expr}", repo_path.display());
+  let flake_ref = git_flake_ref(repo_path, commit_hash, &effective_expr)?;
 
   tracing::debug!(flake_ref = %flake_ref, "Running evix evaluation");
 
@@ -331,6 +342,21 @@ async fn evaluate_flake(
   };
 
   eval_command::run_eval(evix_config, timeout, "flake", cancel).await
+}
+
+fn git_flake_ref(
+  repo_path: &Path,
+  commit_hash: &str,
+  expression: &str,
+) -> Result<String> {
+  let mut url = Url::from_file_path(repo_path).map_err(|()| {
+    CiError::NixEval(format!(
+      "Failed to convert repository path to a file URL: {}",
+      repo_path.display()
+    ))
+  })?;
+  url.query_pairs_mut().append_pair("rev", commit_hash);
+  Ok(format!("git+{url}#{expression}"))
 }
 
 /// Resolve all toplevels in one nix eval.
@@ -889,6 +915,19 @@ mod meta_tests {
       .is_none()
     );
     assert!(rewrite_nixos_config_expr("packages").is_none());
+  }
+
+  #[test]
+  fn git_flake_ref_pins_the_checked_out_commit() {
+    assert_eq!(
+      git_flake_ref(
+        Path::new("/tmp/circus fixture"),
+        "0123456789abcdef",
+        "packages",
+      )
+      .unwrap(),
+      "git+file:///tmp/circus%20fixture?rev=0123456789abcdef#packages",
+    );
   }
 
   #[test]

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -320,6 +320,7 @@ async fn evaluate_flake(
     show_input_drvs: true,
     override_inputs,
     nix_options: policy.nix_options(),
+    ..evix::Config::default()
   };
 
   eval_command::run_eval(evix_config, timeout, "flake").await
@@ -504,6 +505,7 @@ async fn evaluate_legacy(
     show_input_drvs: true,
     override_inputs: Vec::new(),
     nix_options: NixEvalPolicy::from(config).nix_options(),
+    ..evix::Config::default()
   };
 
   eval_command::run_eval(evix_config, timeout, "legacy").await

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -60,7 +60,9 @@ pub(crate) fn nix_job_from_derivation(drv: &evix::Derivation) -> NixJob {
       drv
         .input_drvs
         .iter()
-        .map(|(key, value)| (key.clone(), value.clone()))
+        .map(|(key, value)| {
+          (key.clone(), serde_json::Value::from(value.clone()))
+        })
         .collect(),
     )
   };
@@ -964,7 +966,7 @@ mod meta_tests {
     let mut drv = derivation("hello", "hello");
     drv
       .input_drvs
-      .insert("/nix/store/dep.drv".into(), serde_json::json!(["out"]));
+      .insert("/nix/store/dep.drv".into(), vec!["out".to_string()]);
     let input_drvs = nix_job_from_derivation(&drv).input_drvs.unwrap();
     assert!(input_drvs.contains_key("/nix/store/dep.drv"));
   }

--- a/crates/evaluator/src/nix/eval_command.rs
+++ b/crates/evaluator/src/nix/eval_command.rs
@@ -4,6 +4,7 @@ use circus_common::{CiError, error::Result};
 use circus_config::EvaluatorConfig;
 use futures::StreamExt as _;
 use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 
 use super::{EvalResult, nix_job_from_derivation};
 
@@ -87,6 +88,7 @@ pub(super) async fn run_eval(
   config: evix::Config,
   timeout: Duration,
   description: &'static str,
+  cancel: &CancellationToken,
 ) -> Result<EvalResult> {
   tracing::info!(
     evaluation = description,
@@ -98,7 +100,7 @@ pub(super) async fn run_eval(
     .await
     .map_err(|e| evix_eval_failure(description, &format!("{e:#}")))?;
 
-  let collect = async move {
+  let collect = async {
     let mut events = session.stream();
     let mut jobs = Vec::new();
     let mut error_count = 0usize;
@@ -120,7 +122,8 @@ pub(super) async fn run_eval(
     Ok::<EvalResult, CiError>(EvalResult { jobs, error_count })
   };
 
-  match tokio::time::timeout(timeout, collect).await {
+  tokio::select! {
+    result = tokio::time::timeout(timeout, collect) => match result {
     Ok(result) => {
       let result = result?;
       if result.error_count > 0 {
@@ -135,9 +138,15 @@ pub(super) async fn run_eval(
       Ok(result)
     },
     Err(_elapsed) => {
+      session.cancel();
       Err(CiError::Timeout(format!(
         "Nix evaluation timed out after {timeout:?}"
       )))
+    },
+    },
+    () = cancel.cancelled() => {
+      session.cancel();
+      Err(CiError::NixEval("Nix evaluation was cancelled".to_string()))
     },
   }
 }

--- a/crates/evaluator/src/nix/eval_command.rs
+++ b/crates/evaluator/src/nix/eval_command.rs
@@ -1,17 +1,11 @@
-use std::{
-  sync::{
-    Arc,
-    Mutex,
-    atomic::{AtomicBool, Ordering},
-  },
-  time::Duration,
-};
+use std::time::Duration;
 
 use circus_common::{CiError, error::Result};
 use circus_config::EvaluatorConfig;
+use futures::StreamExt as _;
 use tokio::process::Command;
 
-use super::{EvalResult, NixJob, nix_job_from_derivation};
+use super::{EvalResult, nix_job_from_derivation};
 
 /// Nix evaluation settings derived from the evaluator configuration, forwarded
 /// to evix as `(key, value)` options.
@@ -100,52 +94,35 @@ pub(super) async fn run_eval(
     "Starting evix evaluation with Nix options"
   );
 
-  let collected: Arc<Mutex<(Vec<NixJob>, usize)>> =
-    Arc::new(Mutex::new((Vec::new(), 0)));
-  let cancel = Arc::new(AtomicBool::new(false));
+  let session = evix::Session::open(config)
+    .await
+    .map_err(|e| evix_eval_failure(description, &format!("{e:#}")))?;
 
-  let sink_state = Arc::clone(&collected);
-  let cancel_eval = Arc::clone(&cancel);
-  let handle = tokio::task::spawn_blocking(move || {
-    evix::evaluate_cancellable(&config, &cancel_eval, move |event| {
-      match event {
+  let collect = async move {
+    let mut events = session.stream();
+    let mut jobs = Vec::new();
+    let mut error_count = 0usize;
+
+    while let Some(event) = events.next().await {
+      match event
+        .map_err(|e| evix_eval_failure(description, &format!("{e:#}")))?
+      {
         evix::Event::Derivation(drv) => {
-          sink_state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .0
-            .push(nix_job_from_derivation(drv));
+          jobs.push(nix_job_from_derivation(&drv));
         },
         evix::Event::Error(err) => {
           tracing::warn!(job = %err.attr, "evix reported error: {}", err.error);
-          sink_state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .1 += 1;
+          error_count += 1;
         },
         evix::Event::AttrSet { .. } => {},
       }
-      Ok(())
-    })
-  });
+    }
+    Ok::<EvalResult, CiError>(EvalResult { jobs, error_count })
+  };
 
-  match tokio::time::timeout(timeout, handle).await {
-    Ok(joined) => {
-      joined
-        .map_err(|e| {
-          CiError::NixEval(format!("evix evaluation task failed to join: {e}"))
-        })?
-        .map_err(|e| evix_eval_failure(description, &format!("{e:#}")))?;
-
-      let result = {
-        let guard = collected
-          .lock()
-          .unwrap_or_else(std::sync::PoisonError::into_inner);
-        EvalResult {
-          jobs:        guard.0.clone(),
-          error_count: guard.1,
-        }
-      };
+  match tokio::time::timeout(timeout, collect).await {
+    Ok(result) => {
+      let result = result?;
       if result.error_count > 0 {
         tracing::warn!(
           error_count = result.error_count,
@@ -158,8 +135,6 @@ pub(super) async fn run_eval(
       Ok(result)
     },
     Err(_elapsed) => {
-      // Ask the in-flight evaluation to stop; its workers exit cooperatively.
-      cancel.store(true, Ordering::Relaxed);
       Err(CiError::Timeout(format!(
         "Nix evaluation timed out after {timeout:?}"
       )))
@@ -342,16 +317,17 @@ mod policy_tests {
     };
 
     let evix_config = evix::Config {
-      input:           evix::Input::Expr("{}".to_string()),
-      auto_args:       Vec::new(),
-      force_recurse:   true,
-      gc_roots_dir:    None,
-      workers:         1,
+      input: evix::Input::Expr("{}".to_string()),
+      auto_args: Vec::new(),
+      force_recurse: true,
+      gc_roots_dir: None,
+      workers: 1,
       max_memory_size: 512,
-      meta:            false,
+      meta: false,
       show_input_drvs: false,
       override_inputs: Vec::new(),
-      nix_options:     NixEvalPolicy::from(&config).nix_options(),
+      nix_options: NixEvalPolicy::from(&config).nix_options(),
+      ..evix::Config::default()
     };
 
     assert_eq!(evix_config.nix_options, vec![

--- a/crates/evaluator/tests/eval_tests.rs
+++ b/crates/evaluator/tests/eval_tests.rs
@@ -12,12 +12,13 @@ use circus_config::EvaluatorConfig;
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
 
-fn git_stage(dir: &Path) {
+fn git_stage(dir: &Path) -> String {
   for args in [
     &["init", "-q"][..],
     &["config", "user.email", "test@circus"],
     &["config", "user.name", "Circus Test"],
     &["add", "."],
+    &["commit", "-qm", "fixture"],
   ] {
     Command::new("git")
       .args(args)
@@ -25,6 +26,17 @@ fn git_stage(dir: &Path) {
       .status()
       .expect("git command failed");
   }
+  String::from_utf8(
+    Command::new("git")
+      .args(["rev-parse", "HEAD"])
+      .current_dir(dir)
+      .output()
+      .expect("read fixture commit")
+      .stdout,
+  )
+  .expect("fixture commit is UTF-8")
+  .trim()
+  .to_owned()
 }
 
 fn permissive_config() -> EvaluatorConfig {
@@ -54,10 +66,11 @@ async fn eval_minimal_flake_returns_one_job() {
 }"#,
   )
   .unwrap();
-  git_stage(dir.path());
+  let commit = git_stage(dir.path());
 
   let result = circus_evaluator::nix::evaluate(
     dir.path(),
+    &commit,
     "packages",
     true,
     Duration::from_mins(2),
@@ -99,10 +112,11 @@ async fn eval_captures_per_attribute_errors_without_failing_fatally() {
 }"#,
   )
   .unwrap();
-  git_stage(dir.path());
+  let commit = git_stage(dir.path());
 
   let result = circus_evaluator::nix::evaluate(
     dir.path(),
+    &commit,
     "packages",
     true,
     Duration::from_mins(2),
@@ -130,10 +144,11 @@ async fn eval_fatal_parse_error_returns_cierror_nixeval() {
   let dir = TempDir::new().unwrap();
   fs::write(dir.path().join("flake.nix"), "not valid nix syntax at all")
     .unwrap();
-  git_stage(dir.path());
+  let commit = git_stage(dir.path());
 
   let result = circus_evaluator::nix::evaluate(
     dir.path(),
+    &commit,
     "packages",
     true,
     Duration::from_secs(30),
@@ -171,10 +186,11 @@ async fn eval_timeout_returns_cierror_timeout() {
 }",
   )
   .unwrap();
-  git_stage(dir.path());
+  let commit = git_stage(dir.path());
 
   let result = circus_evaluator::nix::evaluate(
     dir.path(),
+    &commit,
     "packages",
     true,
     Duration::from_millis(500),

--- a/crates/evaluator/tests/eval_tests.rs
+++ b/crates/evaluator/tests/eval_tests.rs
@@ -10,6 +10,7 @@ use std::{fs, path::Path, process::Command, time::Duration};
 
 use circus_config::EvaluatorConfig;
 use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
 
 fn git_stage(dir: &Path) {
   for args in [
@@ -62,6 +63,7 @@ async fn eval_minimal_flake_returns_one_job() {
     Duration::from_mins(2),
     &permissive_config(),
     &[],
+    &CancellationToken::new(),
   )
   .await
   .expect("evaluation should succeed");
@@ -106,6 +108,7 @@ async fn eval_captures_per_attribute_errors_without_failing_fatally() {
     Duration::from_mins(2),
     &permissive_config(),
     &[],
+    &CancellationToken::new(),
   )
   .await
   .expect("fatal eval error not expected for per-attribute throws");
@@ -136,6 +139,7 @@ async fn eval_fatal_parse_error_returns_cierror_nixeval() {
     Duration::from_secs(30),
     &permissive_config(),
     &[],
+    &CancellationToken::new(),
   )
   .await;
 
@@ -176,6 +180,7 @@ async fn eval_timeout_returns_cierror_timeout() {
     Duration::from_millis(500),
     &permissive_config(),
     &[],
+    &CancellationToken::new(),
   )
   .await;
 

--- a/crates/migrations/migrations/0029_evaluation_cancellation.sql
+++ b/crates/migrations/migrations/0029_evaluation_cancellation.sql
@@ -1,0 +1,14 @@
+ALTER TABLE evaluations
+DROP CONSTRAINT evaluations_status_check;
+
+ALTER TABLE evaluations
+ADD CONSTRAINT evaluations_status_check CHECK (
+  status IN (
+    'pending',
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+    'timed_out'
+  )
+);

--- a/crates/server/src/routes/dashboard/admin.rs
+++ b/crates/server/src/routes/dashboard/admin.rs
@@ -770,7 +770,8 @@ pub(super) async fn evaluation_restart(
     .ok_or_else(|| {
       (
         StatusCode::CONFLICT,
-        "Only failed or cancelled evaluations can be restarted",
+        "Only failed, cancelled, or timed-out evaluations with active jobsets \
+         can be restarted",
       )
         .into_response()
     })?;

--- a/crates/server/src/routes/dashboard/admin.rs
+++ b/crates/server/src/routes/dashboard/admin.rs
@@ -726,6 +726,57 @@ pub(super) async fn evaluation_visibility(
   Ok(Redirect::to(&target))
 }
 
+pub(super) async fn evaluation_cancel(
+  State(state): State<AppState>,
+  Path(evaluation_id): Path<Uuid>,
+  ctx: DashboardContext,
+  Form(form): Form<CsrfOnlyForm>,
+) -> Result<Redirect, Response> {
+  ctx
+    .require_permission(Permission::CancelBuild)
+    .map_err(|status| {
+      (status, "Cancel evaluation permission required").into_response()
+    })?;
+  ctx.check_csrf(&form.csrf_token)?;
+  circus_common::repo::evaluations::cancel(&state.pool, evaluation_id)
+    .await
+    .map_err(|e| {
+      (StatusCode::BAD_REQUEST, format!("Cancel failed: {e}")).into_response()
+    })?
+    .ok_or_else(|| {
+      (StatusCode::CONFLICT, "Evaluation is not running or pending")
+        .into_response()
+    })?;
+  Ok(Redirect::to(&format!("/evaluation/{evaluation_id}")))
+}
+
+pub(super) async fn evaluation_restart(
+  State(state): State<AppState>,
+  Path(evaluation_id): Path<Uuid>,
+  ctx: DashboardContext,
+  Form(form): Form<CsrfOnlyForm>,
+) -> Result<Redirect, Response> {
+  ctx
+    .require_permission(Permission::RestartJobs)
+    .map_err(|status| {
+      (status, "Restart evaluation permission required").into_response()
+    })?;
+  ctx.check_csrf(&form.csrf_token)?;
+  circus_common::repo::evaluations::restart(&state.pool, evaluation_id)
+    .await
+    .map_err(|e| {
+      (StatusCode::BAD_REQUEST, format!("Restart failed: {e}")).into_response()
+    })?
+    .ok_or_else(|| {
+      (
+        StatusCode::CONFLICT,
+        "Only failed or cancelled evaluations can be restarted",
+      )
+        .into_response()
+    })?;
+  Ok(Redirect::to(&format!("/evaluation/{evaluation_id}")))
+}
+
 pub(super) async fn notifications_page(
   State(state): State<AppState>,
   Path(project_id): Path<Uuid>,

--- a/crates/server/src/routes/dashboard/mod.rs
+++ b/crates/server/src/routes/dashboard/mod.rs
@@ -50,6 +50,8 @@ pub fn router() -> Router<AppState> {
       "/evaluation/{id}/visibility",
       post(admin::evaluation_visibility),
     )
+    .route("/evaluation/{id}/cancel", post(admin::evaluation_cancel))
+    .route("/evaluation/{id}/restart", post(admin::evaluation_restart))
     .route("/builds", get(pages::builds_page))
     .route("/build/{id}", get(pages::build_page))
     .route("/build/{id}/log", get(pages::build_log))

--- a/crates/server/src/routes/dashboard/preview/fixtures.rs
+++ b/crates/server/src/routes/dashboard/preview/fixtures.rs
@@ -282,16 +282,16 @@ pub(super) fn queue_build(
 
 pub(super) fn eval_view(n: u128, status: &str, class: &str) -> EvalView {
   EvalView {
-    id:           id(n),
-    commit_hash:  "9f2c7a113badf00d7e57c0ffee1234567890abcd".into(),
-    commit_short: "9f2c7a113bad".into(),
-    status_text:  status.into(),
-    status_class: class.into(),
-    time:         "2026-06-18 11:42".into(),
-    error_lines:  Vec::new(),
-    hidden:       false,
-    jobset_name:  "packages".into(),
-    project_name: "circus".into(),
+    id:            id(n),
+    commit_hash:   "9f2c7a113badf00d7e57c0ffee1234567890abcd".into(),
+    commit_short:  "9f2c7a113bad".into(),
+    status_text:   status.into(),
+    status_class:  class.into(),
+    time:          "2026-06-18 11:42".into(),
+    error_message: String::new(),
+    hidden:        false,
+    jobset_name:   "packages".into(),
+    project_name:  "circus".into(),
   }
 }
 

--- a/crates/server/src/routes/dashboard/preview/mod.rs
+++ b/crates/server/src/routes/dashboard/preview/mod.rs
@@ -91,6 +91,8 @@ pub fn router() -> Router {
       "/evaluation/{id}/visibility",
       post(preview_evaluations_action),
     )
+    .route("/evaluation/{id}/cancel", post(preview_evaluations_action))
+    .route("/evaluation/{id}/restart", post(preview_evaluations_action))
     .route("/builds", get(pages::builds))
     .route("/build/{id}", get(pages::build))
     .route("/build/{id}/log", get(build_log))

--- a/crates/server/src/routes/dashboard/shared.rs
+++ b/crates/server/src/routes/dashboard/shared.rs
@@ -174,16 +174,16 @@ pub(super) struct QueueBuildView {
 }
 
 pub(super) struct EvalView {
-  pub(super) id:           Uuid,
-  pub(super) commit_hash:  String,
-  pub(super) commit_short: String,
-  pub(super) status_text:  String,
-  pub(super) status_class: String,
-  pub(super) time:         String,
-  pub(super) error_lines:  Vec<BuildErrorLine>,
-  pub(super) hidden:       bool,
-  pub(super) jobset_name:  String,
-  pub(super) project_name: String,
+  pub(super) id:            Uuid,
+  pub(super) commit_hash:   String,
+  pub(super) commit_short:  String,
+  pub(super) status_text:   String,
+  pub(super) status_class:  String,
+  pub(super) time:          String,
+  pub(super) error_message: String,
+  pub(super) hidden:        bool,
+  pub(super) jobset_name:   String,
+  pub(super) project_name:  String,
 }
 
 pub(super) struct EvalSummaryView {
@@ -763,20 +763,16 @@ impl From<&Evaluation> for EvalView {
       e.commit_hash.clone()
     };
     Self {
-      id:           e.id,
-      commit_hash:  e.commit_hash.clone(),
-      commit_short: short,
-      status_text:  text.to_string(),
-      status_class: class.to_string(),
-      time:         e.evaluation_time.format("%Y-%m-%d %H:%M").to_string(),
-      error_lines:  e
-        .error_message
-        .as_deref()
-        .map(parse_build_error)
-        .unwrap_or_default(),
-      hidden:       e.hidden,
-      jobset_name:  String::new(),
-      project_name: String::new(),
+      id:            e.id,
+      commit_hash:   e.commit_hash.clone(),
+      commit_short:  short,
+      status_text:   text.to_string(),
+      status_class:  class.to_string(),
+      time:          e.evaluation_time.format("%Y-%m-%d %H:%M").to_string(),
+      error_message: e.error_message.clone().unwrap_or_default(),
+      hidden:        e.hidden,
+      jobset_name:   String::new(),
+      project_name:  String::new(),
     }
   }
 }

--- a/crates/server/static/style.css
+++ b/crates/server/static/style.css
@@ -1751,6 +1751,11 @@ button:disabled {
   color: var(--status-failed);
 }
 
+.btn-danger {
+  color: var(--status-failed);
+  border-color: var(--status-failed);
+}
+
 .error-log-warn {
   color: var(--status-running);
 }

--- a/crates/server/templates/evaluation.html
+++ b/crates/server/templates/evaluation.html
@@ -38,6 +38,20 @@
                     <button class="btn btn-small btn-secondary" type="submit">Hide Evaluation</button>
                 {% endif %}
             </form>
+            {% if eval.status_class == "running" || eval.status_class == "pending" %}
+                <form class="inline" method="POST" action="/evaluation/{{ eval.id }}/cancel"
+                      onsubmit="return confirm('Cancel this evaluation?')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button class="btn btn-small btn-danger" type="submit">Cancel Evaluation</button>
+                </form>
+            {% endif %}
+            {% if eval.status_class == "failed" || eval.status_class == "cancelled" %}
+                <form class="inline" method="POST" action="/evaluation/{{ eval.id }}/restart"
+                      onsubmit="return confirm('Restart this evaluation and discard its current builds?')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button class="btn btn-small btn-secondary" type="submit">Restart Evaluation</button>
+                </form>
+            {% endif %}
         </div>
     {% endif %}
     <p>
@@ -51,17 +65,13 @@
     <p>
         <strong>Time:</strong> {{ eval.time }}
     </p>
-    {% if !eval.error_lines.is_empty() %}
+    {% if !eval.error_message.is_empty() %}
         <section class="evaluation-diagnostics">
             <div class="section-heading">
                 <h2>Evaluation Error</h2>
                 <span>Nix diagnostics</span>
             </div>
-            <ul class="error-log">
-                {% for line in eval.error_lines %}
-                    <li class="error-log-line error-log-{{ line.level }}">{{ line.text }}</li>
-                {% endfor %}
-            </ul>
+            <pre class="error-detail">{{ eval.error_message }}</pre>
         </section>
     {% endif %}
 

--- a/crates/server/templates/evaluation.html
+++ b/crates/server/templates/evaluation.html
@@ -39,14 +39,18 @@
                 {% endif %}
             </form>
             {% if eval.status_class == "running" || eval.status_class == "pending" %}
-                <form class="inline" method="POST" action="/evaluation/{{ eval.id }}/cancel"
+                <form class="inline"
+                      method="POST"
+                      action="/evaluation/{{ eval.id }}/cancel"
                       onsubmit="return confirm('Cancel this evaluation?')">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button class="btn btn-small btn-danger" type="submit">Cancel Evaluation</button>
                 </form>
             {% endif %}
-            {% if eval.status_class == "failed" || eval.status_class == "cancelled" %}
-                <form class="inline" method="POST" action="/evaluation/{{ eval.id }}/restart"
+            {% if eval.status_class == "failed" || eval.status_class == "cancelled" || eval.status_class == "timed-out" %}
+                <form class="inline"
+                      method="POST"
+                      action="/evaluation/{{ eval.id }}/restart"
                       onsubmit="return confirm('Restart this evaluation and discard its current builds?')">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button class="btn btn-small btn-secondary" type="submit">Restart Evaluation</button>
@@ -71,7 +75,8 @@
                 <h2>Evaluation Error</h2>
                 <span>Nix diagnostics</span>
             </div>
-            <pre class="error-detail">{{ eval.error_message }}</pre>
+            <pre class="error-detail">
+{{ eval.error_message }}</pre>
         </section>
     {% endif %}
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -175,181 +175,182 @@ configuration or the Nix store.
 
 <!-- markdownlint-disable MD013 -->
 
-| Section              | Key                                                    | Default                                             | Description                                       |
-| -------------------- | ------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------- |
-| `database`           | `url`                                                  | `postgresql://circus:password@localhost/circus`     | PostgreSQL connection URL                         |
-| `database`           | `url_file`                                             | none                                                | File containing the PostgreSQL URL                |
-| `database`           | `max_connections`                                      | `20`                                                | Maximum connection pool size                      |
-| `database`           | `min_connections`                                      | `5`                                                 | Minimum idle connections                          |
-| `database`           | `connect_timeout`                                      | `30`                                                | Connection timeout (seconds)                      |
-| `database`           | `idle_timeout`                                         | `600`                                               | Idle connection timeout (seconds)                 |
-| `database`           | `max_lifetime`                                         | `1800`                                              | Maximum connection lifetime (seconds)             |
-| `server`             | `host`                                                 | `127.0.0.1`                                         | HTTP listen address                               |
-| `server`             | `port`                                                 | `3000`                                              | HTTP listen port                                  |
-| `server`             | `request_timeout`                                      | `30`                                                | Per-request timeout (seconds)                     |
-| `server`             | `max_body_size`                                        | `10485760`                                          | Maximum request body size (10 MB)                 |
-| `server`             | `api_key`                                              | none                                                | Optional legacy API key (prefer DB keys)          |
-| `server`             | `api_key_file`                                         | none                                                | File containing the optional legacy API key       |
-| `server`             | `cors_permissive`                                      | `false`                                             | Allow all CORS origins                            |
-| `server`             | `allowed_origins`                                      | `[]`                                                | Allowed CORS origins list                         |
-| `server`             | `force_secure_cookies`                                 | `false`                                             | Force Secure flag on cookies (HTTPS proxy)        |
-| `server`             | `rate_limit_rps`                                       | none                                                | Requests per second limit per IP                  |
-| `server`             | `rate_limit_burst`                                     | none                                                | Burst size for rate limiting                      |
-| `server`             | `allowed_url_schemes`                                  | `[ "https", "git", "ssh" ]`                         | Allowed URL schemes for repository URLs           |
-| `server`             | `config_editor_enabled`                                | `false`                                             | Allow admin config editing through API/dashboard  |
-| `server`             | `require_api_key_for_reads`                            | `true`                                              | Require auth for read-only `/api/v1` requests     |
-| `server`             | `openapi_enabled`                                      | `true`                                              | Serve `/api/v1/openapi.json`                      |
-| `server`             | `webhook_secret_encryption_key`                        | none                                                | Encrypt webhook and notification secrets          |
-| `server`             | `webhook_secret_encryption_key_file`                   | none                                                | File containing the encryption key                |
-| `server`             | `ldap.enabled`                                         | `true`                                              | Enable configured LDAP login                      |
-| `server`             | `ldap.url`                                             | none                                                | LDAP server URL                                   |
-| `server`             | `ldap.bind_dn_template`                                | none                                                | LDAP bind DN template (`{username}` placeholder)  |
-| `server`             | `ldap.base_dn`                                         | none                                                | LDAP base DN for user searches                    |
-| `server`             | `ldap.tls_ca_cert`                                     | none                                                | Custom CA cert for LDAP TLS                       |
-| `server`             | `email_validation_regex`                               | none                                                | Custom regex for email validation                 |
-| `server.page_access` | per page                                               | mixed                                               | Dashboard page visibility policy                  |
-| `ui`                 | `enabled`                                              | `true`                                              | Mount bundled dashboard and static UI routes      |
-| `ui`                 | `dashboard`                                            | `true`                                              | Mount server-rendered dashboard/login pages       |
-| `ui`                 | `assets`                                               | `true`                                              | Serve bundled static UI assets                    |
-| `ui`                 | `brand_name`                                           | `circus`                                            | Dashboard sidebar brand name                      |
-| `ui`                 | `brand_subtitle`                                       | `Nix CI`                                            | Dashboard sidebar brand subtitle                  |
-| `ui`                 | `logo_url`                                             | none                                                | Optional logo URL                                 |
-| `ui`                 | `favicon_url`                                          | none                                                | Optional favicon URL                              |
-| `ui`                 | `custom_css`                                           | none                                                | CSS file served as `/static/custom.css`           |
-| `ui`                 | `static_dir`                                           | none                                                | Directory served below `/static/custom/`          |
-| `ui.css_variables`   | CSS variable names                                     | `{}`                                                | Variables emitted in `/static/theme.css`          |
-| `evaluator`          | `poll_interval`                                        | `60`                                                | Seconds between git poll cycles                   |
-| `evaluator`          | `git_timeout`                                          | `600`                                               | Git operation timeout (seconds)                   |
-| `evaluator`          | `nix_timeout`                                          | `1800`                                              | Nix evaluation timeout (seconds)                  |
-| `evaluator`          | `max_concurrent_evals`                                 | `4`                                                 | Maximum concurrent evaluations                    |
-| `evaluator`          | `work_dir`                                             | `/tmp/circus-evaluator`                             | Working directory for clones                      |
-| `evaluator`          | `restrict_eval`                                        | `true`                                              | Pass `--option restrict-eval true` to Nix         |
-| `evaluator`          | `allow_ifd`                                            | `false`                                             | Allow import-from-derivation                      |
-| `evaluator`          | `auto_allowed_uris`                                    | `true`                                              | Derive `allowed-uris` from the jobset flake.lock  |
-| `evaluator`          | `allowed_uris`                                         | `[]`                                                | Extra fetch URIs honored under `restrict_eval`    |
-| `evaluator`          | `require_locked_flake`                                 | `false`                                             | Refuse flake jobsets with no committed flake.lock |
-| `evaluator`          | `strict_errors`                                        | `false`                                             | Abort on first evaluation cycle error             |
-| `queue_runner`       | `workers`                                              | `4`                                                 | Concurrent build slots                            |
-| `queue_runner`       | `poll_interval`                                        | `5`                                                 | Seconds between build queue polls                 |
-| `queue_runner`       | `build_timeout`                                        | `3600`                                              | Per-build timeout (seconds)                       |
-| `queue_runner`       | `max_silent_time`                                      | `0`                                                 | Fail agent builds silent for `N` seconds          |
-| `queue_runner`       | `work_dir`                                             | `/tmp/circus-queue-runner`                          | Working directory for builds                      |
-| `queue_runner`       | `strict_errors`                                        | `false`                                             | Abort on first runner loop error                  |
-| `queue_runner`       | `failed_paths_cache`                                   | `true`                                              | Cache failed derivation paths                     |
-| `queue_runner`       | `failed_paths_ttl`                                     | `86400`                                             | TTL for failed paths cache (seconds)              |
-| `queue_runner`       | `unsupported_timeout`                                  | none                                                | Timeout for unsupported system builds             |
-| `queue_runner`       | `scheduling_strategy`                                  | `speed_factor_only`                                 | Builder selection strategy                        |
-| `queue_runner`       | `psi_threshold`                                        | none                                                | PSI pressure threshold (skip builders)            |
-| `queue_runner`       | `psi_check_timeout`                                    | `5`                                                 | SSH PSI check timeout (seconds)                   |
-| `queue_runner`       | `ssh_require_host_key`                                 | `false`                                             | Skip SSH builders without pinned host keys        |
-| `queue_runner`       | `extra_nix_build_args`                                 | `[]`                                                | Extra arguments passed to `nix build`             |
-| `queue_runner`       | `local_systems`                                        | none                                                | Systems the runner host may build locally         |
-| `queue_runner`       | `local_features`                                       | none                                                | System features available on local builds         |
-| `queue_runner`       | `rpc.bind`                                             | none                                                | Cap'n Proto RPC listen address                    |
-| `queue_runner`       | `rpc.auth_tokens`                                      | `[]`                                                | Valid authentication tokens for agents            |
-| `queue_runner`       | `rpc.max_connections`                                  | `256`                                               | Maximum concurrent agent connections              |
-| `queue_runner`       | `rpc.presign_expiry_secs`                              | `3600`                                              | Presigned URL expiry (seconds)                    |
-| `queue_runner`       | `rpc.tls`                                              | none                                                | TLS configuration for RPC endpoint                |
-| `queue_runner`       | `rpc.heartbeat_ttl_secs`                               | `60`                                                | Agent heartbeat TTL before marking unavailable    |
-| `queue_runner`       | `rpc.cache_substituter`                                | none                                                | Cache URL forwarded to agents for drv inputs      |
-| `queue_runner`       | `rpc.cache_public_key`                                 | none                                                | Public key trusted for `rpc.cache_substituter`    |
-| `queue_runner`       | `rpc.oidc.issuer`                                      | `https://token.actions.githubusercontent.com`       | OIDC issuer accepted for agent registration       |
-| `queue_runner`       | `rpc.oidc.jwks_url`                                    | discovered                                          | JWKS endpoint override                            |
-| `queue_runner`       | `rpc.oidc.audiences`                                   | `[]`                                                | Accepted OIDC audiences                           |
-| `queue_runner`       | `rpc.oidc.allowed_repositories`                        | `[]`                                                | GitHub `owner/repo` slugs allowed to register     |
-| `queue_runner`       | `rpc.oidc.allowed_subjects`                            | `[]`                                                | Exact OIDC `sub` claims allowed to register       |
-| `queue_runner`       | `rpc.oidc.allowed_subject_prefixes`                    | `[]`                                                | OIDC `sub` prefixes allowed to register           |
-| `queue_runner`       | `rpc.oidc.allowed_workflow_refs`                       | `[]`                                                | GitHub `workflow_ref` claims allowed              |
-| `queue_runner`       | `rpc.oidc.allowed_refs`                                | `[]`                                                | GitHub `ref` claims allowed                       |
-| `queue_runner`       | `ephemeral_pools`                                      | `[]`                                                | GitHub Actions ephemeral autoscaling pools        |
-| `queue_runner`       | `ephemeral_pools[].name`                               | `gha-x86_64-linux`                                  | Pool name and base agent name                     |
-| `queue_runner`       | `ephemeral_pools[].allowed_build_repositories`         | `[]`                                                | Source repositories this pool may build           |
-| `queue_runner`       | `ephemeral_pools[].systems`                            | `[ "x86_64-linux" ]`                                | Systems advertised by pool agents                 |
-| `queue_runner`       | `ephemeral_pools[].supported_features`                 | `[]`                                                | Features advertised by pool agents                |
-| `queue_runner`       | `ephemeral_pools[].mandatory_features`                 | `[]`                                                | Required build features for pool agents           |
-| `queue_runner`       | `ephemeral_pools[].max_jobs`                           | `1`                                                 | Build slots per pool agent                        |
-| `queue_runner`       | `ephemeral_pools[].cores`                              | `0`                                                 | Nix `cores` value passed to pool agents           |
-| `queue_runner`       | `ephemeral_pools[].speed_factor`                       | `1.0`                                               | Scheduling weight for pool agents                 |
-| `queue_runner`       | `ephemeral_pools[].max_inflight`                       | `4`                                                 | Maximum workflow launches waiting to register     |
-| `queue_runner`       | `ephemeral_pools[].inflight_ttl_secs`                  | `900`                                               | Time before an unregistered launch is forgotten   |
-| `queue_runner`       | `ephemeral_pools[].scale_up_cooldown_secs`             | `30`                                                | Minimum delay between autoscaler launches         |
-| `queue_runner`       | `ephemeral_pools[].poll_interval_secs`                 | `10`                                                | Autoscaler polling interval                       |
-| `queue_runner`       | `ephemeral_pools[].github_actions.workflow_repository` | `""`                                                | GitHub repo containing the builder workflow       |
-| `queue_runner`       | `ephemeral_pools[].github_actions.workflow`            | `circus-builder.yml`                                | Workflow file name or numeric workflow ID         |
-| `queue_runner`       | `ephemeral_pools[].github_actions.ref_name`            | `main`                                              | Git ref used for workflow dispatch                |
-| `queue_runner`       | `ephemeral_pools[].github_actions.token`               | none                                                | GitHub token with Actions write access            |
-| `queue_runner`       | `ephemeral_pools[].github_actions.token_file`          | none                                                | File containing the GitHub token                  |
-| `queue_runner`       | `ephemeral_pools[].github_actions.runner_url`          | `""`                                                | Runner URL passed to ephemeral agents             |
-| `queue_runner`       | `ephemeral_pools[].github_actions.oidc_audience`       | `circus-agent`                                      | Audience requested by the builder workflow        |
-| `queue_runner`       | `ephemeral_pools[].github_actions.agent_binary_url`    | `""`                                                | Pinned `circus-agent` binary URL                  |
-| `gc`                 | `enabled`                                              | `true`                                              | Manage GC roots for build outputs                 |
-| `gc`                 | `gc_roots_dir`                                         | `/nix/var/nix/gcroots/per-user/circus/circus-roots` | GC roots directory                                |
-| `gc`                 | `max_age_days`                                         | `30`                                                | Remove GC roots older than N days                 |
-| `gc`                 | `cleanup_interval`                                     | `3600`                                              | GC cleanup interval (seconds)                     |
-| `logs`               | `log_dir`                                              | `/var/lib/circus/logs`                              | Build log storage directory                       |
-| `logs`               | `compress`                                             | `false`                                             | Compress stored logs                              |
-| `cache`              | `enabled`                                              | `true`                                              | Serve a Nix binary cache at `/nix-cache/`         |
-| `cache`              | `secret_key_file`                                      | none                                                | Deprecated; outputs are signed via `[signing]`    |
-| `cache`              | `cache_url`                                            | none                                                | Public cache URL for channel manifests            |
-| `cache`              | `upstreams`                                            | `[]`                                                | Upstream binary caches used by global builds      |
-| `signing`            | `enabled`                                              | `false`                                             | Sign build outputs                                |
-| `signing`            | `key_file`                                             | none                                                | Signing key file path                             |
-| `cache_upload`       | `enabled`                                              | `false`                                             | Upload builds to external cache store             |
-| `cache_upload`       | `store_uri`                                            | none                                                | Cache store URI (`s3://bucket/path`)              |
-| `cache_upload`       | `s3.region`                                            | none                                                | AWS region                                        |
-| `cache_upload`       | `s3.prefix`                                            | none                                                | Extra path prefix within bucket                   |
-| `cache_upload`       | `s3.access_key_id`                                     | none                                                | Access key for presigned S3 uploads/redirects     |
-| `cache_upload`       | `s3.secret_access_key`                                 | none                                                | Secret key for presigned S3 uploads/redirects     |
-| `cache_upload`       | `s3.secret_access_key_file`                            | none                                                | File containing S3 secret access key              |
-| `cache_upload`       | `s3.session_token`                                     | none                                                | Session token for temporary credentials           |
-| `cache_upload`       | `s3.session_token_file`                                | none                                                | File containing S3 session token                  |
-| `cache_upload`       | `s3.endpoint_url`                                      | none                                                | S3-compatible endpoint URL                        |
-| `cache_upload`       | `s3.use_path_style`                                    | `false`                                             | Use path-style addressing                         |
-| `cache_upload`       | `upload_concurrency`                                   | `4`                                                 | Concurrent uploads per build                      |
-| `cache_upload`       | `upload_max_retries`                                   | `3`                                                 | Max retry attempts per path                       |
-| `cache_upload`       | `fail_build_on_upload_error`                           | `false`                                             | Mark build failed on upload error                 |
-| `cache_upload`       | `compression`                                          | `zstd`                                              | Agent presigned-upload NAR compression            |
-| `notifications`      | `webhook_url`                                          | none                                                | HTTP endpoint for build status JSON               |
-| `notifications`      | `webhook_url_file`                                     | none                                                | File containing generic webhook URL               |
-| `notifications`      | `github_token`                                         | none                                                | GitHub token for commit status updates            |
-| `notifications`      | `github_token_file`                                    | none                                                | File containing GitHub token                      |
-| `notifications`      | `gitea_url`                                            | none                                                | Gitea/Forgejo instance URL                        |
-| `notifications`      | `gitea_token`                                          | none                                                | Gitea/Forgejo API token                           |
-| `notifications`      | `gitea_token_file`                                     | none                                                | File containing Gitea/Forgejo token               |
-| `notifications`      | `gitlab_url`                                           | none                                                | GitLab instance URL                               |
-| `notifications`      | `gitlab_token`                                         | none                                                | GitLab API token                                  |
-| `notifications`      | `gitlab_token_file`                                    | none                                                | File containing GitLab token                      |
-| `notifications`      | `enable_retry_queue`                                   | `true`                                              | Persistent retry queue with backoff               |
-| `notifications`      | `max_retry_attempts`                                   | `5`                                                 | Max notification retry attempts                   |
-| `notifications`      | `retention_days`                                       | `7`                                                 | Retention for completed notification tasks        |
-| `notifications`      | `retry_poll_interval`                                  | `5`                                                 | Retry poll interval (seconds)                     |
-| `notifications`      | `email.smtp_host`                                      | none                                                | SMTP host for email notifications                 |
-| `notifications`      | `email.smtp_port`                                      | none                                                | SMTP port                                         |
-| `notifications`      | `email.smtp_user`                                      | none                                                | SMTP username (optional)                          |
-| `notifications`      | `email.smtp_password`                                  | none                                                | SMTP password (optional)                          |
-| `notifications`      | `email.smtp_password_file`                             | none                                                | File containing SMTP password                     |
-| `notifications`      | `email.tls`                                            | `false`                                             | Enable TLS for SMTP connection                    |
-| `notifications`      | `email.from_address`                                   | none                                                | From address for notification emails              |
-| `notifications`      | `email.to_addresses`                                   | `[]`                                                | Recipient addresses                               |
-| `notifications`      | `slack.webhook_url`                                    | none                                                | Slack incoming webhook URL                        |
-| `notifications`      | `slack.webhook_url_file`                               | none                                                | File containing Slack webhook URL                 |
-| `notifications`      | `slack.on_failure_only`                                | `false`                                             | Only send Slack alerts on failure                 |
-| `notifications`      | `alerts.enabled`                                       | `false`                                             | Enable error-rate threshold alerts                |
-| `notifications`      | `alerts.error_threshold`                               | `0.5`                                               | Error rate threshold to trigger alert             |
-| `notifications`      | `alerts.time_window_minutes`                           | `60`                                                | Time window for error rate calculation            |
-| `tracing`            | `level`                                                | `info`                                              | Log level (trace/debug/info/warn/error)           |
-| `tracing`            | `format`                                               | `compact`                                           | Log output format                                 |
-| `tracing`            | `show_targets`                                         | `true`                                              | Show module path in log messages                  |
-| `tracing`            | `show_timestamps`                                      | `true`                                              | Show timestamps in log messages                   |
-| `oauth`              | `github.client_id`                                     | none                                                | GitHub OAuth App client ID                        |
-| `oauth`              | `github.client_secret`                                 | none                                                | GitHub OAuth App client secret                    |
-| `oauth`              | `github.client_secret_file`                            | none                                                | File containing GitHub OAuth secret               |
-| `oauth`              | `github.redirect_uri`                                  | none                                                | OAuth redirect URI                                |
-| `declarative`        | `projects`                                             | `[]`                                                | Declarative project definitions                   |
-| `declarative`        | `api_keys`                                             | `[]`                                                | Declarative API key definitions                   |
-| `declarative`        | `users`                                                | `[]`                                                | Declarative user definitions                      |
-| `declarative`        | `remote_builders`                                      | `[]`                                                | Declarative remote builder definitions            |
-| `nix`                | `store_dir`                                            | `/nix/store`                                        | Nix store directory                               |
+| Section              | Key                                                    | Default                                             | Description                                                               |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------- |
+| `database`           | `url`                                                  | `postgresql://circus:password@localhost/circus`     | PostgreSQL connection URL                                                 |
+| `database`           | `url_file`                                             | none                                                | File containing the PostgreSQL URL                                        |
+| `database`           | `max_connections`                                      | `20`                                                | Maximum connection pool size                                              |
+| `database`           | `min_connections`                                      | `5`                                                 | Minimum idle connections                                                  |
+| `database`           | `connect_timeout`                                      | `30`                                                | Connection timeout (seconds)                                              |
+| `database`           | `idle_timeout`                                         | `600`                                               | Idle connection timeout (seconds)                                         |
+| `database`           | `max_lifetime`                                         | `1800`                                              | Maximum connection lifetime (seconds)                                     |
+| `server`             | `host`                                                 | `127.0.0.1`                                         | HTTP listen address                                                       |
+| `server`             | `port`                                                 | `3000`                                              | HTTP listen port                                                          |
+| `server`             | `request_timeout`                                      | `30`                                                | Per-request timeout (seconds)                                             |
+| `server`             | `max_body_size`                                        | `10485760`                                          | Maximum request body size (10 MB)                                         |
+| `server`             | `api_key`                                              | none                                                | Optional legacy API key (prefer DB keys)                                  |
+| `server`             | `api_key_file`                                         | none                                                | File containing the optional legacy API key                               |
+| `server`             | `cors_permissive`                                      | `false`                                             | Allow all CORS origins                                                    |
+| `server`             | `allowed_origins`                                      | `[]`                                                | Allowed CORS origins list                                                 |
+| `server`             | `force_secure_cookies`                                 | `false`                                             | Force Secure flag on cookies (HTTPS proxy)                                |
+| `server`             | `rate_limit_rps`                                       | none                                                | Requests per second limit per IP                                          |
+| `server`             | `rate_limit_burst`                                     | none                                                | Burst size for rate limiting                                              |
+| `server`             | `allowed_url_schemes`                                  | `[ "https", "git", "ssh" ]`                         | Allowed URL schemes for repository URLs                                   |
+| `server`             | `config_editor_enabled`                                | `false`                                             | Allow admin config editing through API/dashboard                          |
+| `server`             | `require_api_key_for_reads`                            | `true`                                              | Require auth for read-only `/api/v1` requests                             |
+| `server`             | `openapi_enabled`                                      | `true`                                              | Serve `/api/v1/openapi.json`                                              |
+| `server`             | `webhook_secret_encryption_key`                        | none                                                | Encrypt webhook and notification secrets                                  |
+| `server`             | `webhook_secret_encryption_key_file`                   | none                                                | File containing the encryption key                                        |
+| `server`             | `ldap.enabled`                                         | `true`                                              | Enable configured LDAP login                                              |
+| `server`             | `ldap.url`                                             | none                                                | LDAP server URL                                                           |
+| `server`             | `ldap.bind_dn_template`                                | none                                                | LDAP bind DN template (`{username}` placeholder)                          |
+| `server`             | `ldap.base_dn`                                         | none                                                | LDAP base DN for user searches                                            |
+| `server`             | `ldap.tls_ca_cert`                                     | none                                                | Custom CA cert for LDAP TLS                                               |
+| `server`             | `email_validation_regex`                               | none                                                | Custom regex for email validation                                         |
+| `server.page_access` | per page                                               | mixed                                               | Dashboard page visibility policy                                          |
+| `ui`                 | `enabled`                                              | `true`                                              | Mount bundled dashboard and static UI routes                              |
+| `ui`                 | `dashboard`                                            | `true`                                              | Mount server-rendered dashboard/login pages                               |
+| `ui`                 | `assets`                                               | `true`                                              | Serve bundled static UI assets                                            |
+| `ui`                 | `brand_name`                                           | `circus`                                            | Dashboard sidebar brand name                                              |
+| `ui`                 | `brand_subtitle`                                       | `Nix CI`                                            | Dashboard sidebar brand subtitle                                          |
+| `ui`                 | `logo_url`                                             | none                                                | Optional logo URL                                                         |
+| `ui`                 | `favicon_url`                                          | none                                                | Optional favicon URL                                                      |
+| `ui`                 | `custom_css`                                           | none                                                | CSS file served as `/static/custom.css`                                   |
+| `ui`                 | `static_dir`                                           | none                                                | Directory served below `/static/custom/`                                  |
+| `ui.css_variables`   | CSS variable names                                     | `{}`                                                | Variables emitted in `/static/theme.css`                                  |
+| `evaluator`          | `poll_interval`                                        | `60`                                                | Seconds between git poll cycles                                           |
+| `evaluator`          | `git_timeout`                                          | `600`                                               | Git operation timeout (seconds)                                           |
+| `evaluator`          | `nix_timeout`                                          | `1800`                                              | Nix evaluation timeout (seconds)                                          |
+| `evaluator`          | `max_eval_time`                                        | none                                                | Optional total evaluation limit (seconds); timeout is recorded distinctly |
+| `evaluator`          | `max_concurrent_evals`                                 | `4`                                                 | Maximum concurrent evaluations                                            |
+| `evaluator`          | `work_dir`                                             | `/tmp/circus-evaluator`                             | Working directory for clones                                              |
+| `evaluator`          | `restrict_eval`                                        | `true`                                              | Pass `--option restrict-eval true` to Nix                                 |
+| `evaluator`          | `allow_ifd`                                            | `false`                                             | Allow import-from-derivation                                              |
+| `evaluator`          | `auto_allowed_uris`                                    | `true`                                              | Derive `allowed-uris` from the jobset flake.lock                          |
+| `evaluator`          | `allowed_uris`                                         | `[]`                                                | Extra fetch URIs honored under `restrict_eval`                            |
+| `evaluator`          | `require_locked_flake`                                 | `false`                                             | Refuse flake jobsets with no committed flake.lock                         |
+| `evaluator`          | `strict_errors`                                        | `false`                                             | Abort on first evaluation cycle error                                     |
+| `queue_runner`       | `workers`                                              | `4`                                                 | Concurrent build slots                                                    |
+| `queue_runner`       | `poll_interval`                                        | `5`                                                 | Seconds between build queue polls                                         |
+| `queue_runner`       | `build_timeout`                                        | `3600`                                              | Per-build timeout (seconds)                                               |
+| `queue_runner`       | `max_silent_time`                                      | `0`                                                 | Fail agent builds silent for `N` seconds                                  |
+| `queue_runner`       | `work_dir`                                             | `/tmp/circus-queue-runner`                          | Working directory for builds                                              |
+| `queue_runner`       | `strict_errors`                                        | `false`                                             | Abort on first runner loop error                                          |
+| `queue_runner`       | `failed_paths_cache`                                   | `true`                                              | Cache failed derivation paths                                             |
+| `queue_runner`       | `failed_paths_ttl`                                     | `86400`                                             | TTL for failed paths cache (seconds)                                      |
+| `queue_runner`       | `unsupported_timeout`                                  | none                                                | Timeout for unsupported system builds                                     |
+| `queue_runner`       | `scheduling_strategy`                                  | `speed_factor_only`                                 | Builder selection strategy                                                |
+| `queue_runner`       | `psi_threshold`                                        | none                                                | PSI pressure threshold (skip builders)                                    |
+| `queue_runner`       | `psi_check_timeout`                                    | `5`                                                 | SSH PSI check timeout (seconds)                                           |
+| `queue_runner`       | `ssh_require_host_key`                                 | `false`                                             | Skip SSH builders without pinned host keys                                |
+| `queue_runner`       | `extra_nix_build_args`                                 | `[]`                                                | Extra arguments passed to `nix build`                                     |
+| `queue_runner`       | `local_systems`                                        | none                                                | Systems the runner host may build locally                                 |
+| `queue_runner`       | `local_features`                                       | none                                                | System features available on local builds                                 |
+| `queue_runner`       | `rpc.bind`                                             | none                                                | Cap'n Proto RPC listen address                                            |
+| `queue_runner`       | `rpc.auth_tokens`                                      | `[]`                                                | Valid authentication tokens for agents                                    |
+| `queue_runner`       | `rpc.max_connections`                                  | `256`                                               | Maximum concurrent agent connections                                      |
+| `queue_runner`       | `rpc.presign_expiry_secs`                              | `3600`                                              | Presigned URL expiry (seconds)                                            |
+| `queue_runner`       | `rpc.tls`                                              | none                                                | TLS configuration for RPC endpoint                                        |
+| `queue_runner`       | `rpc.heartbeat_ttl_secs`                               | `60`                                                | Agent heartbeat TTL before marking unavailable                            |
+| `queue_runner`       | `rpc.cache_substituter`                                | none                                                | Cache URL forwarded to agents for drv inputs                              |
+| `queue_runner`       | `rpc.cache_public_key`                                 | none                                                | Public key trusted for `rpc.cache_substituter`                            |
+| `queue_runner`       | `rpc.oidc.issuer`                                      | `https://token.actions.githubusercontent.com`       | OIDC issuer accepted for agent registration                               |
+| `queue_runner`       | `rpc.oidc.jwks_url`                                    | discovered                                          | JWKS endpoint override                                                    |
+| `queue_runner`       | `rpc.oidc.audiences`                                   | `[]`                                                | Accepted OIDC audiences                                                   |
+| `queue_runner`       | `rpc.oidc.allowed_repositories`                        | `[]`                                                | GitHub `owner/repo` slugs allowed to register                             |
+| `queue_runner`       | `rpc.oidc.allowed_subjects`                            | `[]`                                                | Exact OIDC `sub` claims allowed to register                               |
+| `queue_runner`       | `rpc.oidc.allowed_subject_prefixes`                    | `[]`                                                | OIDC `sub` prefixes allowed to register                                   |
+| `queue_runner`       | `rpc.oidc.allowed_workflow_refs`                       | `[]`                                                | GitHub `workflow_ref` claims allowed                                      |
+| `queue_runner`       | `rpc.oidc.allowed_refs`                                | `[]`                                                | GitHub `ref` claims allowed                                               |
+| `queue_runner`       | `ephemeral_pools`                                      | `[]`                                                | GitHub Actions ephemeral autoscaling pools                                |
+| `queue_runner`       | `ephemeral_pools[].name`                               | `gha-x86_64-linux`                                  | Pool name and base agent name                                             |
+| `queue_runner`       | `ephemeral_pools[].allowed_build_repositories`         | `[]`                                                | Source repositories this pool may build                                   |
+| `queue_runner`       | `ephemeral_pools[].systems`                            | `[ "x86_64-linux" ]`                                | Systems advertised by pool agents                                         |
+| `queue_runner`       | `ephemeral_pools[].supported_features`                 | `[]`                                                | Features advertised by pool agents                                        |
+| `queue_runner`       | `ephemeral_pools[].mandatory_features`                 | `[]`                                                | Required build features for pool agents                                   |
+| `queue_runner`       | `ephemeral_pools[].max_jobs`                           | `1`                                                 | Build slots per pool agent                                                |
+| `queue_runner`       | `ephemeral_pools[].cores`                              | `0`                                                 | Nix `cores` value passed to pool agents                                   |
+| `queue_runner`       | `ephemeral_pools[].speed_factor`                       | `1.0`                                               | Scheduling weight for pool agents                                         |
+| `queue_runner`       | `ephemeral_pools[].max_inflight`                       | `4`                                                 | Maximum workflow launches waiting to register                             |
+| `queue_runner`       | `ephemeral_pools[].inflight_ttl_secs`                  | `900`                                               | Time before an unregistered launch is forgotten                           |
+| `queue_runner`       | `ephemeral_pools[].scale_up_cooldown_secs`             | `30`                                                | Minimum delay between autoscaler launches                                 |
+| `queue_runner`       | `ephemeral_pools[].poll_interval_secs`                 | `10`                                                | Autoscaler polling interval                                               |
+| `queue_runner`       | `ephemeral_pools[].github_actions.workflow_repository` | `""`                                                | GitHub repo containing the builder workflow                               |
+| `queue_runner`       | `ephemeral_pools[].github_actions.workflow`            | `circus-builder.yml`                                | Workflow file name or numeric workflow ID                                 |
+| `queue_runner`       | `ephemeral_pools[].github_actions.ref_name`            | `main`                                              | Git ref used for workflow dispatch                                        |
+| `queue_runner`       | `ephemeral_pools[].github_actions.token`               | none                                                | GitHub token with Actions write access                                    |
+| `queue_runner`       | `ephemeral_pools[].github_actions.token_file`          | none                                                | File containing the GitHub token                                          |
+| `queue_runner`       | `ephemeral_pools[].github_actions.runner_url`          | `""`                                                | Runner URL passed to ephemeral agents                                     |
+| `queue_runner`       | `ephemeral_pools[].github_actions.oidc_audience`       | `circus-agent`                                      | Audience requested by the builder workflow                                |
+| `queue_runner`       | `ephemeral_pools[].github_actions.agent_binary_url`    | `""`                                                | Pinned `circus-agent` binary URL                                          |
+| `gc`                 | `enabled`                                              | `true`                                              | Manage GC roots for build outputs                                         |
+| `gc`                 | `gc_roots_dir`                                         | `/nix/var/nix/gcroots/per-user/circus/circus-roots` | GC roots directory                                                        |
+| `gc`                 | `max_age_days`                                         | `30`                                                | Remove GC roots older than N days                                         |
+| `gc`                 | `cleanup_interval`                                     | `3600`                                              | GC cleanup interval (seconds)                                             |
+| `logs`               | `log_dir`                                              | `/var/lib/circus/logs`                              | Build log storage directory                                               |
+| `logs`               | `compress`                                             | `false`                                             | Compress stored logs                                                      |
+| `cache`              | `enabled`                                              | `true`                                              | Serve a Nix binary cache at `/nix-cache/`                                 |
+| `cache`              | `secret_key_file`                                      | none                                                | Deprecated; outputs are signed via `[signing]`                            |
+| `cache`              | `cache_url`                                            | none                                                | Public cache URL for channel manifests                                    |
+| `cache`              | `upstreams`                                            | `[]`                                                | Upstream binary caches used by global builds                              |
+| `signing`            | `enabled`                                              | `false`                                             | Sign build outputs                                                        |
+| `signing`            | `key_file`                                             | none                                                | Signing key file path                                                     |
+| `cache_upload`       | `enabled`                                              | `false`                                             | Upload builds to external cache store                                     |
+| `cache_upload`       | `store_uri`                                            | none                                                | Cache store URI (`s3://bucket/path`)                                      |
+| `cache_upload`       | `s3.region`                                            | none                                                | AWS region                                                                |
+| `cache_upload`       | `s3.prefix`                                            | none                                                | Extra path prefix within bucket                                           |
+| `cache_upload`       | `s3.access_key_id`                                     | none                                                | Access key for presigned S3 uploads/redirects                             |
+| `cache_upload`       | `s3.secret_access_key`                                 | none                                                | Secret key for presigned S3 uploads/redirects                             |
+| `cache_upload`       | `s3.secret_access_key_file`                            | none                                                | File containing S3 secret access key                                      |
+| `cache_upload`       | `s3.session_token`                                     | none                                                | Session token for temporary credentials                                   |
+| `cache_upload`       | `s3.session_token_file`                                | none                                                | File containing S3 session token                                          |
+| `cache_upload`       | `s3.endpoint_url`                                      | none                                                | S3-compatible endpoint URL                                                |
+| `cache_upload`       | `s3.use_path_style`                                    | `false`                                             | Use path-style addressing                                                 |
+| `cache_upload`       | `upload_concurrency`                                   | `4`                                                 | Concurrent uploads per build                                              |
+| `cache_upload`       | `upload_max_retries`                                   | `3`                                                 | Max retry attempts per path                                               |
+| `cache_upload`       | `fail_build_on_upload_error`                           | `false`                                             | Mark build failed on upload error                                         |
+| `cache_upload`       | `compression`                                          | `zstd`                                              | Agent presigned-upload NAR compression                                    |
+| `notifications`      | `webhook_url`                                          | none                                                | HTTP endpoint for build status JSON                                       |
+| `notifications`      | `webhook_url_file`                                     | none                                                | File containing generic webhook URL                                       |
+| `notifications`      | `github_token`                                         | none                                                | GitHub token for commit status updates                                    |
+| `notifications`      | `github_token_file`                                    | none                                                | File containing GitHub token                                              |
+| `notifications`      | `gitea_url`                                            | none                                                | Gitea/Forgejo instance URL                                                |
+| `notifications`      | `gitea_token`                                          | none                                                | Gitea/Forgejo API token                                                   |
+| `notifications`      | `gitea_token_file`                                     | none                                                | File containing Gitea/Forgejo token                                       |
+| `notifications`      | `gitlab_url`                                           | none                                                | GitLab instance URL                                                       |
+| `notifications`      | `gitlab_token`                                         | none                                                | GitLab API token                                                          |
+| `notifications`      | `gitlab_token_file`                                    | none                                                | File containing GitLab token                                              |
+| `notifications`      | `enable_retry_queue`                                   | `true`                                              | Persistent retry queue with backoff                                       |
+| `notifications`      | `max_retry_attempts`                                   | `5`                                                 | Max notification retry attempts                                           |
+| `notifications`      | `retention_days`                                       | `7`                                                 | Retention for completed notification tasks                                |
+| `notifications`      | `retry_poll_interval`                                  | `5`                                                 | Retry poll interval (seconds)                                             |
+| `notifications`      | `email.smtp_host`                                      | none                                                | SMTP host for email notifications                                         |
+| `notifications`      | `email.smtp_port`                                      | none                                                | SMTP port                                                                 |
+| `notifications`      | `email.smtp_user`                                      | none                                                | SMTP username (optional)                                                  |
+| `notifications`      | `email.smtp_password`                                  | none                                                | SMTP password (optional)                                                  |
+| `notifications`      | `email.smtp_password_file`                             | none                                                | File containing SMTP password                                             |
+| `notifications`      | `email.tls`                                            | `false`                                             | Enable TLS for SMTP connection                                            |
+| `notifications`      | `email.from_address`                                   | none                                                | From address for notification emails                                      |
+| `notifications`      | `email.to_addresses`                                   | `[]`                                                | Recipient addresses                                                       |
+| `notifications`      | `slack.webhook_url`                                    | none                                                | Slack incoming webhook URL                                                |
+| `notifications`      | `slack.webhook_url_file`                               | none                                                | File containing Slack webhook URL                                         |
+| `notifications`      | `slack.on_failure_only`                                | `false`                                             | Only send Slack alerts on failure                                         |
+| `notifications`      | `alerts.enabled`                                       | `false`                                             | Enable error-rate threshold alerts                                        |
+| `notifications`      | `alerts.error_threshold`                               | `0.5`                                               | Error rate threshold to trigger alert                                     |
+| `notifications`      | `alerts.time_window_minutes`                           | `60`                                                | Time window for error rate calculation                                    |
+| `tracing`            | `level`                                                | `info`                                              | Log level (trace/debug/info/warn/error)                                   |
+| `tracing`            | `format`                                               | `compact`                                           | Log output format                                                         |
+| `tracing`            | `show_targets`                                         | `true`                                              | Show module path in log messages                                          |
+| `tracing`            | `show_timestamps`                                      | `true`                                              | Show timestamps in log messages                                           |
+| `oauth`              | `github.client_id`                                     | none                                                | GitHub OAuth App client ID                                                |
+| `oauth`              | `github.client_secret`                                 | none                                                | GitHub OAuth App client secret                                            |
+| `oauth`              | `github.client_secret_file`                            | none                                                | File containing GitHub OAuth secret                                       |
+| `oauth`              | `github.redirect_uri`                                  | none                                                | OAuth redirect URI                                                        |
+| `declarative`        | `projects`                                             | `[]`                                                | Declarative project definitions                                           |
+| `declarative`        | `api_keys`                                             | `[]`                                                | Declarative API key definitions                                           |
+| `declarative`        | `users`                                                | `[]`                                                | Declarative user definitions                                              |
+| `declarative`        | `remote_builders`                                      | `[]`                                                | Declarative remote builder definitions                                    |
+| `nix`                | `store_dir`                                            | `/nix/store`                                        | Nix store directory                                                       |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/nix/common/base.nix
+++ b/nix/common/base.nix
@@ -71,7 +71,6 @@ in {
         work_dir = "/var/lib/circus/evaluator";
         nix_timeout = 60;
         strict_errors = true;
-        eval_workers = 1;
       };
 
       queue_runner = {

--- a/nix/common/base.nix
+++ b/nix/common/base.nix
@@ -71,6 +71,7 @@ in {
         work_dir = "/var/lib/circus/evaluator";
         nix_timeout = 60;
         strict_errors = true;
+        eval_workers = 1;
       };
 
       queue_runner = {

--- a/nix/common/vm.nix
+++ b/nix/common/vm.nix
@@ -4,7 +4,7 @@
 
   config = {
     virtualisation = {
-      memorySize = 4096;
+      memorySize = 2048;
       cores = 2;
       diskSize = 10000;
       graphics = false;

--- a/nix/common/vm.nix
+++ b/nix/common/vm.nix
@@ -4,7 +4,7 @@
 
   config = {
     virtualisation = {
-      memorySize = 2048;
+      memorySize = 4096;
       cores = 2;
       diskSize = 10000;
       graphics = false;

--- a/nix/tests/e2e.nix
+++ b/nix/tests/e2e.nix
@@ -150,6 +150,7 @@ testers.runNixOSTest {
             f"curl -sf 'http://127.0.0.1:3000/api/v1/builds?evaluation_id={e2e_eval_id}' | jq -r '.items[0].drv_path'"
         ).strip()
         assert drv_path.startswith("/nix/store/"), f"Expected /nix/store/ drv_path, got '{drv_path}'"
+        e2e_drv_path = drv_path
 
         # Get the build ID for later
         e2e_build_id = machine.succeed(
@@ -197,12 +198,26 @@ testers.runNixOSTest {
         )
         machine.succeed("cd /tmp/test-flake-work && git add -A && git commit -m 'v2 update'")
         machine.succeed("cd /tmp/test-flake-work && git push origin HEAD:refs/heads/master")
+        updated_commit = machine.succeed(
+            "cd /tmp/test-flake-work && git rev-parse HEAD"
+        ).strip()
 
-        # Wait for evaluator to detect and create new evaluation
+        # Wait for this commit, rather than the older completed evaluation.
         machine.wait_until_succeeds(
-            f"test $(curl -sf 'http://127.0.0.1:3000/api/v1/evaluations?jobset_id={e2e_jobset_id}' | jq '.items | length') -gt {before_count_int}",
+            f"curl -sf 'http://127.0.0.1:3000/api/v1/evaluations?jobset_id={e2e_jobset_id}' "
+            f"| jq -e '.items[] | select(.commit_hash==\"{updated_commit}\" and .status==\"completed\")'",
             timeout=60
         )
+        updated_eval_id = machine.succeed(
+            f"curl -sf 'http://127.0.0.1:3000/api/v1/evaluations?jobset_id={e2e_jobset_id}' "
+            f"| jq -r '.items[] | select(.commit_hash==\"{updated_commit}\" and .status==\"completed\") | .id'"
+        ).strip()
+        updated_drv_path = machine.succeed(
+            f"curl -sf 'http://127.0.0.1:3000/api/v1/builds?evaluation_id={updated_eval_id}' "
+            "| jq -r '.items[0].drv_path'"
+        ).strip()
+        assert updated_drv_path != e2e_drv_path, \
+            "Expected the updated commit to produce a different derivation"
 
     with subtest("Queue runner builds pending derivation"):
         # Poll the E2E build until succeeded (queue-runner is already running)


### PR DESCRIPTION
Updates the `evix` to the latest version and refactors the Nix evaluation logic to use the new asynchronous streaming API provided by `evix`.  This makes the evaluation code slightly simpler and with my latest changes in nix-bindings the error handling for evaluations is improved slightly.

Change-Id: I6d77fd62f962d4b2ad9c7f42d8de44356a6a6964