### PR TITLE
Add configurable memory limits for Nix subprocesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "futures",
  "git2",
  "hex",
+ "libc",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/circus.example.toml
+++ b/circus.example.toml
@@ -40,6 +40,9 @@ auto_allowed_uris = true
 git_timeout       = 600
 nix_timeout       = 1800
 # max_eval_time      = 3600
+# Per Nix subprocess. Peak evaluator allowance is approximately this times
+# eval_workers times max_concurrent_evals, plus the Circus parent process.
+# memory_limit_mb     = 4096
 poll_interval        = 60
 require_locked_flake = false
 restrict_eval        = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,7 +39,11 @@ pub fn project_cache_url(
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "Fine in tests")]
 mod tests {
-  use std::time::Duration;
+  use std::{
+    env,
+    fs,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+  };
 
   use circus_types::GlobalRole;
 
@@ -402,12 +406,27 @@ mod tests {
   }
 
   #[test]
+  fn evaluator_memory_limit_loads_from_toml() {
+    let toml_str = r#"
+      [evaluator]
+      memory_limit_mb = 3072
+    "#;
+
+    let mut table = toml::Value::try_from(Config::default()).unwrap();
+    let file_table: toml::Value = toml::from_str(toml_str).unwrap();
+    deep_merge(&mut table, file_table);
+
+    let config: Config = table.try_into().unwrap();
+    assert_eq!(config.evaluator.memory_limit_mb, Some(3072));
+  }
+
+  #[test]
   fn load_requires_explicit_config_path() {
-    let old = std::env::var_os("CIRCUS_CONFIG_FILE");
+    let old = env::var_os("CIRCUS_CONFIG_FILE");
     // SAFETY: tests in this module run single-threaded with respect to this
     // env var; no other thread reads or writes CIRCUS_CONFIG_FILE concurrently.
     unsafe {
-      std::env::remove_var("CIRCUS_CONFIG_FILE");
+      env::remove_var("CIRCUS_CONFIG_FILE");
     }
 
     let err = Config::load(None).unwrap_err().to_string();
@@ -416,26 +435,26 @@ mod tests {
     if let Some(value) = old {
       // SAFETY: see above; restoring the original value, still single-threaded.
       unsafe {
-        std::env::set_var("CIRCUS_CONFIG_FILE", value);
+        env::set_var("CIRCUS_CONFIG_FILE", value);
       }
     }
   }
 
   #[test]
   fn load_reads_explicit_config_path() {
-    let path = std::env::temp_dir().join(format!(
+    let path = env::temp_dir().join(format!(
       "circus-config-test-{}.toml",
-      std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos()
     ));
-    std::fs::write(&path, "[server]\nport = 4321\n").unwrap();
+    fs::write(&path, "[server]\nport = 4321\n").unwrap();
 
     let config = Config::load(Some(&path)).unwrap();
     assert_eq!(config.server.port, 4321);
 
-    let _ = std::fs::remove_file(path);
+    let _ = fs::remove_file(path);
   }
 
   #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -421,6 +421,16 @@ mod tests {
   }
 
   #[test]
+  fn evaluator_memory_limit_rejects_invalid_values() {
+    let mut config = Config::default();
+    config.evaluator.memory_limit_mb = Some(0);
+    assert!(config.validate().is_err());
+
+    config.evaluator.memory_limit_mb = Some(u64::MAX);
+    assert!(config.validate().is_err());
+  }
+
+  #[test]
   fn load_requires_explicit_config_path() {
     let old = env::var_os("CIRCUS_CONFIG_FILE");
     // SAFETY: tests in this module run single-threaded with respect to this

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -407,10 +407,10 @@ mod tests {
 
   #[test]
   fn evaluator_memory_limit_loads_from_toml() {
-    let toml_str = r#"
+    let toml_str = r"
       [evaluator]
       memory_limit_mb = 3072
-    "#;
+    ";
 
     let mut table = toml::Value::try_from(Config::default()).unwrap();
     let file_table: toml::Value = toml::from_str(toml_str).unwrap();

--- a/crates/config/src/structs.rs
+++ b/crates/config/src/structs.rs
@@ -254,6 +254,11 @@ pub struct EvaluatorConfig {
   /// initializes a full Nix evaluator, so higher counts increase parallelism
   /// at the cost of memory. Reduce this on memory-constrained hosts.
   pub eval_workers: usize,
+
+  /// Hard address-space limit, in MiB, for each Nix evaluator subprocess.
+  /// This applies independently to every evix worker and auxiliary `nix`
+  /// process. `None` disables the limit.
+  pub memory_limit_mb: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -798,6 +803,7 @@ impl Default for EvaluatorConfig {
       require_locked_flake: false,
       strict_errors:        false,
       eval_workers:         4,
+      memory_limit_mb:      None,
     }
   }
 }

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -95,6 +95,12 @@ impl Config {
     if self.evaluator.memory_limit_mb == Some(0) {
       bail!("Evaluator memory limit must be greater than 0 MiB");
     }
+    if self.evaluator.memory_limit_mb.is_some_and(|limit| {
+      usize::try_from(limit).is_err()
+        || limit.checked_mul(1024 * 1024).is_none()
+    }) {
+      bail!("Evaluator memory limit is too large for this platform");
+    }
 
     if let Some(url) = self.cache.cache_url.as_deref() {
       validate_shared(validate_cache_url(url, "cache.cache_url"))?;

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -92,6 +92,9 @@ impl Config {
     if self.evaluator.poll_interval == 0 {
       bail!("Evaluator poll interval must be greater than 0");
     }
+    if self.evaluator.memory_limit_mb == Some(0) {
+      bail!("Evaluator memory limit must be greater than 0 MiB");
+    }
 
     if let Some(url) = self.cache.cache_url.as_deref() {
       validate_shared(validate_cache_url(url, "cache.cache_url"))?;

--- a/crates/evaluator/Cargo.toml
+++ b/crates/evaluator/Cargo.toml
@@ -15,6 +15,7 @@ evix.workspace               = true
 futures.workspace            = true
 git2.workspace               = true
 hex.workspace                = true
+libc.workspace               = true
 serde.workspace              = true
 serde_json.workspace         = true
 sha2.workspace               = true

--- a/crates/evaluator/src/builds.rs
+++ b/crates/evaluator/src/builds.rs
@@ -11,9 +11,27 @@ use circus_common::{
 use tokio::process::Command;
 use uuid::Uuid;
 
-async fn read_required_features(drv_path: &str) -> Vec<String> {
-  circus_nix::derivation::show_required_features(&[drv_path.to_owned()])
-    .await
+use crate::memory::MemoryLimit;
+
+async fn read_required_features(
+  drv_path: &str,
+  memory_limit: MemoryLimit,
+) -> Vec<String> {
+  let mut command = circus_nix::derivation::required_features_command(&[
+    drv_path.to_owned(),
+  ]);
+  command.kill_on_drop(true);
+  if memory_limit.apply_to(&mut command).is_err() {
+    return Vec::new();
+  }
+  let Ok(output) = command.output().await else {
+    return Vec::new();
+  };
+  if !output.status.success() {
+    return Vec::new();
+  }
+  serde_json::from_slice(&output.stdout)
+    .map(|value| circus_nix::derivation::union_required_features(&value))
     .unwrap_or_default()
 }
 
@@ -79,18 +97,23 @@ fn parse_derivation_infos(
 
 async fn show_recursive_derivations(
   drv_paths: &[String],
+  memory_limit: MemoryLimit,
 ) -> HashMap<String, DerivationInfo> {
   if drv_paths.is_empty() {
     return HashMap::new();
   }
-  let output = Command::new("nix")
+  let mut command = Command::new("nix");
+  command
     .arg("derivation")
     .arg("show")
     .arg("--recursive")
     .args(drv_paths)
-    .kill_on_drop(true)
-    .output()
-    .await;
+    .kill_on_drop(true);
+  if let Err(error) = memory_limit.apply_to(&mut command) {
+    tracing::warn!(%error, "failed to apply evaluator memory limit");
+    return HashMap::new();
+  }
+  let output = command.output().await;
   let Ok(output) = output else {
     return HashMap::new();
   };
@@ -106,31 +129,40 @@ async fn show_recursive_derivations(
     .unwrap_or_default()
 }
 
-async fn output_available(path: &str) -> bool {
-  let valid = Command::new("nix-store")
+async fn output_available(path: &str, memory_limit: MemoryLimit) -> bool {
+  let mut command = Command::new("nix-store");
+  command
     .args(["--check-validity", path])
-    .kill_on_drop(true)
-    .status()
-    .await
-    .is_ok_and(|status| status.success());
+    .kill_on_drop(true);
+  let valid = memory_limit.apply_to(&mut command).is_ok()
+    && command
+      .status()
+      .await
+      .is_ok_and(|status| status.success());
   if valid {
     return true;
   }
 
-  Command::new("nix")
+  let mut command = Command::new("nix");
+  command
     .args(["path-info", "--json", path])
-    .kill_on_drop(true)
-    .status()
-    .await
-    .is_ok_and(|status| status.success())
+    .kill_on_drop(true);
+  memory_limit.apply_to(&mut command).is_ok()
+    && command
+      .status()
+      .await
+      .is_ok_and(|status| status.success())
 }
 
-async fn should_enqueue_derivation(info: &DerivationInfo) -> bool {
+async fn should_enqueue_derivation(
+  info: &DerivationInfo,
+  memory_limit: MemoryLimit,
+) -> bool {
   let Some(outputs) = &info.outputs else {
     return true;
   };
   for output in outputs.values() {
-    if !output_available(output).await {
+    if !output_available(output, memory_limit).await {
       return true;
     }
   }
@@ -148,12 +180,14 @@ fn dependency_job_name(drv_path: &str) -> String {
 
 async fn expand_derivation_graph(
   jobs: &[crate::nix::NixJob],
+  memory_limit: MemoryLimit,
 ) -> Vec<crate::nix::NixJob> {
   let top_level_drvs = jobs
     .iter()
     .map(|job| job.drv_path.clone())
     .collect::<Vec<_>>();
-  let derivations = show_recursive_derivations(&top_level_drvs).await;
+  let derivations =
+    show_recursive_derivations(&top_level_drvs, memory_limit).await;
   if derivations.is_empty() {
     return jobs.to_vec();
   }
@@ -177,7 +211,7 @@ async fn expand_derivation_graph(
     let Some(info) = derivations.get(&drv_path) else {
       continue;
     };
-    if !should_enqueue_derivation(info).await {
+    if !should_enqueue_derivation(info, memory_limit).await {
       continue;
     }
 
@@ -231,10 +265,11 @@ pub(crate) async fn create_builds_from_eval(
   pool: &PgPool,
   eval_id: Uuid,
   eval_result: &crate::nix::EvalResult,
+  memory_limit: MemoryLimit,
 ) -> color_eyre::Result<bool> {
   let mut drv_to_build: HashMap<String, Uuid> = HashMap::new();
   let mut name_to_build: HashMap<String, Uuid> = HashMap::new();
-  let jobs = expand_derivation_graph(&eval_result.jobs).await;
+  let jobs = expand_derivation_graph(&eval_result.jobs, memory_limit).await;
   let mut builds = Vec::with_capacity(jobs.len());
 
   for job in &jobs {
@@ -249,7 +284,8 @@ pub(crate) async fn create_builds_from_eval(
     let is_aggregate = job.constituents.is_some();
 
     let (is_fod, fod_hash) = detect_fod(&job.drv_path);
-    let required_features = read_required_features(&job.drv_path).await;
+    let required_features =
+      read_required_features(&job.drv_path, memory_limit).await;
     builds.push(CreateBuild {
       evaluation_id: eval_id,
       job_name: job.name.clone(),

--- a/crates/evaluator/src/builds.rs
+++ b/crates/evaluator/src/builds.rs
@@ -17,9 +17,8 @@ async fn read_required_features(
   drv_path: &str,
   memory_limit: MemoryLimit,
 ) -> Vec<String> {
-  let mut command = circus_nix::derivation::required_features_command(&[
-    drv_path.to_owned(),
-  ]);
+  let mut command =
+    circus_nix::derivation::required_features_command(&[drv_path.to_owned()]);
   command.kill_on_drop(true);
   if memory_limit.apply_to(&mut command).is_err() {
     return Vec::new();
@@ -131,14 +130,9 @@ async fn show_recursive_derivations(
 
 async fn output_available(path: &str, memory_limit: MemoryLimit) -> bool {
   let mut command = Command::new("nix-store");
-  command
-    .args(["--check-validity", path])
-    .kill_on_drop(true);
+  command.args(["--check-validity", path]).kill_on_drop(true);
   let valid = memory_limit.apply_to(&mut command).is_ok()
-    && command
-      .status()
-      .await
-      .is_ok_and(|status| status.success());
+    && command.status().await.is_ok_and(|status| status.success());
   if valid {
     return true;
   }
@@ -148,10 +142,7 @@ async fn output_available(path: &str, memory_limit: MemoryLimit) -> bool {
     .args(["path-info", "--json", path])
     .kill_on_drop(true);
   memory_limit.apply_to(&mut command).is_ok()
-    && command
-      .status()
-      .await
-      .is_ok_and(|status| status.success())
+    && command.status().await.is_ok_and(|status| status.success())
 }
 
 async fn should_enqueue_derivation(

--- a/crates/evaluator/src/cli.rs
+++ b/crates/evaluator/src/cli.rs
@@ -61,16 +61,10 @@ where
 
   // evix workers re-execute this binary and inherit its environment. Set the
   // limit before the runtime creates threads and before any workers spawn.
-  if let Some(limit_mb) = config.evaluator.memory_limit_mb {
-    // SAFETY: no threads have been spawned at this point.
-    unsafe {
-      env::set_var(crate::memory::WORKER_LIMIT_ENV, limit_mb.to_string());
-    }
-  } else {
-    // Do not let a service-manager environment accidentally override config.
-    // SAFETY: no threads have been spawned at this point.
-    unsafe { env::remove_var(crate::memory::WORKER_LIMIT_ENV) };
-  }
+  let memory_limit =
+    crate::memory::MemoryLimit::new(config.evaluator.memory_limit_mb);
+  // SAFETY: no threads have been spawned at this point.
+  unsafe { memory_limit.export_worker_env() };
 
   let runtime = tokio::runtime::Builder::new_multi_thread()
     .enable_all()

--- a/crates/evaluator/src/cli.rs
+++ b/crates/evaluator/src/cli.rs
@@ -1,5 +1,5 @@
 #[cfg(not(unix))] use std::future::pending;
-use std::{ffi::OsString, path::PathBuf, sync::Arc, time::Duration};
+use std::{env, ffi::OsString, path::PathBuf, sync::Arc, time::Duration};
 
 use circus_common::Database;
 use circus_config::Config;
@@ -20,7 +20,7 @@ struct Cli {
 /// Returns an error when worker startup, configuration, database setup, or the
 /// evaluator runtime fails.
 pub fn run() -> color_eyre::Result<()> {
-  run_from(std::env::args_os())
+  run_from(env::args_os())
 }
 
 /// Run the Circus evaluator CLI with explicit argv values.
@@ -36,15 +36,16 @@ where
 {
   // Cap Nix's GC heap. By default it sizes from total RAM and the reservation
   // fails on swapless low-memory hosts, killing the evix worker.
-  if std::env::var_os("GC_INITIAL_HEAP_SIZE").is_none() {
+  if env::var_os("GC_INITIAL_HEAP_SIZE").is_none() {
     // SAFETY: set at process start, before any threads spawn.
-    unsafe { std::env::set_var("GC_INITIAL_HEAP_SIZE", "268435456") };
+    unsafe { env::set_var("GC_INITIAL_HEAP_SIZE", "268435456") };
   }
 
   // evix evaluates Nix in worker subprocesses that re-execute this binary with
   // `EVIX_WORKER` set. When invoked that way, act purely as an evix worker and
   // do not start the evaluator service (tokio runtime, database, etc.).
-  if std::env::var_os(evix::WORKER_ENV).is_some() {
+  if env::var_os(evix::WORKER_ENV).is_some() {
+    crate::memory::limit_evix_worker_from_env()?;
     return evix::run_worker().map_err(|e| {
       color_eyre::eyre::eyre!(
         "evix worker failed: {}",
@@ -55,20 +56,29 @@ where
   color_eyre::install()?;
   circus_common::install_crypto_provider()?;
 
+  let cli = Cli::parse_from(args);
+  let config = Config::load(cli.config.as_deref())?;
+
+  // evix workers re-execute this binary and inherit its environment. Set the
+  // limit before the runtime creates threads and before any workers spawn.
+  if let Some(limit_mb) = config.evaluator.memory_limit_mb {
+    // SAFETY: no threads have been spawned at this point.
+    unsafe {
+      env::set_var(crate::memory::WORKER_LIMIT_ENV, limit_mb.to_string());
+    }
+  } else {
+    // Do not let a service-manager environment accidentally override config.
+    // SAFETY: no threads have been spawned at this point.
+    unsafe { env::remove_var(crate::memory::WORKER_LIMIT_ENV) };
+  }
+
   let runtime = tokio::runtime::Builder::new_multi_thread()
     .enable_all()
     .build()?;
-  runtime.block_on(run_async(args))
+  runtime.block_on(run_async(config))
 }
 
-async fn run_async<I, T>(args: I) -> color_eyre::Result<()>
-where
-  I: IntoIterator<Item = T>,
-  T: Into<OsString> + Clone,
-{
-  let cli = Cli::parse_from(args);
-
-  let config = Config::load(cli.config.as_deref())?;
+async fn run_async(config: Config) -> color_eyre::Result<()> {
   circus_common::init_tracing(&config.tracing);
 
   tracing::info!("Starting CI Evaluator");

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -457,7 +457,14 @@ async fn run_nix_and_record_builds(
           "Evaluation discovered jobs"
       );
 
-      if !create_builds_from_eval(pool, eval.id, &eval_result).await? {
+      if !create_builds_from_eval(
+        pool,
+        eval.id,
+        &eval_result,
+        crate::memory::MemoryLimit::from(config),
+      )
+      .await?
+      {
         tracing::info!(eval_id = %eval.id, "Evaluation was cancelled");
         return Ok(());
       }

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -3,4 +3,5 @@ pub mod cli;
 pub mod eval_loop;
 mod evaluation_state;
 pub mod git;
+mod memory;
 pub mod nix;

--- a/crates/evaluator/src/memory.rs
+++ b/crates/evaluator/src/memory.rs
@@ -1,10 +1,73 @@
 #[cfg(unix)] use std::os::unix::process::CommandExt as _;
 use std::{env, io};
 
+use circus_config::EvaluatorConfig;
 use tokio::process::Command;
 
-pub(crate) const WORKER_LIMIT_ENV: &str =
+const DEFAULT_EVIX_MEMORY_MB: usize = 4096;
+const WORKER_LIMIT_ENV: &str =
   "CIRCUS_EVALUATOR_WORKER_MEMORY_LIMIT_MB";
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MemoryLimit(Option<u64>);
+
+impl MemoryLimit {
+  pub(crate) const fn new(limit_mb: Option<u64>) -> Self {
+    Self(limit_mb)
+  }
+
+  pub(crate) fn evix_mb(self) -> io::Result<usize> {
+    self.0.map_or(Ok(DEFAULT_EVIX_MEMORY_MB), |limit| {
+      usize::try_from(limit)
+        .map_err(|_| io::Error::other("evaluator memory limit is too large"))
+    })
+  }
+
+  pub(crate) fn apply_to(self, command: &mut Command) -> io::Result<()> {
+    let Some(limit_mb) = self.0 else {
+      return Ok(());
+    };
+
+    #[cfg(unix)]
+    {
+      let limit = bytes(limit_mb)?;
+      // SAFETY: the closure only calls async-signal-safe resource-limit
+      // syscalls.
+      unsafe {
+        command.pre_exec(move || set_address_space_limit(limit));
+      }
+      Ok(())
+    }
+
+    #[cfg(not(unix))]
+    Err(io::Error::new(
+      io::ErrorKind::Unsupported,
+      "evaluator memory limits require Unix",
+    ))
+  }
+
+  /// Export the limit inherited by evix worker re-executions.
+  ///
+  /// # Safety
+  ///
+  /// The process must still be single-threaded because environment mutation
+  /// is not thread-safe on every supported platform.
+  pub(crate) unsafe fn export_worker_env(self) {
+    if let Some(limit_mb) = self.0 {
+      // SAFETY: guaranteed by the caller.
+      unsafe { env::set_var(WORKER_LIMIT_ENV, limit_mb.to_string()) };
+    } else {
+      // SAFETY: guaranteed by the caller.
+      unsafe { env::remove_var(WORKER_LIMIT_ENV) };
+    }
+  }
+}
+
+impl From<&EvaluatorConfig> for MemoryLimit {
+  fn from(config: &EvaluatorConfig) -> Self {
+    Self::new(config.memory_limit_mb)
+  }
+}
 
 #[cfg(unix)]
 fn bytes(limit_mb: u64) -> io::Result<libc::rlim_t> {
@@ -12,31 +75,6 @@ fn bytes(limit_mb: u64) -> io::Result<libc::rlim_t> {
     .checked_mul(1024 * 1024)
     .and_then(|value| libc::rlim_t::try_from(value).ok())
     .ok_or_else(|| io::Error::other("evaluator memory limit is too large"))
-}
-
-pub(crate) fn limit_command(
-  command: &mut Command,
-  limit_mb: Option<u64>,
-) -> io::Result<()> {
-  let Some(limit_mb) = limit_mb else {
-    return Ok(());
-  };
-
-  #[cfg(unix)]
-  {
-    let limit = bytes(limit_mb)?;
-    // SAFETY: the closure only calls the async-signal-safe setrlimit syscall.
-    unsafe {
-      command.pre_exec(move || set_address_space_limit(limit));
-    }
-    Ok(())
-  }
-
-  #[cfg(not(unix))]
-  Err(io::Error::new(
-    io::ErrorKind::Unsupported,
-    "evaluator memory limits require Unix",
-  ))
 }
 
 pub(crate) fn limit_evix_worker_from_env() -> io::Result<()> {
@@ -92,12 +130,18 @@ mod tests {
     assert!(bytes(u64::MAX).is_err());
   }
 
+  #[test]
+  fn evix_keeps_legacy_default_without_a_hard_limit() {
+    assert_eq!(MemoryLimit::new(None).evix_mb().unwrap(), 4096);
+    assert_eq!(MemoryLimit::new(Some(512)).evix_mb().unwrap(), 512);
+  }
+
   #[cfg(unix)]
   #[tokio::test]
   async fn command_receives_address_space_limit() {
     let mut command = Command::new("sh");
     command.args(["-c", "ulimit -v"]);
-    limit_command(&mut command, Some(64)).unwrap();
+    MemoryLimit::new(Some(64)).apply_to(&mut command).unwrap();
 
     let output = command.output().await.unwrap();
     assert!(output.status.success());

--- a/crates/evaluator/src/memory.rs
+++ b/crates/evaluator/src/memory.rs
@@ -1,15 +1,13 @@
-#[cfg(unix)] use std::os::unix::process::CommandExt as _;
 use std::{env, io};
 
 use circus_config::EvaluatorConfig;
 use tokio::process::Command;
 
 const DEFAULT_EVIX_MEMORY_MB: usize = 4096;
-const WORKER_LIMIT_ENV: &str =
-  "CIRCUS_EVALUATOR_WORKER_MEMORY_LIMIT_MB";
+const WORKER_LIMIT_ENV: &str = "CIRCUS_EVALUATOR_WORKER_MEMORY_LIMIT_MB";
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct MemoryLimit(Option<u64>);
+pub struct MemoryLimit(Option<u64>);
 
 impl MemoryLimit {
   pub(crate) const fn new(limit_mb: Option<u64>) -> Self {
@@ -77,7 +75,7 @@ fn bytes(limit_mb: u64) -> io::Result<libc::rlim_t> {
     .ok_or_else(|| io::Error::other("evaluator memory limit is too large"))
 }
 
-pub(crate) fn limit_evix_worker_from_env() -> io::Result<()> {
+pub fn limit_evix_worker_from_env() -> io::Result<()> {
   let Some(value) = env::var_os(WORKER_LIMIT_ENV) else {
     return Ok(());
   };
@@ -106,13 +104,14 @@ fn set_address_space_limit(limit: libc::rlim_t) -> io::Result<()> {
     rlim_max: 0,
   };
   // SAFETY: resource_limit points to writable storage for a valid rlimit.
-  if unsafe { libc::getrlimit(libc::RLIMIT_AS, &mut resource_limit) } != 0 {
+  if unsafe { libc::getrlimit(libc::RLIMIT_AS, &raw mut resource_limit) } != 0 {
     return Err(io::Error::last_os_error());
   }
   resource_limit.rlim_cur = limit.min(resource_limit.rlim_max);
   // SAFETY: resource_limit contains the existing hard limit and a soft limit
   // no greater than it.
-  if unsafe { libc::setrlimit(libc::RLIMIT_AS, &resource_limit) } == 0 {
+  if unsafe { libc::setrlimit(libc::RLIMIT_AS, &raw const resource_limit) } == 0
+  {
     Ok(())
   } else {
     Err(io::Error::last_os_error())
@@ -121,6 +120,7 @@ fn set_address_space_limit(limit: libc::rlim_t) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+  #![expect(clippy::unwrap_used, reason = "fine in tests")]
   use super::*;
 
   #[cfg(unix)]

--- a/crates/evaluator/src/memory.rs
+++ b/crates/evaluator/src/memory.rs
@@ -1,0 +1,106 @@
+#[cfg(unix)] use std::os::unix::process::CommandExt as _;
+use std::{env, io};
+
+use tokio::process::Command;
+
+pub(crate) const WORKER_LIMIT_ENV: &str =
+  "CIRCUS_EVALUATOR_WORKER_MEMORY_LIMIT_MB";
+
+#[cfg(unix)]
+fn bytes(limit_mb: u64) -> io::Result<libc::rlim_t> {
+  limit_mb
+    .checked_mul(1024 * 1024)
+    .and_then(|value| libc::rlim_t::try_from(value).ok())
+    .ok_or_else(|| io::Error::other("evaluator memory limit is too large"))
+}
+
+pub(crate) fn limit_command(
+  command: &mut Command,
+  limit_mb: Option<u64>,
+) -> io::Result<()> {
+  let Some(limit_mb) = limit_mb else {
+    return Ok(());
+  };
+
+  #[cfg(unix)]
+  {
+    let limit = bytes(limit_mb)?;
+    // SAFETY: the closure only calls the async-signal-safe setrlimit syscall.
+    unsafe {
+      command.pre_exec(move || set_address_space_limit(limit));
+    }
+    Ok(())
+  }
+
+  #[cfg(not(unix))]
+  Err(io::Error::new(
+    io::ErrorKind::Unsupported,
+    "evaluator memory limits require Unix",
+  ))
+}
+
+pub(crate) fn limit_evix_worker_from_env() -> io::Result<()> {
+  let Some(value) = env::var_os(WORKER_LIMIT_ENV) else {
+    return Ok(());
+  };
+  let value = value.to_string_lossy();
+  let limit_mb = value.parse::<u64>().map_err(|error| {
+    io::Error::new(
+      io::ErrorKind::InvalidInput,
+      format!("invalid {WORKER_LIMIT_ENV} value {value:?}: {error}"),
+    )
+  })?;
+
+  #[cfg(unix)]
+  return set_address_space_limit(bytes(limit_mb)?);
+
+  #[cfg(not(unix))]
+  Err(io::Error::new(
+    io::ErrorKind::Unsupported,
+    "evaluator memory limits require Unix",
+  ))
+}
+
+#[cfg(unix)]
+fn set_address_space_limit(limit: libc::rlim_t) -> io::Result<()> {
+  let mut resource_limit = libc::rlimit {
+    rlim_cur: 0,
+    rlim_max: 0,
+  };
+  // SAFETY: resource_limit points to writable storage for a valid rlimit.
+  if unsafe { libc::getrlimit(libc::RLIMIT_AS, &mut resource_limit) } != 0 {
+    return Err(io::Error::last_os_error());
+  }
+  resource_limit.rlim_cur = limit.min(resource_limit.rlim_max);
+  // SAFETY: resource_limit contains the existing hard limit and a soft limit
+  // no greater than it.
+  if unsafe { libc::setrlimit(libc::RLIMIT_AS, &resource_limit) } == 0 {
+    Ok(())
+  } else {
+    Err(io::Error::last_os_error())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[cfg(unix)]
+  #[test]
+  fn converts_mib_to_bytes() {
+    assert_eq!(bytes(512).unwrap(), 512 * 1024 * 1024);
+    assert!(bytes(u64::MAX).is_err());
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn command_receives_address_space_limit() {
+    let mut command = Command::new("sh");
+    command.args(["-c", "ulimit -v"]);
+    limit_command(&mut command, Some(64)).unwrap();
+
+    let output = command.output().await.unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "65536");
+  }
+}

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -1,8 +1,4 @@
-use std::{
-  collections::{BTreeMap, HashMap},
-  path::Path,
-  time::Duration,
-};
+use std::{collections::HashMap, path::Path, time::Duration};
 
 use circus_common::{CiError, InputType, error::Result, models::JobsetInput};
 use circus_config::EvaluatorConfig;
@@ -700,6 +696,8 @@ fn parse_derivation_show(value: &serde_json::Value) -> Option<ShownDerivation> {
 #[cfg(test)]
 mod meta_tests {
   #![expect(clippy::unwrap_used, reason = "fine in tests")]
+  use std::collections::BTreeMap;
+
   use super::*;
 
   #[test]

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -16,16 +16,6 @@ mod flake_lock;
 use eval_command::NixEvalPolicy;
 pub use eval_command::error_chain;
 
-fn evix_memory_limit(config: &EvaluatorConfig) -> Result<usize> {
-  config.memory_limit_mb.map_or(Ok(usize::MAX), |limit| {
-    usize::try_from(limit).map_err(|_| {
-      CiError::NixEval(format!(
-        "Evaluator memory limit {limit} MiB is too large for this platform"
-      ))
-    })
-  })
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct NixMeta {
   pub description: Option<String>,
@@ -358,7 +348,9 @@ async fn evaluate_flake(
     workers: config.eval_workers,
     // evix uses this as a post-attribute recycle threshold; RLIMIT_AS is the
     // corresponding hard ceiling while an attribute is still evaluating.
-    max_memory_size: evix_memory_limit(config)?,
+    max_memory_size: crate::memory::MemoryLimit::from(config)
+      .evix_mb()
+      .map_err(|e| CiError::NixEval(e.to_string()))?,
     meta: true,
     show_input_drvs: true,
     override_inputs,
@@ -416,11 +408,11 @@ async fn evaluate_all_nixos_configs(
   NixEvalPolicy::from(config)
     .with_extra_allowed_uris(derived_uris)
     .apply_to(&mut cmd);
-  crate::memory::limit_command(&mut cmd, config.memory_limit_mb).map_err(
-    |e| {
+  crate::memory::MemoryLimit::from(config)
+    .apply_to(&mut cmd)
+    .map_err(|e| {
       CiError::NixEval(format!("Failed to apply evaluator memory limit: {e}"))
-    },
-  )?;
+    })?;
   let output = tokio::select! {
     output = cmd.output() => output,
     () = cancel.cancelled() => return Err(CiError::NixEval("Nix evaluation was cancelled".to_string())),
@@ -499,7 +491,9 @@ async fn resolve_drv(
   command
     .args(["derivation", "show", flake_ref])
     .kill_on_drop(true);
-  crate::memory::limit_command(&mut command, config.memory_limit_mb).ok()?;
+  crate::memory::MemoryLimit::from(config)
+    .apply_to(&mut command)
+    .ok()?;
   let out = command.output().await.ok()?;
 
   if !out.status.success() {
@@ -578,7 +572,9 @@ async fn evaluate_legacy(
     force_recurse: true,
     gc_roots_dir: None,
     workers: config.eval_workers,
-    max_memory_size: evix_memory_limit(config)?,
+    max_memory_size: crate::memory::MemoryLimit::from(config)
+      .evix_mb()
+      .map_err(|e| CiError::NixEval(e.to_string()))?,
     meta: true,
     show_input_drvs: true,
     override_inputs: Vec::new(),

--- a/crates/evaluator/src/nix.rs
+++ b/crates/evaluator/src/nix.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::{
+  collections::{BTreeMap, HashMap},
+  path::Path,
+  time::Duration,
+};
 
 use circus_common::{CiError, InputType, error::Result, models::JobsetInput};
 use circus_config::EvaluatorConfig;
@@ -12,8 +16,15 @@ mod flake_lock;
 use eval_command::NixEvalPolicy;
 pub use eval_command::error_chain;
 
-/// Per-worker memory ceiling in MB; evix restarts a worker once it is exceeded.
-const EVAL_MAX_MEMORY_MB: usize = 4096;
+fn evix_memory_limit(config: &EvaluatorConfig) -> Result<usize> {
+  config.memory_limit_mb.map_or(Ok(usize::MAX), |limit| {
+    usize::try_from(limit).map_err(|_| {
+      CiError::NixEval(format!(
+        "Evaluator memory limit {limit} MiB is too large for this platform"
+      ))
+    })
+  })
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct NixMeta {
@@ -345,7 +356,9 @@ async fn evaluate_flake(
     force_recurse: true,
     gc_roots_dir: None,
     workers: config.eval_workers,
-    max_memory_size: EVAL_MAX_MEMORY_MB,
+    // evix uses this as a post-attribute recycle threshold; RLIMIT_AS is the
+    // corresponding hard ceiling while an attribute is still evaluating.
+    max_memory_size: evix_memory_limit(config)?,
     meta: true,
     show_input_drvs: true,
     override_inputs,
@@ -403,6 +416,11 @@ async fn evaluate_all_nixos_configs(
   NixEvalPolicy::from(config)
     .with_extra_allowed_uris(derived_uris)
     .apply_to(&mut cmd);
+  crate::memory::limit_command(&mut cmd, config.memory_limit_mb).map_err(
+    |e| {
+      CiError::NixEval(format!("Failed to apply evaluator memory limit: {e}"))
+    },
+  )?;
   let output = tokio::select! {
     output = cmd.output() => output,
     () = cancel.cancelled() => return Err(CiError::NixEval("Nix evaluation was cancelled".to_string())),
@@ -437,7 +455,7 @@ async fn evaluate_all_nixos_configs(
       "{}#nixosConfigurations.{name}.config.system.build.toplevel",
       repo_path.display()
     );
-    let shown = resolve_drv(&drv_ref).await;
+    let shown = resolve_drv(&drv_ref, config).await;
 
     let (drv_path, system, outputs, input_drvs) = if let Some(shown) = shown {
       (
@@ -473,13 +491,16 @@ async fn evaluate_all_nixos_configs(
   })
 }
 
-async fn resolve_drv(flake_ref: &str) -> Option<ShownDerivation> {
-  let out = Command::new("nix")
+async fn resolve_drv(
+  flake_ref: &str,
+  config: &EvaluatorConfig,
+) -> Option<ShownDerivation> {
+  let mut command = Command::new("nix");
+  command
     .args(["derivation", "show", flake_ref])
-    .kill_on_drop(true)
-    .output()
-    .await
-    .ok()?;
+    .kill_on_drop(true);
+  crate::memory::limit_command(&mut command, config.memory_limit_mb).ok()?;
+  let out = command.output().await.ok()?;
 
   if !out.status.success() {
     return None;
@@ -557,7 +578,7 @@ async fn evaluate_legacy(
     force_recurse: true,
     gc_roots_dir: None,
     workers: config.eval_workers,
-    max_memory_size: EVAL_MAX_MEMORY_MB,
+    max_memory_size: evix_memory_limit(config)?,
     meta: true,
     show_input_drvs: true,
     override_inputs: Vec::new(),
@@ -614,7 +635,7 @@ fn flatten_attrs(
 
 fn is_store_drv_path(value: &str) -> bool {
   is_store_path(value)
-    && std::path::Path::new(value)
+    && Path::new(value)
       .extension()
       .is_some_and(|ext| ext.eq_ignore_ascii_case("drv"))
 }
@@ -1001,9 +1022,9 @@ mod meta_tests {
       name:          name.to_string(),
       system:        "x86_64-linux".to_string(),
       drv_path:      "/nix/store/abc-hello.drv".to_string(),
-      outputs:       std::collections::BTreeMap::new(),
+      outputs:       BTreeMap::new(),
       meta:          None,
-      input_drvs:    std::collections::BTreeMap::new(),
+      input_drvs:    BTreeMap::new(),
       constituents:  None,
       gc_root_error: None,
     }

--- a/crates/nix/src/derivation.rs
+++ b/crates/nix/src/derivation.rs
@@ -2,6 +2,8 @@
 
 use std::collections::BTreeSet;
 
+use tokio::process::Command;
+
 use crate::{Error, Result};
 
 fn features_of_structured(sa: &serde_json::Value, out: &mut BTreeSet<String>) {
@@ -78,14 +80,7 @@ pub fn union_required_features(parsed: &serde_json::Value) -> Vec<String> {
 pub async fn show_required_features(drvs: &[String]) -> Result<Vec<String>> {
   let mut features = BTreeSet::new();
   for chunk in drvs.chunks(1024) {
-    let out = tokio::process::Command::new("nix")
-      .args([
-        "--extra-experimental-features",
-        "nix-command",
-        "derivation",
-        "show",
-      ])
-      .args(chunk)
+    let out = required_features_command(chunk)
       .output()
       .await
       .map_err(|e| {
@@ -102,6 +97,22 @@ pub async fn show_required_features(drvs: &[String]) -> Result<Vec<String>> {
     features.extend(union_required_features(&parsed));
   }
   Ok(features.into_iter().collect())
+}
+
+/// Construct the canonical `nix derivation show` command used to inspect
+/// required system features.
+#[must_use]
+pub fn required_features_command(drvs: &[String]) -> Command {
+  let mut command = Command::new("nix");
+  command
+    .args([
+      "--extra-experimental-features",
+      "nix-command",
+      "derivation",
+      "show",
+    ])
+    .args(drvs);
+  command
 }
 
 #[cfg(test)]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -220,6 +220,8 @@ configuration or the Nix store.
 | `evaluator`          | `nix_timeout`                                          | `1800`                                              | Nix evaluation timeout (seconds)                                          |
 | `evaluator`          | `max_eval_time`                                        | none                                                | Optional total evaluation limit (seconds); timeout is recorded distinctly |
 | `evaluator`          | `max_concurrent_evals`                                 | `4`                                                 | Maximum concurrent evaluations                                            |
+| `evaluator`          | `eval_workers`                                         | `4`                                                 | Evix worker subprocesses per evaluation                                   |
+| `evaluator`          | `memory_limit_mb`                                      | none                                                | Hard address-space limit per Nix subprocess (MiB)                         |
 | `evaluator`          | `work_dir`                                             | `/tmp/circus-evaluator`                             | Working directory for clones                                              |
 | `evaluator`          | `restrict_eval`                                        | `true`                                              | Pass `--option restrict-eval true` to Nix                                 |
 | `evaluator`          | `allow_ifd`                                            | `false`                                             | Allow import-from-derivation                                              |
@@ -350,6 +352,14 @@ configuration or the Nix store.
 | `nix`                | `store_dir`                                            | `/nix/store`                                        | Nix store directory                                                       |
 
 <!-- markdownlint-enable MD013 -->
+
+`evaluator.memory_limit_mb` is enforced per Nix subprocess, not as one shared
+budget for the evaluator service. It covers evix workers and the auxiliary
+`nix eval`/`nix derivation show` processes used for `nixosConfigurations`. Evix
+also uses the same value as its post-attribute worker recycle threshold. Plan
+for up to `memory_limit_mb * eval_workers * max_concurrent_evals`, plus the
+comparatively small Circus parent process. Lower `eval_workers` or
+`max_concurrent_evals` when the resulting aggregate is too high for the host.
 
 ## Binary Cache Storage
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -991,11 +991,11 @@ Circus exposes a Prometheus-compatible metrics endpoint at `/prometheus`.
 
 ```yaml
 scrape_configs:
-    - job_name: "circus-ci"
-      static_configs:
-          - targets: ["ci.example.org:3000"]
-      metrics_path: "/prometheus"
-      scrape_interval: 30s
+  - job_name: "circus-ci"
+    static_configs:
+      - targets: ["ci.example.org:3000"]
+    metrics_path: "/prometheus"
+    scrape_interval: 30s
 ```
 
 The `/health` endpoint reports database and service status. Administrative

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -354,10 +354,11 @@ configuration or the Nix store.
 <!-- markdownlint-enable MD013 -->
 
 `evaluator.memory_limit_mb` is enforced per Nix subprocess, not as one shared
-budget for the evaluator service. It covers evix workers and the auxiliary
-`nix eval`/`nix derivation show` processes used for `nixosConfigurations`. Evix
-also uses the same value as its post-attribute worker recycle threshold. Plan
-for up to `memory_limit_mb * eval_workers * max_concurrent_evals`, plus the
+budget for the evaluator service. It covers evix workers and every auxiliary
+`nix`/`nix-store` process spawned while discovering and recording builds. Evix
+also uses the same value as its post-attribute worker recycle threshold. When
+the hard limit is unset, that threshold retains its historical 4096 MiB default.
+Plan for up to `memory_limit_mb * eval_workers * max_concurrent_evals`, plus the
 comparatively small Circus parent process. Lower `eval_workers` or
 `max_concurrent_evals` when the resulting aggregate is too high for the host.
 
@@ -990,11 +991,11 @@ Circus exposes a Prometheus-compatible metrics endpoint at `/prometheus`.
 
 ```yaml
 scrape_configs:
-  - job_name: "circus-ci"
-    static_configs:
-      - targets: ["ci.example.org:3000"]
-    metrics_path: "/prometheus"
-    scrape_interval: 30s
+    - job_name: "circus-ci"
+      static_configs:
+          - targets: ["ci.example.org:3000"]
+      metrics_path: "/prometheus"
+      scrape_interval: 30s
 ```
 
 The `/health` endpoint reports database and service status. Administrative


### PR DESCRIPTION
So @max-privatevoid can keep his sanity and RAM.

Introduces configurable hard memory limit for each Nix evaluator subproc (`memory_limit_mb`) to improve control over circus-evaluator's resource usage. This'd previously bite us in the ass when there are too many projects pending evaluation.

The limit is enforced per subprocess, including evix workers and auxiliary `nix` commands, and is configurable via the Circus configuration. See INSTALL.md and the sample config.