### PR TITLE
circus: stamp the build commit into reported versions

### DIFF
--- a/crates/circus/src/cli.rs
+++ b/crates/circus/src/cli.rs
@@ -50,7 +50,7 @@ fn run_subcommand(mut args: Vec<OsString>) -> color_eyre::Result<()> {
     return Ok(());
   }
   if matches!(command, "-V" | "--version") {
-    println!("circus {}", env!("CARGO_PKG_VERSION"));
+    println!("circus {}", circus_common::version::long());
     return Ok(());
   }
 

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,0 +1,44 @@
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+  println!("cargo:rerun-if-env-changed=CIRCUS_BUILD_SHA");
+
+  if let Some(sha) = build_sha() {
+    println!("cargo:rustc-env=BUILD_SHA={sha}");
+  }
+}
+
+/// Nix builds have no git metadata in the source, so the flake passes its
+/// revision instead.
+fn build_sha() -> Option<String> {
+  if let Some(sha) = env::var_os("CIRCUS_BUILD_SHA") {
+    let sha = sha.to_string_lossy().trim().to_owned();
+    return (!sha.is_empty()).then_some(sha);
+  }
+  read_git_sha()
+}
+
+fn read_git_sha() -> Option<String> {
+  let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR")?);
+  let workspace_root = manifest_dir.parent()?.parent()?;
+  if !workspace_root.join(".git").exists() {
+    return None;
+  }
+
+  println!(
+    "cargo:rerun-if-changed={}",
+    workspace_root.join(".git/HEAD").display()
+  );
+
+  let output = Command::new("git")
+    .args(["rev-parse", "--short=12", "HEAD"])
+    .current_dir(workspace_root)
+    .output()
+    .ok()?;
+  if !output.status.success() {
+    return None;
+  }
+
+  let sha = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+  (!sha.is_empty()).then_some(sha)
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod roles;
 pub mod service_heartbeat;
 pub mod validate;
 pub mod validation;
+pub mod version;
 
 pub use circus_logs::{TracingConfig, init_tracing};
 pub use circus_types::{

--- a/crates/common/src/service_heartbeat.rs
+++ b/crates/common/src/service_heartbeat.rs
@@ -60,6 +60,8 @@ pub struct ServiceStatus {
   pub seconds_since:     Option<f64>,
   /// Configured poll interval the service most recently reported.
   pub poll_interval:     Option<i32>,
+  /// Build of the service most recently reported.
+  pub version:           Option<String>,
   /// True when the heartbeat is fresh; false when stale or missing.
   pub healthy:           bool,
   /// Optional human-readable hint about why this service is unhealthy.
@@ -112,6 +114,7 @@ pub async fn status_for(
       last_heartbeat_at: Some(row.last_heartbeat_at),
       seconds_since: Some(row.seconds_since),
       poll_interval: Some(row.poll_interval_seconds),
+      version: row.version,
       healthy,
       detail,
     });
@@ -124,6 +127,7 @@ pub async fn status_for(
         last_heartbeat_at: None,
         seconds_since:     None,
         poll_interval:     None,
+        version:           None,
         healthy:           false,
         detail:            Some(
           "service has never reported a heartbeat".to_string(),

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -1,0 +1,20 @@
+//! Build identity shared by every circus binary.
+
+use std::sync::LazyLock;
+
+/// Release version from the workspace manifest.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Short commit the binary was built from. This is absent when built outside a
+/// git checkout without the flake passing its revision.
+pub const SHA: Option<&str> = option_env!("BUILD_SHA");
+
+static LONG: LazyLock<String> = LazyLock::new(|| {
+  SHA.map_or_else(|| VERSION.to_owned(), |sha| format!("{VERSION} ({sha})"))
+});
+
+/// Version with the build commit when one is known.
+#[must_use]
+pub fn long() -> &'static str {
+  &LONG
+}

--- a/crates/evaluator/src/cli.rs
+++ b/crates/evaluator/src/cli.rs
@@ -137,7 +137,7 @@ async fn heartbeat_loop(
     &pool,
     circus_common::service_heartbeat::SERVICE_EVALUATOR,
     poll_u32,
-    Some(env!("CARGO_PKG_VERSION")),
+    Some(circus_common::version::long()),
   )
   .await
   {
@@ -151,7 +151,7 @@ async fn heartbeat_loop(
       &pool,
       circus_common::service_heartbeat::SERVICE_EVALUATOR,
       poll_u32,
-      Some(env!("CARGO_PKG_VERSION")),
+      Some(circus_common::version::long()),
     )
     .await
     {

--- a/crates/queue-runner/src/cli.rs
+++ b/crates/queue-runner/src/cli.rs
@@ -515,7 +515,7 @@ async fn heartbeat_loop(
     circus_common::service_heartbeat::SERVICE_QUEUE_RUNNER,
     u32::try_from(poll_interval_seconds.min(u64::from(u32::MAX)))
       .unwrap_or(u32::MAX),
-    Some(env!("CARGO_PKG_VERSION")),
+    Some(circus_common::version::long()),
   )
   .await
   {
@@ -533,7 +533,7 @@ async fn heartbeat_loop(
       circus_common::service_heartbeat::SERVICE_QUEUE_RUNNER,
       u32::try_from(poll_interval_seconds.min(u64::from(u32::MAX)))
         .unwrap_or(u32::MAX),
-      Some(env!("CARGO_PKG_VERSION")),
+      Some(circus_common::version::long()),
     )
     .await
     {

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -589,7 +589,7 @@ impl runner::Server for RunnerImpl {
   ) -> Promise<(), capnp::Error> {
     let mut r = results.get();
     r.set_proto(PROTO_VERSION);
-    r.set_server(env!("CARGO_PKG_VERSION"));
+    r.set_server(circus_common::version::long());
     Promise::ok(())
   }
 

--- a/crates/server/src/routes/dashboard/shared.rs
+++ b/crates/server/src/routes/dashboard/shared.rs
@@ -39,6 +39,7 @@ pub(super) struct UiTemplateConfig {
   pub(super) favicon_url:    String,
   pub(super) has_favicon:    bool,
   pub(super) has_custom_css: bool,
+  pub(super) version:        &'static str,
 }
 
 impl UiTemplateConfig {
@@ -53,6 +54,7 @@ impl UiTemplateConfig {
       has_favicon: !favicon_url.is_empty(),
       favicon_url,
       has_custom_css: config.custom_css.is_some(),
+      version: circus_common::version::long(),
     }
   }
 }

--- a/crates/server/src/routes/health.rs
+++ b/crates/server/src/routes/health.rs
@@ -25,6 +25,8 @@ const STALE_THRESHOLD_MULTIPLIER: u32 = 3;
 struct HealthResponse {
   /// Overall status: "ok" if everything healthy, "degraded" otherwise.
   status:   &'static str,
+  /// Build of the server answering this request.
+  version:  &'static str,
   /// True if the database is reachable.
   database: bool,
   /// Per-service liveness, as reported by background-service heartbeats.
@@ -56,6 +58,7 @@ async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
 
   let body = Json(HealthResponse {
     status,
+    version: circus_common::version::long(),
     database: db_ok,
     services,
   });

--- a/crates/server/src/routes/openapi.rs
+++ b/crates/server/src/routes/openapi.rs
@@ -46,7 +46,7 @@ fn document_value() -> Value {
     "openapi": "3.1.0",
     "info": {
       "title":       "circus API",
-      "version":     env!("CARGO_PKG_VERSION"),
+      "version":     circus_common::version::VERSION,
       "description": "REST API for the circus continuous integration server.",
       "license":     { "name": "MPL-2.0" }
     },

--- a/crates/server/static/style.css
+++ b/crates/server/static/style.css
@@ -456,12 +456,17 @@ textarea::placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   min-height: 36px;
   padding: 8px 16px;
   color: var(--text-subtle);
   border-top: 1px solid var(--border);
   font-size: 12px;
   line-height: 16px;
+}
+
+.footer-version {
+  opacity: 0.75;
 }
 
 h1 {

--- a/crates/server/templates/base.html
+++ b/crates/server/templates/base.html
@@ -95,6 +95,7 @@
                 </main>
                 <footer class="footer">
                     <p>{{ ui.brand_name }} &mdash; {{ ui.brand_subtitle }}</p>
+                    <p class="footer-version mono">circus {{ ui.version }}</p>
                 </footer>
             </div>
         </div>

--- a/db/circus-codegen/src/queries/service_heartbeats.rs
+++ b/db/circus-codegen/src/queries/service_heartbeats.rs
@@ -12,12 +12,14 @@ pub struct ListStatus {
     pub last_heartbeat_at: chrono::DateTime<chrono::Utc>,
     pub seconds_since: f64,
     pub poll_interval_seconds: i32,
+    pub version: Option<String>,
 }
 pub struct ListStatusBorrowed<'a> {
     pub service: &'a str,
     pub last_heartbeat_at: chrono::DateTime<chrono::Utc>,
     pub seconds_since: f64,
     pub poll_interval_seconds: i32,
+    pub version: Option<&'a str>,
 }
 impl<'a> From<ListStatusBorrowed<'a>> for ListStatus {
     fn from(
@@ -26,6 +28,7 @@ impl<'a> From<ListStatusBorrowed<'a>> for ListStatus {
             last_heartbeat_at,
             seconds_since,
             poll_interval_seconds,
+            version,
         }: ListStatusBorrowed<'a>,
     ) -> Self {
         Self {
@@ -33,6 +36,7 @@ impl<'a> From<ListStatusBorrowed<'a>> for ListStatus {
             last_heartbeat_at,
             seconds_since,
             poll_interval_seconds,
+            version: version.map(|v| v.into()),
         }
     }
 }
@@ -162,7 +166,7 @@ impl<'a, C: GenericClient + Send + Sync, T1: crate::StringSql, T2: crate::String
 pub struct ListStatusStmt(&'static str, Option<tokio_postgres::Statement>);
 pub fn list_status() -> ListStatusStmt {
     ListStatusStmt(
-        "SELECT service, last_heartbeat_at, EXTRACT( EPOCH FROM (NOW() - last_heartbeat_at) )::float8 AS seconds_since, poll_interval_seconds FROM service_heartbeats",
+        "SELECT service, last_heartbeat_at, EXTRACT( EPOCH FROM (NOW() - last_heartbeat_at) )::float8 AS seconds_since, poll_interval_seconds, version FROM service_heartbeats",
         None,
     )
 }
@@ -190,6 +194,7 @@ impl ListStatusStmt {
                         last_heartbeat_at: row.try_get(1)?,
                         seconds_since: row.try_get(2)?,
                         poll_interval_seconds: row.try_get(3)?,
+                        version: row.try_get(4)?,
                     })
                 },
             mapper: |it| ListStatus::from(it),

--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,15 @@
             inherit cargoExtraArgs;
           });
 
+      # Kept out of commonArgs so the shared dependency artifacts stay cached across commits
+      buildShaArgs = {
+        env = commonArgs.env // {CIRCUS_BUILD_SHA = self.rev or self.dirtyRev or "";};
+      };
+
       callCratePackage = path: name: cargoExtraArgs:
         pkgs.callPackage path {
-          inherit craneLib commonArgs;
+          inherit craneLib;
+          commonArgs = commonArgs // buildShaArgs;
           cargoArtifacts = cargoArtifactsFor name cargoExtraArgs;
         };
 
@@ -118,7 +124,11 @@
       }
       // lib.optionalAttrs (muslCrossAttr ? ${system}) {
         circus-agent-static = staticCraneLib.buildPackage (
-          staticAgentArgs // {cargoArtifacts = staticCraneLib.buildDepsOnly staticAgentArgs;}
+          staticAgentArgs
+          // {
+            cargoArtifacts = staticCraneLib.buildDepsOnly staticAgentArgs;
+            env = staticAgentArgs.env // {CIRCUS_BUILD_SHA = self.rev or self.dirtyRev or "";};
+          }
         );
       });
 

--- a/queries/service_heartbeats.sql
+++ b/queries/service_heartbeats.sql
@@ -17,7 +17,7 @@ SET
   poll_interval_seconds = EXCLUDED.poll_interval_seconds,
   version = EXCLUDED.version;
 
---! list_status
+--! list_status : (version?)
 SELECT
   service,
   last_heartbeat_at,
@@ -26,6 +26,7 @@ SELECT
     FROM
       (NOW() - last_heartbeat_at)
   )::float8 AS seconds_since,
-  poll_interval_seconds
+  poll_interval_seconds,
+  version
 FROM
   service_heartbeats;


### PR DESCRIPTION
This commit stamps the commit of circus at build time into the final
binary. It's taken from the flake revision under Nix since the store
source has no git metadata, and is surfaced next to the per-service
heartbeat versions in ServiceStatus.