### PR TITLE
circus-server: hide dependency builds from job listings

### DIFF
--- a/crates/evaluator/tests/eval_tests.rs
+++ b/crates/evaluator/tests/eval_tests.rs
@@ -182,19 +182,21 @@ async fn eval_fatal_parse_error_returns_cierror_nixeval() {
 
 #[tokio::test]
 #[ignore = "requires nix in PATH with flakes enabled"]
-async fn eval_timeout_returns_cierror_timeout() {
+async fn eval_zero_timeout_returns_cierror_timeout() {
   let dir = TempDir::new().unwrap();
-  // A flake that loops forever to trigger the timeout path.
   fs::write(
     dir.path().join("flake.nix"),
-    r"{
+    r#"{
   outputs = { self }: let
     system = builtins.currentSystem;
-    loop = x: loop x;
   in {
-    packages.${system}.hang = loop null;
+    packages.${system}.test = derivation {
+      name = "circus-timeout-test";
+      inherit system;
+      builder = "/bin/sh";
+    };
   };
-}",
+}"#,
   )
   .unwrap();
   let commit = git_stage(dir.path());
@@ -204,7 +206,7 @@ async fn eval_timeout_returns_cierror_timeout() {
     &commit,
     "packages",
     true,
-    Duration::from_millis(500),
+    Duration::ZERO,
     &permissive_config(),
     &[],
     &CancellationToken::new(),
@@ -212,7 +214,7 @@ async fn eval_timeout_returns_cierror_timeout() {
   )
   .await;
 
-  assert!(result.is_err(), "infinite loop should time out");
+  assert!(result.is_err(), "a zero timeout must expire");
   let err = result.unwrap_err();
   assert!(
     matches!(err, circus_common::CiError::Timeout(_)),

--- a/crates/server/src/routes/dashboard/pages.rs
+++ b/crates/server/src/routes/dashboard/pages.rs
@@ -77,6 +77,28 @@ fn ui_config(state: &AppState) -> UiTemplateConfig {
   UiTemplateConfig::from_config(&state.config.ui)
 }
 
+fn is_job_name(name: &str) -> bool {
+  !name.starts_with(circus_common::models::DEPENDENCY_JOB_PREFIX)
+}
+
+fn is_failed_status(status: BuildStatus) -> bool {
+  status_badge(status).1 == "failed"
+}
+
+const fn is_failed_derivation_status(status: BuildStatus) -> bool {
+  matches!(
+    status,
+    BuildStatus::Failed
+      | BuildStatus::FailedWithOutput
+      | BuildStatus::Timeout
+      | BuildStatus::CachedFailure
+      | BuildStatus::LogLimitExceeded
+      | BuildStatus::NarSizeLimitExceeded
+      | BuildStatus::NonDeterministic
+      | BuildStatus::OomKilled
+  )
+}
+
 fn dashboard_system_filters(
   overview: &operator::OperatorOverview,
 ) -> Vec<String> {
@@ -344,7 +366,7 @@ pub(super) async fn jobset_page(
   .unwrap_or_default();
 
   let mut builds_by_eval: HashMap<Uuid, Vec<&Build>> = HashMap::new();
-  for b in &builds {
+  for b in builds.iter().filter(|build| is_job_name(&build.job_name)) {
     builds_by_eval.entry(b.evaluation_id).or_default().push(b);
   }
 
@@ -466,7 +488,10 @@ pub(super) async fn jobset_jobs_page(
 
   let mut builds_by_job: BTreeMap<String, HashMap<Uuid, Build>> =
     BTreeMap::new();
-  for build in builds {
+  for build in builds
+    .into_iter()
+    .filter(|build| is_job_name(&build.job_name))
+  {
     builds_by_job
       .entry(build.job_name.clone())
       .or_default()
@@ -617,62 +642,54 @@ pub(super) async fn evaluation_page(
     return Err(not_found("Project"));
   };
 
-  let builds = circus_common::repo::builds::list_filtered(
-    &state.pool,
-    Some(id),
-    None,
-    None,
-    None,
-    200,
-    0,
-  )
-  .await
-  .unwrap_or_default();
+  let builds =
+    circus_common::repo::builds::list_for_evaluation(&state.pool, id)
+      .await
+      .unwrap_or_default();
 
-  let succeeded = builds
+  let top_level_builds = builds
+    .iter()
+    .filter(|build| is_job_name(&build.job_name))
+    .collect::<Vec<_>>();
+  let failed_derivations = builds
+    .iter()
+    .filter(|build| is_failed_derivation_status(build.status))
+    .map(build_view)
+    .collect();
+
+  let succeeded = top_level_builds
     .iter()
     .filter(|b| b.status == BuildStatus::Succeeded)
     .count() as i64;
-  let failed = builds
+  let failed = top_level_builds
     .iter()
-    .filter(|b| {
-      matches!(
-        b.status,
-        BuildStatus::Failed
-          | BuildStatus::DependencyFailed
-          | BuildStatus::FailedWithOutput
-          | BuildStatus::Timeout
-          | BuildStatus::CachedFailure
-          | BuildStatus::LogLimitExceeded
-          | BuildStatus::NarSizeLimitExceeded
-          | BuildStatus::NonDeterministic
-      )
-    })
+    .filter(|b| is_failed_status(b.status))
     .count() as i64;
-  let running = builds
+  let running = top_level_builds
     .iter()
     .filter(|b| b.status == BuildStatus::Running)
     .count() as i64;
-  let pending = builds
+  let pending = top_level_builds
     .iter()
     .filter(|b| b.status == BuildStatus::Pending)
     .count() as i64;
 
   let tmpl = EvaluationTemplate {
-    ui:              ui_config(&state),
-    eval:            eval_view(&eval),
-    builds:          builds.iter().map(build_view).collect(),
-    project_name:    project.name,
-    project_id:      project.id,
-    jobset_name:     jobset.name,
-    jobset_id:       jobset.id,
+    ui: ui_config(&state),
+    eval: eval_view(&eval),
+    builds: top_level_builds.into_iter().map(build_view).collect(),
+    failed_derivations,
+    project_name: project.name,
+    project_id: project.id,
+    jobset_name: jobset.name,
+    jobset_id: jobset.id,
     succeeded_count: succeeded,
-    failed_count:    failed,
-    running_count:   running,
-    pending_count:   pending,
-    is_admin:        ctx.is_admin,
-    auth_name:       ctx.auth_name.clone(),
-    csrf_token:      ctx.csrf_token.clone(),
+    failed_count: failed,
+    running_count: running,
+    pending_count: pending,
+    is_admin: ctx.is_admin,
+    auth_name: ctx.auth_name.clone(),
+    csrf_token: ctx.csrf_token.clone(),
   };
   tmpl.render_html_or_500()
 }
@@ -964,7 +981,14 @@ pub(super) async fn build_log(
 
 #[cfg(test)]
 mod tests {
-  use super::BuildFilterParams;
+  use circus_common::models::BuildStatus;
+
+  use super::{
+    BuildFilterParams,
+    is_failed_derivation_status,
+    is_failed_status,
+    is_job_name,
+  };
 
   #[test]
   fn blank_filter_params_deserialize_to_none() {
@@ -980,5 +1004,23 @@ mod tests {
     let kept = serde_urlencoded::from_str::<BuildFilterParams>("status=failed")
       .expect("deserialize query");
     assert_eq!(kept.status.as_deref(), Some("failed"));
+  }
+
+  #[test]
+  fn job_lists_exclude_synthetic_dependency_names() {
+    assert!(is_job_name("x86_64-linux.docs"));
+    assert!(!is_job_name("drv:0vdd2i8j-intermediate"));
+  }
+
+  #[test]
+  fn failed_derivations_exclude_dependency_failure_cascades() {
+    assert!(is_failed_derivation_status(BuildStatus::Failed));
+    assert!(is_failed_derivation_status(BuildStatus::OomKilled));
+    assert!(!is_failed_derivation_status(BuildStatus::DependencyFailed));
+    assert!(!is_failed_derivation_status(BuildStatus::Succeeded));
+    assert!(!is_failed_derivation_status(BuildStatus::Running));
+    assert!(!is_failed_derivation_status(BuildStatus::Cancelled));
+
+    assert!(is_failed_status(BuildStatus::DependencyFailed));
   }
 }

--- a/crates/server/src/routes/dashboard/preview/pages.rs
+++ b/crates/server/src/routes/dashboard/preview/pages.rs
@@ -233,21 +233,31 @@ pub(super) async fn evaluations() -> Response {
 }
 
 pub(super) async fn evaluation() -> Response {
+  let failed_derivations = vec![
+    fixtures::build_view(
+      5,
+      "packages.aarch64-linux.circus-server",
+      "Failed",
+      "failed",
+    ),
+    fixtures::build_view(7, "drv:0vdd2i8j-intermediate", "Failed", "failed"),
+  ];
   render(EvaluationTemplate {
-    ui:              ui(),
-    eval:            fixtures::eval_view(3, "Completed", "completed"),
-    builds:          builds_fixture(),
-    project_name:    "circus".into(),
-    project_id:      id(1),
-    jobset_name:     "packages".into(),
-    jobset_id:       id(2),
+    ui: ui(),
+    eval: fixtures::eval_view(3, "Completed", "completed"),
+    builds: builds_fixture(),
+    failed_derivations,
+    project_name: "circus".into(),
+    project_id: id(1),
+    jobset_name: "packages".into(),
+    jobset_id: id(2),
     succeeded_count: 2,
-    failed_count:    1,
-    running_count:   1,
-    pending_count:   1,
-    is_admin:        true,
-    auth_name:       "operator".into(),
-    csrf_token:      csrf(),
+    failed_count: 1,
+    running_count: 1,
+    pending_count: 1,
+    is_admin: true,
+    auth_name: "operator".into(),
+    csrf_token: csrf(),
   })
 }
 

--- a/crates/server/src/routes/dashboard/templates.rs
+++ b/crates/server/src/routes/dashboard/templates.rs
@@ -137,20 +137,21 @@ pub(super) struct EvaluationsTemplate {
 #[derive(Template)]
 #[template(path = "evaluation.html")]
 pub(super) struct EvaluationTemplate {
-  pub(super) ui:              UiTemplateConfig,
-  pub(super) eval:            EvalView,
-  pub(super) builds:          Vec<BuildView>,
-  pub(super) project_name:    String,
-  pub(super) project_id:      Uuid,
-  pub(super) jobset_name:     String,
-  pub(super) jobset_id:       Uuid,
-  pub(super) succeeded_count: i64,
-  pub(super) failed_count:    i64,
-  pub(super) running_count:   i64,
-  pub(super) pending_count:   i64,
-  pub(super) is_admin:        bool,
-  pub(super) auth_name:       String,
-  pub(super) csrf_token:      String,
+  pub(super) ui:                 UiTemplateConfig,
+  pub(super) eval:               EvalView,
+  pub(super) builds:             Vec<BuildView>,
+  pub(super) failed_derivations: Vec<BuildView>,
+  pub(super) project_name:       String,
+  pub(super) project_id:         Uuid,
+  pub(super) jobset_name:        String,
+  pub(super) jobset_id:          Uuid,
+  pub(super) succeeded_count:    i64,
+  pub(super) failed_count:       i64,
+  pub(super) running_count:      i64,
+  pub(super) pending_count:      i64,
+  pub(super) is_admin:           bool,
+  pub(super) auth_name:          String,
+  pub(super) csrf_token:         String,
 }
 
 #[derive(Template)]

--- a/crates/server/templates/evaluation.html
+++ b/crates/server/templates/evaluation.html
@@ -105,6 +105,30 @@
         </div>
     </section>
 
+    {% if !failed_derivations.is_empty() %}
+        <h2>Failed Derivations</h2>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Derivation</th>
+                        <th>Status</th>
+                        <th>System</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for b in failed_derivations %}
+                        <tr>
+                            <td><a href="/build/{{ b.id }}">{{ b.job_name }}</a></td>
+                            <td><span class="badge badge-{{ b.status_class }}">{{ b.status_text }}</span></td>
+                            <td>{{ b.system }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
     <h2>Builds</h2>
     {% if builds.is_empty() %}
         <div class="empty">No builds for this evaluation.</div>


### PR DESCRIPTION
Somewhat improves the way failed derivations and job names are handled and displayed on the dashboard. More specifically, in evaluation pages. This is done through a helper to filter out synthetic dependency job names and to better distinguish between failed derivations and other failure types. The evaluation page now includes a dedicated "Failed Derivations" section to make it clearer *which derivations failed*, directly, rather than due to dependency cascades. 

Fixes #151 

Change-Id: I015d66d784012a717bb3c973ba8052a76a6a6964