### PR TITLE
queue-runner: avoid duplicate derivation dispatch

### DIFF
--- a/crates/common/src/repo/builds.rs
+++ b/crates/common/src/repo/builds.rs
@@ -145,13 +145,15 @@ pub async fn list_pending(
       "WITH eligible_pending AS ( SELECT b.* FROM builds b WHERE b.status = \
        'pending' AND NOT EXISTS ( SELECT 1 FROM build_dependencies bd JOIN \
        builds dep ON dep.id = bd.dependency_build_id WHERE bd.build_id = b.id \
-       AND dep.status != 'succeeded' ) ), running_counts AS ( SELECT \
-       e.jobset_id, COUNT(*) AS running FROM builds b JOIN evaluations e ON \
-       b.evaluation_id = e.id WHERE b.status = 'running' GROUP BY e.jobset_id \
-       ), active_shares AS ( SELECT j.id AS jobset_id, j.scheduling_shares, \
-       COALESCE(rc.running, 0) AS running, SUM(j.scheduling_shares) OVER () \
-       AS total_shares FROM jobsets j JOIN evaluations e2 ON e2.jobset_id = \
-       j.id JOIN eligible_pending b2 ON b2.evaluation_id = e2.id LEFT JOIN \
+       AND dep.status != 'succeeded' ) AND NOT EXISTS ( SELECT 1 FROM builds \
+       active WHERE active.drv_path = b.drv_path AND active.status = \
+       'running' ) ), running_counts AS ( SELECT e.jobset_id, COUNT(*) AS \
+       running FROM builds b JOIN evaluations e ON b.evaluation_id = e.id \
+       WHERE b.status = 'running' GROUP BY e.jobset_id ), active_shares AS ( \
+       SELECT j.id AS jobset_id, j.scheduling_shares, COALESCE(rc.running, 0) \
+       AS running, SUM(j.scheduling_shares) OVER () AS total_shares FROM \
+       jobsets j JOIN evaluations e2 ON e2.jobset_id = j.id JOIN \
+       eligible_pending b2 ON b2.evaluation_id = e2.id LEFT JOIN \
        running_counts rc ON rc.jobset_id = j.id WHERE j.scheduling_shares > 0 \
        GROUP BY j.id, j.scheduling_shares, rc.running ) SELECT b.* FROM \
        eligible_pending b JOIN evaluations e ON b.evaluation_id = e.id JOIN \
@@ -168,7 +170,9 @@ pub async fn list_pending(
   )
 }
 
-/// Atomically claim a pending build by setting it to running.
+/// Atomically claim a pending build by setting it to running. The advisory
+/// lock and the running twin check keep duplicate pending builds of one
+/// `drv_path` from both dispatching.
 ///
 /// # Returns
 ///
@@ -180,10 +184,13 @@ pub async fn list_pending(
 pub async fn start(pool: &PgPool, id: Uuid) -> Result<Option<Build>> {
   Ok(
     sqlx::query_as::<_, Build>(
-      "WITH candidate AS ( SELECT id FROM builds WHERE id = $1 AND status = \
-       'pending' FOR UPDATE SKIP LOCKED ) UPDATE builds SET status = \
-       'running', started_at = NOW() FROM candidate WHERE builds.id = \
-       candidate.id RETURNING builds.*",
+      "WITH candidate AS ( SELECT b.id FROM builds b WHERE b.id = $1 AND \
+       b.status = 'pending' AND \
+       pg_try_advisory_xact_lock(hashtextextended(b.drv_path, 0)) AND NOT \
+       EXISTS ( SELECT 1 FROM builds active WHERE active.drv_path = \
+       b.drv_path AND active.status = 'running' ) FOR UPDATE SKIP LOCKED ) \
+       UPDATE builds SET status = 'running', started_at = NOW() FROM \
+       candidate WHERE builds.id = candidate.id RETURNING builds.*",
     )
     .bind(id)
     .fetch_optional(pool)
@@ -400,6 +407,30 @@ pub async fn get_stats(pool: &PgPool) -> Result<BuildStats> {
   }
 }
 
+/// Reset builds that were left in 'running' state, excluding IDs that are
+/// known to still be active in the current runner process.
+///
+/// # Errors
+///
+/// Returns error if database update fails.
+pub async fn reset_orphaned_excluding(
+  pool: &PgPool,
+  older_than_secs: i64,
+  excluded_ids: &[Uuid],
+) -> Result<u64> {
+  let result = sqlx::query(
+    "UPDATE builds SET status = 'pending', started_at = NULL, \
+     effective_features = NULL WHERE status = 'running' AND started_at < \
+     NOW() - make_interval(secs => $1) AND NOT (id = ANY($2))",
+  )
+  .bind(older_than_secs)
+  .bind(excluded_ids)
+  .execute(pool)
+  .await?;
+
+  Ok(result.rows_affected())
+}
+
 /// Reset builds that were left in 'running' state (orphaned by a crashed
 /// runner). Resets every row older than the threshold; the caller is
 /// expected to run this periodically so a crash that orphans many builds
@@ -412,16 +443,7 @@ pub async fn reset_orphaned(
   pool: &PgPool,
   older_than_secs: i64,
 ) -> Result<u64> {
-  let result = sqlx::query(
-    "UPDATE builds SET status = 'pending', started_at = NULL, \
-     effective_features = NULL WHERE status = 'running' AND started_at < \
-     NOW() - make_interval(secs => $1)",
-  )
-  .bind(older_than_secs)
-  .execute(pool)
-  .await?;
-
-  Ok(result.rows_affected())
+  reset_orphaned_excluding(pool, older_than_secs, &[]).await
 }
 
 /// List builds with optional `evaluation_id`, status, system, and `job_name`

--- a/crates/common/tests/repo_tests.rs
+++ b/crates/common/tests/repo_tests.rs
@@ -535,6 +535,64 @@ async fn test_evaluation_and_build_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_start_blocks_duplicate_running_drv_path() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "duplicate-drv").await;
+  let jobset = create_test_jobset(&pool, project.id).await;
+  let eval = create_test_eval(&pool, jobset.id).await;
+  let drv = format!("/nix/store/{}.drv", uuid::Uuid::new_v4().simple());
+
+  let first =
+    create_test_build(&pool, eval.id, "first", &drv, Some("x86_64-linux"))
+      .await;
+  let second =
+    create_test_build(&pool, eval.id, "second", &drv, Some("x86_64-linux"))
+      .await;
+
+  let claimed_first = repo::builds::start(&pool, first.id)
+    .await
+    .expect("start first build");
+  assert!(claimed_first.is_some());
+
+  let pending = repo::builds::list_pending(&pool, 10, 4)
+    .await
+    .expect("list pending");
+  assert!(!pending.iter().any(|build| build.id == second.id));
+
+  let claimed_second = repo::builds::start(&pool, second.id)
+    .await
+    .expect("start second build");
+  assert!(claimed_second.is_none());
+
+  let second = repo::builds::get(&pool, second.id)
+    .await
+    .expect("reload second build");
+  assert!(matches!(second.status, BuildStatus::Pending));
+
+  repo::builds::complete(
+    &pool,
+    first.id,
+    BuildStatus::Succeeded,
+    None,
+    None,
+    None,
+  )
+  .await
+  .expect("complete first build");
+
+  let claimed_second = repo::builds::start(&pool, second.id)
+    .await
+    .expect("start second build after first completed");
+  assert!(claimed_second.is_some());
+
+  // Cleanup
+  let _ = repo::projects::delete(&pool, project.id).await;
+}
+
+#[tokio::test]
 async fn test_not_found_errors() {
   let Some(pool) = get_pool().await else {
     return;
@@ -916,6 +974,68 @@ async fn test_reset_orphaned_batch_limit() {
   let build = repo::builds::get(&pool, build.id).await.expect("get build");
   assert!(matches!(build.status, BuildStatus::Pending));
   assert!(build.started_at.is_none());
+
+  // Cleanup
+  let _ = repo::projects::delete(&pool, project.id).await;
+}
+
+#[tokio::test]
+async fn test_reset_orphaned_excludes_active_builds() {
+  let Some(pool) = get_pool().await else {
+    return;
+  };
+
+  let project = create_test_project(&pool, "orphan-active").await;
+  let jobset = create_test_jobset(&pool, project.id).await;
+  let eval = create_test_eval(&pool, jobset.id).await;
+
+  let active_drv = format!("/nix/store/{}.drv", uuid::Uuid::new_v4().simple());
+  let orphan_drv = format!("/nix/store/{}.drv", uuid::Uuid::new_v4().simple());
+  let active =
+    create_test_build(&pool, eval.id, "active", &active_drv, None).await;
+  let orphan =
+    create_test_build(&pool, eval.id, "orphan", &orphan_drv, None).await;
+
+  repo::builds::start(&pool, active.id).await.unwrap();
+  repo::builds::start(&pool, orphan.id).await.unwrap();
+
+  let old_ids = vec![active.id, orphan.id];
+  sqlx::query(
+    "UPDATE builds SET started_at = NOW() - INTERVAL '2 hours' WHERE id = \
+     ANY($1)",
+  )
+  .bind(&old_ids)
+  .execute(&pool)
+  .await
+  .unwrap();
+
+  let reset_count =
+    repo::builds::reset_orphaned_excluding(&pool, 3600, &[active.id])
+      .await
+      .expect("reset orphaned excluding active");
+  assert!(reset_count >= 1);
+
+  let active = repo::builds::get(&pool, active.id)
+    .await
+    .expect("reload active build");
+  let orphan = repo::builds::get(&pool, orphan.id)
+    .await
+    .expect("reload orphan build");
+  assert!(matches!(active.status, BuildStatus::Running));
+  assert!(active.started_at.is_some());
+  assert!(matches!(orphan.status, BuildStatus::Pending));
+  assert!(orphan.started_at.is_none());
+
+  let reset_count = repo::builds::reset_orphaned(&pool, 3600)
+    .await
+    .expect("reset remaining orphaned build");
+  assert!(reset_count >= 1);
+
+  let active = repo::builds::get(&pool, active.id)
+    .await
+    .expect("reload active build after full reset");
+  assert!(matches!(active.status, BuildStatus::Pending));
+  assert!(active.started_at.is_none());
 
   // Cleanup
   let _ = repo::projects::delete(&pool, project.id).await;

--- a/crates/queue-runner/src/runner_loop.rs
+++ b/crates/queue-runner/src/runner_loop.rs
@@ -13,13 +13,19 @@ use uuid::Uuid;
 use crate::{
   dispatch::supports_required_features,
   helpers::{get_project_for_build, is_interval_rebuild},
-  worker::WorkerPool,
+  worker::{ActiveBuilds, WorkerPool},
 };
 
 /// Reset builds left in `running` from a crashed runner. Builds older
 /// than 5 minutes in `running` are assumed orphaned.
-async fn reset_orphaned_builds(pool: &PgPool) {
-  match repo::builds::reset_orphaned(pool, 300).await {
+async fn reset_orphaned_builds(pool: &PgPool, active_builds: &ActiveBuilds) {
+  // Builds claimed after this snapshot stay under the age threshold anyway.
+  let active_ids = active_builds
+    .iter()
+    .map(|entry| *entry.key())
+    .collect::<Vec<Uuid>>();
+
+  match repo::builds::reset_orphaned_excluding(pool, 300, &active_ids).await {
     Ok(count) if count > 0 => {
       tracing::warn!(count, "Reset orphaned builds back to pending");
     },
@@ -194,12 +200,12 @@ pub async fn run(
 ) -> color_eyre::Result<()> {
   let mut last_orphan_reset = tokio::time::Instant::now();
   let orphan_reset_interval = Duration::from_mins(1);
-  reset_orphaned_builds(&pool).await;
+  reset_orphaned_builds(&pool, worker_pool.active_builds()).await;
   prune_stale_ephemeral_sessions(&pool).await;
 
   loop {
     if last_orphan_reset.elapsed() >= orphan_reset_interval {
-      reset_orphaned_builds(&pool).await;
+      reset_orphaned_builds(&pool, worker_pool.active_builds()).await;
       prune_stale_ephemeral_sessions(&pool).await;
       last_orphan_reset = tokio::time::Instant::now();
     }


### PR DESCRIPTION
### Problem

Two pending builds for the same `drv_path` could both end up running when claims raced. The periodic orphan reset made this worse by re-pending long builds that were still active in the runner process, which created fresh duplicates of work already in flight.

### Solution

Build claims now take a per `drv_path` advisory lock and refuse to claim while a twin build is already running. Additionally, pending scheduling skips any `drv_path` that already has a running build, and the orphan reset leaves out build IDs the runner still tracks in process.