### PR TITLE
Fix eval lifecycle

### DIFF
--- a/crates/common/src/repo/evaluations.rs
+++ b/crates/common/src/repo/evaluations.rs
@@ -684,3 +684,42 @@ pub async fn sweep_orphaned(
     .await?;
   rows.into_iter().map(Evaluation::try_from).collect()
 }
+
+/// Cancel pending push evaluations of a jobset made obsolete by a newer
+/// commit.
+///
+/// # Errors
+///
+/// Returns error if database query fails.
+pub async fn supersede_pending_push(
+  pool: &PgPool,
+  jobset_id: Uuid,
+  commit_hash: &str,
+) -> Result<Vec<Evaluation>> {
+  let client = pool.get().await?;
+  let rows = q::supersede_pending_push()
+    .bind(&client, &commit_hash, &jobset_id)
+    .all()
+    .await?;
+  rows.into_iter().map(Evaluation::try_from).collect()
+}
+
+/// Cancel pending evaluations of a change request made obsolete by a newer
+/// head commit.
+///
+/// # Errors
+///
+/// Returns error if database query fails.
+pub async fn supersede_pending_change_request(
+  pool: &PgPool,
+  jobset_id: Uuid,
+  pr_number: i32,
+  commit_hash: &str,
+) -> Result<Vec<Evaluation>> {
+  let client = pool.get().await?;
+  let rows = q::supersede_pending_change_request()
+    .bind(&client, &commit_hash, &jobset_id, &pr_number)
+    .all()
+    .await?;
+  rows.into_iter().map(Evaluation::try_from).collect()
+}

--- a/crates/common/src/repo/evaluations.rs
+++ b/crates/common/src/repo/evaluations.rs
@@ -662,3 +662,25 @@ pub async fn get_build_contexts(
       .collect(),
   )
 }
+
+/// Recover running evaluations whose claim is older than `deadline_secs`.
+///
+/// A row can only stay running that long if the evaluator that claimed it
+/// died before finishing, so it is requeued as pending. After three
+/// orphanings the row is marked failed instead to keep a crash-inducing
+/// evaluation from cycling forever.
+///
+/// # Errors
+///
+/// Returns error if database query fails.
+pub async fn sweep_orphaned(
+  pool: &PgPool,
+  deadline_secs: f64,
+) -> Result<Vec<Evaluation>> {
+  let client = pool.get().await?;
+  let rows = q::sweep_orphaned()
+    .bind(&client, &deadline_secs)
+    .all()
+    .await?;
+  rows.into_iter().map(Evaluation::try_from).collect()
+}

--- a/crates/evaluator/src/eval_loop.rs
+++ b/crates/evaluator/src/eval_loop.rs
@@ -69,6 +69,34 @@ pub async fn run(
   }
 }
 
+/// Grace period past the worst-case evaluation time before a running row is
+/// considered orphaned.
+const ORPHAN_SWEEP_SLACK_SECS: f64 = 300.0;
+
+/// Requeue evaluations stranded in running state by an evaluator that died
+/// after claiming them. No live evaluation can outlast the git plus nix
+/// timeouts, so anything older is unowned. Also unwedges the duplicate-poll
+/// skip that a stranded row otherwise holds forever.
+async fn sweep_orphaned_evaluations(pool: &PgPool, worst_case: Duration) {
+  let deadline_secs = worst_case.as_secs_f64() + ORPHAN_SWEEP_SLACK_SECS;
+  match repo::evaluations::sweep_orphaned(pool, deadline_secs).await {
+    Ok(swept) => {
+      for eval in swept {
+        tracing::warn!(
+          eval_id = %eval.id,
+          jobset_id = %eval.jobset_id,
+          commit = %eval.commit_hash,
+          status = eval.status.as_db_str(),
+          "Recovered orphaned evaluation"
+        );
+      }
+    },
+    Err(e) => {
+      tracing::warn!("Failed to sweep orphaned evaluations: {e}");
+    },
+  }
+}
+
 async fn run_cycle(
   pool: &PgPool,
   config: &EvaluatorConfig,
@@ -77,6 +105,8 @@ async fn run_cycle(
   nix_timeout: Duration,
   git_timeout: Duration,
 ) -> color_eyre::Result<()> {
+  sweep_orphaned_evaluations(pool, git_timeout + nix_timeout).await;
+
   let active = repo::jobsets::list_active(pool).await?;
   let active_by_id: HashMap<Uuid, ActiveJobset> =
     active.iter().cloned().map(|j| (j.id, j)).collect();

--- a/crates/migrations/migrations/0031_evaluation_started_at.sql
+++ b/crates/migrations/migrations/0031_evaluation_started_at.sql
@@ -1,0 +1,7 @@
+-- Stamp when a running evaluation was claimed so stranded rows are detectable.
+ALTER TABLE evaluations
+ADD COLUMN started_at TIMESTAMP WITH TIME ZONE;
+
+-- Requeue budget for orphaned evaluations before the sweep gives up.
+ALTER TABLE evaluations
+ADD COLUMN orphaned_count INTEGER NOT NULL DEFAULT 0;

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -57,6 +57,7 @@ const MIGRATIONS: &[Migration] = migrations![
   (28, "0028_narinfo_cache_project_owners"),
   (29, "0029_evaluation_cancellation"),
   (30, "0030_runtime_enum_constraints"),
+  (31, "0031_evaluation_started_at"),
 ];
 
 /// Runs all migrations, creating the database first if it doesn't exist.

--- a/crates/server/src/routes/webhooks.rs
+++ b/crates/server/src/routes/webhooks.rs
@@ -136,6 +136,48 @@ fn is_deleted_commit(commit: &str) -> bool {
   commit.is_empty() || commit == "0000000000000000000000000000000000000000"
 }
 
+/// Cancel pending evaluations obsoleted by a newer commit on the same ref.
+///
+/// Scoped to a single change request or a jobset tracking one concrete
+/// branch. Pattern jobsets span refs the rows do not record, so their
+/// pending evaluations are never superseded.
+async fn supersede_pending(
+  state: &AppState,
+  jobset_id: Uuid,
+  pr_number: Option<i32>,
+  commit: &str,
+) {
+  let result = match pr_number {
+    Some(number) => {
+      repo::evaluations::supersede_pending_change_request(
+        &state.pool,
+        jobset_id,
+        number,
+        commit,
+      )
+      .await
+    },
+    None => {
+      repo::evaluations::supersede_pending_push(&state.pool, jobset_id, commit)
+        .await
+    },
+  };
+  match result {
+    Ok(superseded) if !superseded.is_empty() => {
+      tracing::info!(
+        %jobset_id,
+        commit,
+        count = superseded.len(),
+        "Cancelled superseded pending evaluations"
+      );
+    },
+    Ok(_) => {},
+    Err(e) => {
+      tracing::warn!(%jobset_id, "Failed to supersede pending evaluations: {e}");
+    },
+  }
+}
+
 async fn trigger_push_evaluations(
   state: &AppState,
   project_id: Uuid,
@@ -163,7 +205,16 @@ async fn trigger_push_evaluations(
     })
     .await
     {
-      Ok(_) => triggered += 1,
+      Ok(_) => {
+        triggered += 1;
+        if matches!(pushed_ref, PushedRef::Branch(_))
+          && jobset.branch.is_some()
+          && jobset.branch_pattern.is_none()
+          && jobset.tag_pattern.is_none()
+        {
+          supersede_pending(state, jobset.id, None, commit).await;
+        }
+      },
       Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }
@@ -208,7 +259,13 @@ async fn trigger_change_request_evaluations(
     })
     .await
     {
-      Ok(_) => triggered += 1,
+      Ok(_) => {
+        triggered += 1;
+        if let Some(number) = input.number {
+          supersede_pending(state, jobset.id, Some(number), &input.commit)
+            .await;
+        }
+      },
       Err(circus_common::CiError::Conflict(_)) => {},
       Err(e) => tracing::warn!("Failed to create evaluation: {e}"),
     }

--- a/db/circus-codegen/src/queries/evaluations.rs
+++ b/db/circus-codegen/src/queries/evaluations.rs
@@ -70,6 +70,17 @@ pub struct FinishRunningParams<T1: crate::StringSql, T2: crate::StringSql> {
     pub id: uuid::Uuid,
 }
 #[derive(Debug)]
+pub struct SupersedePendingPushParams<T1: crate::StringSql> {
+    pub commit_hash: T1,
+    pub jobset_id: uuid::Uuid,
+}
+#[derive(Debug)]
+pub struct SupersedePendingChangeRequestParams<T1: crate::StringSql> {
+    pub commit_hash: T1,
+    pub jobset_id: uuid::Uuid,
+    pub pr_number: i32,
+}
+#[derive(Debug)]
 pub struct ListPageFilteredParams<
     T1: crate::StringSql,
     T2: crate::StringSql,
@@ -1669,6 +1680,148 @@ impl SweepOrphanedStmt {
                 },
             mapper: |it| EvaluationRow::from(it),
         }
+    }
+}
+pub struct SupersedePendingPushStmt(&'static str, Option<tokio_postgres::Statement>);
+pub fn supersede_pending_push() -> SupersedePendingPushStmt {
+    SupersedePendingPushStmt(
+        "UPDATE evaluations SET status = 'cancelled', error_message = 'superseded by ' || $1 WHERE jobset_id = $2 AND status = 'pending' AND trigger_kind = 'source_change' AND pr_number IS NULL AND commit_hash <> $1 RETURNING *",
+        None,
+    )
+}
+impl SupersedePendingPushStmt {
+    pub async fn prepare<'a, C: GenericClient>(
+        mut self,
+        client: &'a C,
+    ) -> Result<Self, tokio_postgres::Error> {
+        self.1 = Some(client.prepare(self.0).await?);
+        Ok(self)
+    }
+    pub fn bind<'c, 'a, 's, C: GenericClient, T1: crate::StringSql>(
+        &'s self,
+        client: &'c C,
+        commit_hash: &'a T1,
+        jobset_id: &'a uuid::Uuid,
+    ) -> EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 2> {
+        EvaluationRowQuery {
+            client,
+            params: [commit_hash, jobset_id],
+            query: self.0,
+            cached: self.1.as_ref(),
+            extractor:
+                |row: &tokio_postgres::Row| -> Result<EvaluationRowBorrowed, tokio_postgres::Error> {
+                    Ok(EvaluationRowBorrowed {
+                        id: row.try_get(0)?,
+                        jobset_id: row.try_get(1)?,
+                        commit_hash: row.try_get(2)?,
+                        evaluation_time: row.try_get(3)?,
+                        status: row.try_get(4)?,
+                        error_message: row.try_get(5)?,
+                        inputs_hash: row.try_get(6)?,
+                        pr_number: row.try_get(7)?,
+                        pr_head_branch: row.try_get(8)?,
+                        pr_base_branch: row.try_get(9)?,
+                        pr_action: row.try_get(10)?,
+                        trigger_kind: row.try_get(11)?,
+                        hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
+                    })
+                },
+            mapper: |it| EvaluationRow::from(it),
+        }
+    }
+}
+impl<'c, 'a, 's, C: GenericClient, T1: crate::StringSql>
+    crate::client::async_::Params<
+        'c,
+        'a,
+        's,
+        SupersedePendingPushParams<T1>,
+        EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 2>,
+        C,
+    > for SupersedePendingPushStmt
+{
+    fn params(
+        &'s self,
+        client: &'c C,
+        params: &'a SupersedePendingPushParams<T1>,
+    ) -> EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 2> {
+        self.bind(client, &params.commit_hash, &params.jobset_id)
+    }
+}
+pub struct SupersedePendingChangeRequestStmt(&'static str, Option<tokio_postgres::Statement>);
+pub fn supersede_pending_change_request() -> SupersedePendingChangeRequestStmt {
+    SupersedePendingChangeRequestStmt(
+        "UPDATE evaluations SET status = 'cancelled', error_message = 'superseded by ' || $1 WHERE jobset_id = $2 AND status = 'pending' AND pr_number = $3 AND commit_hash <> $1 RETURNING *",
+        None,
+    )
+}
+impl SupersedePendingChangeRequestStmt {
+    pub async fn prepare<'a, C: GenericClient>(
+        mut self,
+        client: &'a C,
+    ) -> Result<Self, tokio_postgres::Error> {
+        self.1 = Some(client.prepare(self.0).await?);
+        Ok(self)
+    }
+    pub fn bind<'c, 'a, 's, C: GenericClient, T1: crate::StringSql>(
+        &'s self,
+        client: &'c C,
+        commit_hash: &'a T1,
+        jobset_id: &'a uuid::Uuid,
+        pr_number: &'a i32,
+    ) -> EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 3> {
+        EvaluationRowQuery {
+            client,
+            params: [commit_hash, jobset_id, pr_number],
+            query: self.0,
+            cached: self.1.as_ref(),
+            extractor:
+                |row: &tokio_postgres::Row| -> Result<EvaluationRowBorrowed, tokio_postgres::Error> {
+                    Ok(EvaluationRowBorrowed {
+                        id: row.try_get(0)?,
+                        jobset_id: row.try_get(1)?,
+                        commit_hash: row.try_get(2)?,
+                        evaluation_time: row.try_get(3)?,
+                        status: row.try_get(4)?,
+                        error_message: row.try_get(5)?,
+                        inputs_hash: row.try_get(6)?,
+                        pr_number: row.try_get(7)?,
+                        pr_head_branch: row.try_get(8)?,
+                        pr_base_branch: row.try_get(9)?,
+                        pr_action: row.try_get(10)?,
+                        trigger_kind: row.try_get(11)?,
+                        hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
+                    })
+                },
+            mapper: |it| EvaluationRow::from(it),
+        }
+    }
+}
+impl<'c, 'a, 's, C: GenericClient, T1: crate::StringSql>
+    crate::client::async_::Params<
+        'c,
+        'a,
+        's,
+        SupersedePendingChangeRequestParams<T1>,
+        EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 3>,
+        C,
+    > for SupersedePendingChangeRequestStmt
+{
+    fn params(
+        &'s self,
+        client: &'c C,
+        params: &'a SupersedePendingChangeRequestParams<T1>,
+    ) -> EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 3> {
+        self.bind(
+            client,
+            &params.commit_hash,
+            &params.jobset_id,
+            &params.pr_number,
+        )
     }
 }
 pub struct RestartRequeueStmt(&'static str, Option<tokio_postgres::Statement>);

--- a/db/circus-codegen/src/queries/evaluations.rs
+++ b/db/circus-codegen/src/queries/evaluations.rs
@@ -112,6 +112,8 @@ pub struct EvaluationRow {
     pub pr_action: Option<String>,
     pub trigger_kind: String,
     pub hidden: bool,
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub orphaned_count: i32,
 }
 pub struct EvaluationRowBorrowed<'a> {
     pub id: uuid::Uuid,
@@ -127,6 +129,8 @@ pub struct EvaluationRowBorrowed<'a> {
     pub pr_action: Option<&'a str>,
     pub trigger_kind: &'a str,
     pub hidden: bool,
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub orphaned_count: i32,
 }
 impl<'a> From<EvaluationRowBorrowed<'a>> for EvaluationRow {
     fn from(
@@ -144,6 +148,8 @@ impl<'a> From<EvaluationRowBorrowed<'a>> for EvaluationRow {
             pr_action,
             trigger_kind,
             hidden,
+            started_at,
+            orphaned_count,
         }: EvaluationRowBorrowed<'a>,
     ) -> Self {
         Self {
@@ -160,6 +166,8 @@ impl<'a> From<EvaluationRowBorrowed<'a>> for EvaluationRow {
             pr_action: pr_action.map(|v| v.into()),
             trigger_kind: trigger_kind.into(),
             hidden,
+            started_at,
+            orphaned_count,
         }
     }
 }
@@ -528,7 +536,7 @@ where
 pub struct CreateWithKindStmt(&'static str, Option<tokio_postgres::Statement>);
 pub fn create_with_kind() -> CreateWithKindStmt {
     CreateWithKindStmt(
-        "INSERT INTO evaluations ( jobset_id, commit_hash, status, trigger_kind, pr_number, pr_head_branch, pr_base_branch, pr_action ) VALUES ( $1, $2, $3, $4, $5, $6, $7, $8 ) RETURNING *",
+        "INSERT INTO evaluations ( jobset_id, commit_hash, status, trigger_kind, pr_number, pr_head_branch, pr_base_branch, pr_action, started_at ) VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, CASE WHEN $3::text = 'running' THEN NOW() END ) RETURNING *",
         None,
     )
 }
@@ -593,6 +601,8 @@ impl CreateWithKindStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -676,6 +686,8 @@ impl GetStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -724,6 +736,8 @@ impl GetVisibleStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -789,6 +803,8 @@ impl ListForJobsetStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -840,6 +856,8 @@ impl ListFilteredWithVisibilityStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -968,6 +986,8 @@ impl SetHiddenStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -995,7 +1015,7 @@ impl<'c, 'a, 's, C: GenericClient>
 pub struct TryClaimPendingStmt(&'static str, Option<tokio_postgres::Statement>);
 pub fn try_claim_pending() -> TryClaimPendingStmt {
     TryClaimPendingStmt(
-        "UPDATE evaluations SET status = 'running' WHERE id = $1 AND status = 'pending' RETURNING *",
+        "UPDATE evaluations SET status = 'running', started_at = NOW() WHERE id = $1 AND status = 'pending' RETURNING *",
         None,
     )
 }
@@ -1033,6 +1053,8 @@ impl TryClaimPendingStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1082,6 +1104,8 @@ impl UpdateStatusStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1147,6 +1171,8 @@ impl GetLatestStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1241,6 +1267,8 @@ impl GetByInputsHashStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1331,6 +1359,8 @@ impl ListPendingStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1408,6 +1438,8 @@ impl GetByJobsetAndCommitStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1515,6 +1547,8 @@ impl FinishRunningStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1580,6 +1614,57 @@ impl CancelStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
+                    })
+                },
+            mapper: |it| EvaluationRow::from(it),
+        }
+    }
+}
+pub struct SweepOrphanedStmt(&'static str, Option<tokio_postgres::Statement>);
+pub fn sweep_orphaned() -> SweepOrphanedStmt {
+    SweepOrphanedStmt(
+        "UPDATE evaluations SET status = CASE WHEN orphaned_count >= 2 THEN 'failed' ELSE 'pending' END, error_message = CASE WHEN orphaned_count >= 2 THEN 'evaluation orphaned repeatedly, giving up' END, orphaned_count = orphaned_count + 1, started_at = NULL, inputs_hash = NULL, evaluation_time = NOW() WHERE status = 'running' AND COALESCE(started_at, evaluation_time) < NOW() - make_interval(secs => $1) RETURNING *",
+        None,
+    )
+}
+impl SweepOrphanedStmt {
+    pub async fn prepare<'a, C: GenericClient>(
+        mut self,
+        client: &'a C,
+    ) -> Result<Self, tokio_postgres::Error> {
+        self.1 = Some(client.prepare(self.0).await?);
+        Ok(self)
+    }
+    pub fn bind<'c, 'a, 's, C: GenericClient>(
+        &'s self,
+        client: &'c C,
+        deadline_secs: &'a f64,
+    ) -> EvaluationRowQuery<'c, 'a, 's, C, EvaluationRow, 1> {
+        EvaluationRowQuery {
+            client,
+            params: [deadline_secs],
+            query: self.0,
+            cached: self.1.as_ref(),
+            extractor:
+                |row: &tokio_postgres::Row| -> Result<EvaluationRowBorrowed, tokio_postgres::Error> {
+                    Ok(EvaluationRowBorrowed {
+                        id: row.try_get(0)?,
+                        jobset_id: row.try_get(1)?,
+                        commit_hash: row.try_get(2)?,
+                        evaluation_time: row.try_get(3)?,
+                        status: row.try_get(4)?,
+                        error_message: row.try_get(5)?,
+                        inputs_hash: row.try_get(6)?,
+                        pr_number: row.try_get(7)?,
+                        pr_head_branch: row.try_get(8)?,
+                        pr_base_branch: row.try_get(9)?,
+                        pr_action: row.try_get(10)?,
+                        trigger_kind: row.try_get(11)?,
+                        hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1589,7 +1674,7 @@ impl CancelStmt {
 pub struct RestartRequeueStmt(&'static str, Option<tokio_postgres::Statement>);
 pub fn restart_requeue() -> RestartRequeueStmt {
     RestartRequeueStmt(
-        "UPDATE evaluations e SET status = 'pending', evaluation_time = NOW(), error_message = NULL, inputs_hash = NULL FROM jobsets j WHERE e.id = $1 AND e.jobset_id = j.id AND e.status IN ('cancelled', 'failed', 'timed_out') AND (j.state = 'one_shot' OR (j.enabled AND j.state IN ('enabled', 'one_at_a_time'))) RETURNING e.*",
+        "UPDATE evaluations e SET status = 'pending', evaluation_time = NOW(), error_message = NULL, inputs_hash = NULL, started_at = NULL, orphaned_count = 0 FROM jobsets j WHERE e.id = $1 AND e.jobset_id = j.id AND e.status IN ('cancelled', 'failed', 'timed_out') AND (j.state = 'one_shot' OR (j.enabled AND j.state IN ('enabled', 'one_at_a_time'))) RETURNING e.*",
         None,
     )
 }
@@ -1627,6 +1712,8 @@ impl RestartRequeueStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),
@@ -1797,6 +1884,8 @@ impl ListPageFilteredStmt {
                         pr_action: row.try_get(10)?,
                         trigger_kind: row.try_get(11)?,
                         hidden: row.try_get(12)?,
+                        started_at: row.try_get(13)?,
+                        orphaned_count: row.try_get(14)?,
                     })
                 },
             mapper: |it| EvaluationRow::from(it),

--- a/db/circus-codegen/src/queries/search.rs
+++ b/db/circus-codegen/src/queries/search.rs
@@ -377,6 +377,8 @@ pub struct EvaluationSearchRow {
     pub pr_action: Option<String>,
     pub trigger_kind: String,
     pub hidden: bool,
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub orphaned_count: i32,
 }
 pub struct EvaluationSearchRowBorrowed<'a> {
     pub id: uuid::Uuid,
@@ -392,6 +394,8 @@ pub struct EvaluationSearchRowBorrowed<'a> {
     pub pr_action: Option<&'a str>,
     pub trigger_kind: &'a str,
     pub hidden: bool,
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub orphaned_count: i32,
 }
 impl<'a> From<EvaluationSearchRowBorrowed<'a>> for EvaluationSearchRow {
     fn from(
@@ -409,6 +413,8 @@ impl<'a> From<EvaluationSearchRowBorrowed<'a>> for EvaluationSearchRow {
             pr_action,
             trigger_kind,
             hidden,
+            started_at,
+            orphaned_count,
         }: EvaluationSearchRowBorrowed<'a>,
     ) -> Self {
         Self {
@@ -425,6 +431,8 @@ impl<'a> From<EvaluationSearchRowBorrowed<'a>> for EvaluationSearchRow {
             pr_action: pr_action.map(|v| v.into()),
             trigger_kind: trigger_kind.into(),
             hidden,
+            started_at,
+            orphaned_count,
         }
     }
 }
@@ -1252,6 +1260,8 @@ impl SearchEvaluationsStmt {
                     pr_action: row.try_get(10)?,
                     trigger_kind: row.try_get(11)?,
                     hidden: row.try_get(12)?,
+                    started_at: row.try_get(13)?,
+                    orphaned_count: row.try_get(14)?,
                 })
             },
             mapper: |it| EvaluationSearchRow::from(it),

--- a/queries/evaluations.sql
+++ b/queries/evaluations.sql
@@ -115,6 +115,21 @@ WHERE status = 'running'
     < NOW() - make_interval(secs => :deadline_secs)
 RETURNING *;
 
+--! supersede_pending_push : EvaluationRow
+UPDATE evaluations
+SET status = 'cancelled', error_message = 'superseded by ' || :commit_hash
+WHERE jobset_id = :jobset_id AND status = 'pending'
+  AND trigger_kind = 'source_change'
+  AND pr_number IS NULL AND commit_hash <> :commit_hash
+RETURNING *;
+
+--! supersede_pending_change_request : EvaluationRow
+UPDATE evaluations
+SET status = 'cancelled', error_message = 'superseded by ' || :commit_hash
+WHERE jobset_id = :jobset_id AND status = 'pending'
+  AND pr_number = :pr_number AND commit_hash <> :commit_hash
+RETURNING *;
+
 --! restart_requeue : EvaluationRow
 UPDATE evaluations e
 SET status = 'pending', evaluation_time = NOW(),

--- a/queries/evaluations.sql
+++ b/queries/evaluations.sql
@@ -1,13 +1,14 @@
---: EvaluationRow(error_message?, inputs_hash?, pr_number?, pr_head_branch?, pr_base_branch?, pr_action?)
+--: EvaluationRow(error_message?, inputs_hash?, pr_number?, pr_head_branch?, pr_base_branch?, pr_action?, started_at?)
 
 --! create_with_kind (pr_number?, pr_head_branch?, pr_base_branch?, pr_action?) : EvaluationRow
 INSERT INTO evaluations (
   jobset_id, commit_hash, status, trigger_kind,
-  pr_number, pr_head_branch, pr_base_branch, pr_action
+  pr_number, pr_head_branch, pr_base_branch, pr_action, started_at
 )
 VALUES (
   :jobset_id, :commit_hash, :status, :trigger_kind,
-  :pr_number, :pr_head_branch, :pr_base_branch, :pr_action
+  :pr_number, :pr_head_branch, :pr_base_branch, :pr_action,
+  CASE WHEN :status::text = 'running' THEN NOW() END
 )
 RETURNING *;
 
@@ -39,7 +40,7 @@ WHERE (:jobset_id::uuid IS NULL OR jobset_id = :jobset_id)
 UPDATE evaluations SET hidden = :hidden WHERE id = :id RETURNING *;
 
 --! try_claim_pending : EvaluationRow
-UPDATE evaluations SET status = 'running'
+UPDATE evaluations SET status = 'running', started_at = NOW()
 WHERE id = :id AND status = 'pending'
 RETURNING *;
 
@@ -102,10 +103,23 @@ UPDATE evaluations SET status = 'cancelled', error_message = NULL
 WHERE id = :id AND status IN ('pending', 'running')
 RETURNING *;
 
+--! sweep_orphaned : EvaluationRow
+UPDATE evaluations
+SET status = CASE WHEN orphaned_count >= 2 THEN 'failed' ELSE 'pending' END,
+    error_message = CASE WHEN orphaned_count >= 2
+      THEN 'evaluation orphaned repeatedly, giving up' END,
+    orphaned_count = orphaned_count + 1,
+    started_at = NULL, inputs_hash = NULL, evaluation_time = NOW()
+WHERE status = 'running'
+  AND COALESCE(started_at, evaluation_time)
+    < NOW() - make_interval(secs => :deadline_secs)
+RETURNING *;
+
 --! restart_requeue : EvaluationRow
 UPDATE evaluations e
 SET status = 'pending', evaluation_time = NOW(),
-    error_message = NULL, inputs_hash = NULL
+    error_message = NULL, inputs_hash = NULL,
+    started_at = NULL, orphaned_count = 0
 FROM jobsets j
 WHERE e.id = :id AND e.jobset_id = j.id
   AND e.status IN ('cancelled', 'failed', 'timed_out')

--- a/queries/search.sql
+++ b/queries/search.sql
@@ -28,7 +28,7 @@ LIMIT
   :limit;
 
 --: JobsetSearchRow(branch?, branch_pattern?, tag_pattern?, last_checked_at?)
---: EvaluationSearchRow(error_message?, inputs_hash?, pr_number?, pr_head_branch?, pr_base_branch?, pr_action?)
+--: EvaluationSearchRow(error_message?, inputs_hash?, pr_number?, pr_head_branch?, pr_base_branch?, pr_action?, started_at?)
 
 -- The optional filters use NULL-guarded predicates and the dynamic sort is a
 -- CASE ladder keyed on :sort, so the whole search surface stays static.


### PR DESCRIPTION
### Problem

When the evaluator dies after claiming an evaluation (say from a
deploy restart, crash, whatever), the row stays `running` forever, since
nothing ever re-examines running evaluations. Also, a stranded
row is load-bearing in the worst way, in that the poll path hits the
"already running, skipping duplicate poll" skip on it, so a jobset
whose branch tip doesn't move never evaluates again. Currently, builds
have `reset_orphaned_builds` for exactly this, but evaluations have nothing.

Separately, webhooks queue a full evaluation for every pushed
commit and nothing ever cancels the obsolete ones. In our instance,
a project piled up ~200 pending evaluations from PR/renovate churn,
all of which would get evaluated pointlessly at 4 concurrent, starving
every other project for hours.

### Solution

Evaluations now stamp `started_at` when claimed (new migration,
which also adds an `orphaned_count`). Each evaluator cycle sweeps
`running` rows older than the git + nix timeout budget plus slack
back to pending. After three orphanings the row is failed instead,
so an evaluation that keeps killing the evaluator can't cycle
forever. Also, pre-migration stranded rows have `NULL started_at` and
fall back to `evaluation_time`, so the currently stuck evals
self-clear on the first cycle after deploy.

On the webhook side, creating an evaluation now cancels pending
ones superseded by the newer commit, scoped to jobsets tracking one
concrete branch or to the exact `pr_number`.