### PR TITLE
circus-agent: give the rootless sandbox a pty and a full /dev

### DIFF
--- a/crates/agent/src/build.rs
+++ b/crates/agent/src/build.rs
@@ -55,6 +55,14 @@ pub struct BuildOptions<'a> {
   pub rootless:          bool,
 }
 
+/// Everything needed to pull the assigned derivation from the runner. Kept
+/// out of `BuildOptions` because that mirrors the schema's `BuildAssignment`.
+pub struct DrvFetch<'a> {
+  pub runner_cap: &'a circus_proto::runner::Client,
+  pub machine_id: &'a str,
+  pub build_id:   &'a str,
+}
+
 /// One output discovered after a successful realisation.
 #[derive(Debug, Clone)]
 pub struct ResolvedOutput {
@@ -90,6 +98,7 @@ pub struct LocalResult {
 /// raised as generic diagnostic errors.
 pub async fn run(
   opts: BuildOptions<'_>,
+  drv_fetch: DrvFetch<'_>,
   log_sink: log_sink::Client,
   cancel: CancellationToken,
 ) -> color_eyre::Result<LocalResult> {
@@ -97,14 +106,63 @@ pub async fn run(
     clippy::future_not_send,
     reason = "capnp futures are not Send; agent uses a single-threaded runtime"
   )]
-  // nix-store --realise requires the .drv to be present in the local store;
-  // it will not fetch it from a substituter. Pull it from the runner's cache
-  // before realising so the agent doesn't need out-of-band store access.
-  if !opts.cache_substituter.is_empty() {
-    fetch_drv_from_cache(&opts).await;
+  // nix-store --realise requires the .drv in the local store and will not
+  // fetch it from a substituter, so ask the runner that assigned it.
+  if !drv_is_valid(&opts).await
+    && let Err(e) = fetch_drv_over_rpc(&opts, &drv_fetch).await
+  {
+    if opts.cache_substituter.is_empty() {
+      tracing::warn!(drv = %opts.drv_path, "drv fetch from runner failed: {e}");
+    } else {
+      tracing::warn!(
+        drv = %opts.drv_path,
+        "drv fetch from runner failed, falling back to cache: {e}"
+      );
+      fetch_drv_from_cache(&opts).await;
+    }
   }
   let cmd = crate::sandbox::wrap_command(opts.rootless, build_command(&opts)?)?;
   run_command(cmd, &opts, Tunables::default(), log_sink, cancel).await
+}
+
+/// A valid path's references are themselves valid, so a present `.drv`
+/// implies its whole input closure is too and nothing needs fetching.
+async fn drv_is_valid(opts: &BuildOptions<'_>) -> bool {
+  let Ok(mut cmd) =
+    crate::sandbox::nix_command(opts.rootless, NixTool::NixStore)
+  else {
+    return false;
+  };
+  cmd.args(["--query", "--hash", opts.drv_path]);
+  let Ok(mut cmd) = crate::sandbox::wrap_command(opts.rootless, cmd) else {
+    return false;
+  };
+  matches!(
+    cmd.stdin(Stdio::null()).output().await,
+    Ok(o) if o.status.success()
+  )
+}
+
+#[expect(
+  clippy::future_not_send,
+  reason = "capnp futures are not Send; agent uses a single-threaded runtime"
+)]
+async fn fetch_drv_over_rpc(
+  opts: &BuildOptions<'_>,
+  drv_fetch: &DrvFetch<'_>,
+) -> color_eyre::Result<()> {
+  let sink: circus_proto::drv_sink::Client = capnp_rpc::new_client(
+    crate::drv_sink::DrvSinkImpl::new(opts.drv_path.to_owned(), opts.rootless),
+  );
+  let mut req = drv_fetch.runner_cap.fetch_drv_closure_request();
+  {
+    let mut p = req.get();
+    p.set_machine_id(drv_fetch.machine_id);
+    p.set_build_id(drv_fetch.build_id);
+    p.set_sink(sink);
+  }
+  req.send().promise.await?;
+  Ok(())
 }
 
 async fn fetch_drv_from_cache(opts: &BuildOptions<'_>) {

--- a/crates/agent/src/drv_sink.rs
+++ b/crates/agent/src/drv_sink.rs
@@ -1,0 +1,150 @@
+//! `DrvSink` pipes an assigned derivation's closure into `nix-store --import`
+//! on the agent. The mirror of the runner's `OutputSink`, letting the agent
+//! obtain what it was told to build over the authenticated RPC instead of a
+//! reachable binary cache.
+
+use std::{process::Stdio, sync::Arc};
+
+use capnp::capability::Promise;
+use circus_proto::{drv_sink, limits};
+use tokio::{
+  io::AsyncWriteExt as _,
+  process::{Child, ChildStdin},
+  sync::Mutex,
+};
+
+use crate::sandbox::NixTool;
+
+pub struct DrvSinkImpl {
+  inner: Arc<Inner>,
+}
+
+struct Inner {
+  drv_path: String,
+  rootless: bool,
+  state:    Mutex<State>,
+}
+
+struct State {
+  child:  Option<Child>,
+  stdin:  Option<ChildStdin>,
+  closed: bool,
+  total:  u64,
+}
+
+impl DrvSinkImpl {
+  #[must_use]
+  pub fn new(drv_path: String, rootless: bool) -> Self {
+    Self {
+      inner: Arc::new(Inner {
+        drv_path,
+        rootless,
+        state: Mutex::new(State {
+          child:  None,
+          stdin:  None,
+          closed: false,
+          total:  0,
+        }),
+      }),
+    }
+  }
+}
+
+fn spawn_import(rootless: bool) -> color_eyre::Result<(Child, ChildStdin)> {
+  let mut cmd = crate::sandbox::nix_command(rootless, NixTool::NixStore)?;
+  cmd.arg("--import");
+  let mut cmd = crate::sandbox::wrap_command(rootless, cmd)?;
+  let mut child = cmd
+    .stdin(Stdio::piped())
+    .stdout(Stdio::null())
+    .kill_on_drop(true)
+    .spawn()?;
+  let stdin = child.stdin.take().ok_or_else(|| {
+    color_eyre::eyre::eyre!("nix-store --import produced no stdin")
+  })?;
+  Ok((child, stdin))
+}
+
+#[allow(refining_impl_trait_internal, refining_impl_trait_reachable)]
+impl drv_sink::Server for DrvSinkImpl {
+  #[expect(
+    clippy::significant_drop_tightening,
+    reason = "import child lock held across the chunk write"
+  )]
+  fn write(
+    self: capnp::capability::Rc<Self>,
+    params: drv_sink::WriteParams,
+    _results: drv_sink::WriteResults,
+  ) -> Promise<(), capnp::Error> {
+    let inner = Arc::clone(&self.inner);
+    Promise::from_future(async move {
+      let pr = params.get()?;
+      let chunk = pr.get_chunk()?.to_vec();
+      if chunk.len() > limits::MAX_NAR_CHUNK_BYTES {
+        return Err(capnp::Error::failed(format!(
+          "drv chunk too large: {} > {}",
+          chunk.len(),
+          limits::MAX_NAR_CHUNK_BYTES
+        )));
+      }
+
+      let mut state = inner.state.lock().await;
+      if state.closed {
+        return Err(capnp::Error::failed("drv sink is closed".into()));
+      }
+      state.total = state.total.saturating_add(chunk.len() as u64);
+      if state.total > limits::MAX_IMPORT_TOTAL_BYTES {
+        return Err(capnp::Error::failed(format!(
+          "drv closure exceeds {} bytes for {}",
+          limits::MAX_IMPORT_TOTAL_BYTES,
+          inner.drv_path
+        )));
+      }
+      if state.child.is_none() {
+        let (child, stdin) = spawn_import(inner.rootless).map_err(|e| {
+          capnp::Error::failed(format!("spawn nix-store --import: {e}"))
+        })?;
+        state.child = Some(child);
+        state.stdin = Some(stdin);
+      }
+      if let Some(stdin) = state.stdin.as_mut() {
+        stdin.write_all(&chunk).await.map_err(|e| {
+          capnp::Error::failed(format!("write to nix-store --import: {e}"))
+        })?;
+      }
+      Ok(())
+    })
+  }
+
+  fn close(
+    self: capnp::capability::Rc<Self>,
+    _params: drv_sink::CloseParams,
+    _results: drv_sink::CloseResults,
+  ) -> Promise<(), capnp::Error> {
+    let inner = Arc::clone(&self.inner);
+    Promise::from_future(async move {
+      let (child, stdin) = {
+        let mut state = inner.state.lock().await;
+        state.closed = true;
+        (state.child.take(), state.stdin.take())
+      };
+      // No chunk ever arrived
+      let Some(mut child) = child else {
+        return Ok(());
+      };
+
+      // Drop stdin to signal EOF so the import drains and exits.
+      drop(stdin);
+      let status = child.wait().await.map_err(|e| {
+        capnp::Error::failed(format!("wait for nix-store --import: {e}"))
+      })?;
+      if !status.success() {
+        return Err(capnp::Error::failed(format!(
+          "nix-store --import failed for {} ({status})",
+          inner.drv_path
+        )));
+      }
+      Ok(())
+    })
+  }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod build;
 pub mod cli;
 pub mod config;
+pub mod drv_sink;
 pub mod psi;
 pub mod sandbox;
 pub mod session;

--- a/crates/agent/src/sandbox.rs
+++ b/crates/agent/src/sandbox.rs
@@ -38,6 +38,10 @@ const HELPER_ARG: &str = "--circus-sandbox";
 const NIX_ENV: &str = "CIRCUS_AGENT_NIX";
 pub const DATA_DIR_ENV: &str = "CIRCUS_AGENT_DATA_DIR";
 
+#[cfg(target_os = "linux")]
+const BUILD_DEV_NODES: [&str; 6] =
+  ["full", "null", "random", "tty", "urandom", "zero"];
+
 #[derive(Clone, Copy)]
 pub(crate) enum NixTool {
   Nix,
@@ -330,15 +334,17 @@ fn prepare_paths() -> color_eyre::Result<SandboxPaths> {
     "tmp",
     "proc",
     "dev",
+    "dev/pts",
     "etc",
     "etc/ssl/certs",
     ".oldroot",
   ] {
     fs::create_dir_all(newroot.path().join(dir))?;
   }
-  for dev in ["null", "zero", "random", "urandom"] {
+  for dev in BUILD_DEV_NODES {
     touch(newroot.path().join("dev").join(dev))?;
   }
+  std::os::unix::fs::symlink("pts/ptmx", newroot.path().join("dev/ptmx"))?;
 
   Ok(SandboxPaths {
     local_nixdir,
@@ -408,6 +414,7 @@ fn child_enter_and_exec(
       .env("USER", "root")
       .env("NIX_REMOTE", "local")
       .env("NIX_CONF_DIR", "/nix/etc/nix")
+      .env("NIX_CONFIG", "require-drop-supplementary-groups = false")
       .env("TMPDIR", "/tmp");
     let e = cmd.as_std_mut().exec();
     Err(e.into())
@@ -520,6 +527,20 @@ fn bind_if_exists(
   Ok(())
 }
 
+/// Nix opens `/dev/ptmx` for the builder console before it forks, and a
+/// private `devpts` is one of the few mounts an unprivileged namespace gets.
+#[cfg(target_os = "linux")]
+fn mount_devpts(target: impl AsRef<Path>) -> color_eyre::Result<()> {
+  mount(
+    Some("devpts"),
+    target.as_ref(),
+    Some("devpts"),
+    MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
+    Some("newinstance,ptmxmode=0666,mode=0620"),
+  )?;
+  Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn make_mounts_private() -> color_eyre::Result<()> {
   mount::<str, str, str, str>(
@@ -541,10 +562,10 @@ fn setup_pivot_root(paths: &SandboxPaths) -> color_eyre::Result<()> {
 
   bind(&paths.local_nixdir, newroot.join("nix"))?;
   bind(paths.local_tmp.path(), newroot.join("tmp"))?;
-  bind("/dev/null", newroot.join("dev/null"))?;
-  bind("/dev/zero", newroot.join("dev/zero"))?;
-  bind("/dev/random", newroot.join("dev/random"))?;
-  bind("/dev/urandom", newroot.join("dev/urandom"))?;
+  for dev in BUILD_DEV_NODES {
+    bind(Path::new("/dev").join(dev), newroot.join("dev").join(dev))?;
+  }
+  mount_devpts(newroot.join("dev/pts"))?;
   bind_if_exists("/etc/resolv.conf", newroot.join("etc/resolv.conf"))?;
   bind_if_exists("/etc/hosts", newroot.join("etc/hosts"))?;
   bind_if_exists("/etc/nsswitch.conf", newroot.join("etc/nsswitch.conf"))?;

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -647,6 +647,11 @@ impl builder::Server for BuilderImpl {
             cache_public_key,
             rootless: inner_for_task.rootless,
           },
+          build::DrvFetch {
+            runner_cap: &inner_for_task.runner_cap,
+            machine_id: &inner_for_task.machine_id,
+            build_id:   &build_id_str,
+          },
           log,
           cancel,
         )

--- a/crates/proto/schema/circus.capnp
+++ b/crates/proto/schema/circus.capnp
@@ -35,6 +35,10 @@ interface Runner {
   # configured) so subsequent fetches see the path in the cache.
   notifyUploadComplete @3 (machineId :Text, buildId :Text, narInfo :NarInfo)
                        -> ();
+
+  # Stream the assigned derivation's closure to the agent so realising it
+  # needs no reachable binary cache. Only the active build's drv is served.
+  fetchDrvClosure @4 (machineId :Text, buildId :Text, sink :DrvSink) -> ();
 }
 
 # Capability the agent passes to the runner during register. The runner calls
@@ -72,6 +76,13 @@ interface LogSink {
 # Runner-side capability for a build's output closure. The agent streams
 # `nix-store --export` bytes via `write` and ends with `close`.
 interface OutputSink {
+  write @0 (chunk :Data) -> ();
+  close @1 () -> ();
+}
+
+# Agent-side sink for a derivation closure. The runner streams
+# `nix-store --export` bytes via `write` and ends with `close`.
+interface DrvSink {
   write @0 (chunk :Data) -> ();
   close @1 () -> ();
 }

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -58,6 +58,7 @@ pub use circus_capnp::{
   build_outcome,
   build_result,
   builder,
+  drv_sink,
   heartbeat,
   log_sink,
   nar_info,

--- a/crates/queue-runner/src/dispatch.rs
+++ b/crates/queue-runner/src/dispatch.rs
@@ -538,6 +538,29 @@ pub(crate) async fn read_drv_outputs(drv_path: &str) -> Vec<String> {
   try_read_drv_outputs(drv_path).await.unwrap_or_default()
 }
 
+/// Every store path the derivation needs, including its input drvs.
+pub(crate) async fn drv_requisites(
+  drv_path: &str,
+) -> color_eyre::Result<Vec<String>> {
+  let out = Command::new("nix-store")
+    .args(["--query", "--requisites", drv_path])
+    .output()
+    .await?;
+  if !out.status.success() {
+    return Err(color_eyre::eyre::eyre!(
+      "nix-store --query --requisites {drv_path} exited with {}",
+      out.status
+    ));
+  }
+  Ok(
+    String::from_utf8_lossy(&out.stdout)
+      .lines()
+      .map(|s| s.trim().to_owned())
+      .filter(|s| !s.is_empty())
+      .collect(),
+  )
+}
+
 pub(crate) async fn try_read_drv_outputs(
   drv_path: &str,
 ) -> color_eyre::Result<Vec<String>> {

--- a/crates/queue-runner/src/rpc/server.rs
+++ b/crates/queue-runner/src/rpc/server.rs
@@ -21,6 +21,7 @@ use circus_proto::{
   PROTO_VERSION,
   agent_session,
   builder,
+  drv_sink,
   limits,
   log_sink,
   result_sink,
@@ -884,6 +885,114 @@ impl runner::Server for RunnerImpl {
       Ok(())
     })
   }
+
+  fn fetch_drv_closure(
+    self: capnp::capability::Rc<Self>,
+    params: runner::FetchDrvClosureParams,
+    _results: runner::FetchDrvClosureResults,
+  ) -> Promise<(), capnp::Error> {
+    let db_pool = self.db_pool.clone();
+    Promise::from_future(async move {
+      let pr = params.get()?;
+      let machine_id =
+        parse_uuid_param(pr.get_machine_id()?.to_str()?, "machine_id")?;
+      let build_id =
+        parse_uuid_param(pr.get_build_id()?.to_str()?, "build_id")?;
+      let sink = pr.get_sink()?;
+
+      let registered = *self.registered_machine.lock();
+      if registered.map(|r| r.machine_id) != Some(machine_id) {
+        return Err(capnp::Error::failed(
+          "machine_id does not match registered session".into(),
+        ));
+      }
+      let Some(meta) = self.pool.get(&machine_id) else {
+        return Err(capnp::Error::failed(
+          "registered agent is not in the live pool".into(),
+        ));
+      };
+      // Scoped to the assigned build, else any authenticated agent could
+      // read arbitrary paths out of the runner's store.
+      if !meta.active_builds.read().contains(&build_id) {
+        return Err(capnp::Error::failed(
+          "build_id is not active for this agent".into(),
+        ));
+      }
+      let build = circus_common::repo::builds::get(&db_pool, build_id)
+        .await
+        .map_err(|e| {
+          capnp::Error::failed(format!("cannot load build {build_id}: {e}"))
+        })?;
+
+      export_drv_closure(&build.drv_path, sink).await.map_err(|e| {
+        tracing::warn!(%machine_id, %build_id, "drv closure export failed: {e}");
+        capnp::Error::failed(format!("drv closure export failed: {e}"))
+      })
+    })
+  }
+}
+
+/// Stream `nix-store --export` of a derivation's closure into an agent's sink.
+#[expect(clippy::future_not_send, reason = "capnp future")]
+async fn export_drv_closure(
+  drv_path: &str,
+  sink: drv_sink::Client,
+) -> color_eyre::Result<()> {
+  use tokio::io::AsyncReadExt as _;
+
+  let closure = crate::dispatch::drv_requisites(drv_path).await?;
+  if closure.is_empty() {
+    return Err(color_eyre::eyre::eyre!(
+      "derivation {drv_path} has an empty closure"
+    ));
+  }
+
+  let mut child = tokio::process::Command::new("nix-store")
+    .arg("--export")
+    .args(&closure)
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::piped())
+    .kill_on_drop(true)
+    .spawn()?;
+  let mut stdout = child
+    .stdout
+    .take()
+    .ok_or_else(|| color_eyre::eyre::eyre!("export stdout missing"))?;
+
+  let mut buf = vec![0u8; 1024 * 1024];
+  let mut stream_err = None;
+  loop {
+    let n = match stdout.read(&mut buf).await {
+      Ok(0) => break,
+      Ok(n) => n,
+      Err(e) => {
+        stream_err =
+          Some(color_eyre::eyre::eyre!("read nix-store --export: {e}"));
+        break;
+      },
+    };
+    let mut req = sink.write_request();
+    req.get().set_chunk(&buf[..n]);
+    if let Err(e) = req.send().promise.await {
+      stream_err = Some(color_eyre::eyre::eyre!("stream drv closure: {e}"));
+      break;
+    }
+  }
+
+  // Always close so the agent reaps its import child, even on a short read.
+  let close_res = sink.close_request().send().promise.await;
+  if let Some(e) = stream_err {
+    return Err(e);
+  }
+  close_res?;
+
+  let status = child.wait().await?;
+  if !status.success() {
+    return Err(color_eyre::eyre::eyre!(
+      "nix-store --export exited with {status}"
+    ));
+  }
+  Ok(())
 }
 
 /// Sign a narinfo fingerprint with the on-disk Nix signing key, returning


### PR DESCRIPTION
Nix binds a fixed set of device nodes into its own chroot and opens
`/dev/ptmx` before it forks, so the sandbox has to provide all of them
for a local build to run. Mapping a uid unprivileged also denies
setgroups, which the `require-drop-supplementary-groups` check trips
over.

Also, `DrvSink` mirrors `OutputSink` so the runner streams the assigned .drv
closure to the agent directly, which drops the reachable-cache
prerequisite for agents that do not share its store.