### PR TITLE
circus-server: render badges with badgelib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -389,6 +389,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "badgelib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e51ca8bc944c97ffd76b405052031133daafe47f21348b6200538c43b8ea3d"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "maud",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,9 +410,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -764,7 +778,7 @@ dependencies = [
  "sha2 0.11.0",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -802,7 +816,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -848,7 +862,7 @@ name = "circus-common"
 version = "0.13.0"
 dependencies = [
  "argon2",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "circus-binary-cache",
  "circus-codegen",
@@ -878,7 +892,7 @@ dependencies = [
  "sha2 0.11.0",
  "shellexpand",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-postgres",
  "toml",
@@ -926,7 +940,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml",
@@ -970,7 +984,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1004,7 +1018,7 @@ dependencies = [
  "capnpc 0.27.0",
  "futures",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1012,7 +1026,7 @@ name = "circus-queue-runner"
 version = "0.13.0"
 dependencies = [
  "async-compression",
- "base64 0.23.0",
+ "base64 0.23.1",
  "capnp 0.27.0",
  "capnp-futures 0.27.0",
  "capnp-rpc",
@@ -1041,7 +1055,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-rustls",
@@ -1076,7 +1090,8 @@ dependencies = [
  "async-stream",
  "axum",
  "axum-extra",
- "base64 0.23.0",
+ "badgelib",
+ "base64 0.23.1",
  "chrono",
  "circus-binary-cache",
  "circus-common",
@@ -1108,7 +1123,7 @@ dependencies = [
  "strip-ansi-escapes",
  "subtle",
  "tar",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-rusqlite",
@@ -2654,7 +2669,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -2790,7 +2805,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-native-certs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2806,7 +2821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2959,6 +2974,28 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "md-5"
@@ -3566,6 +3603,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "version_check",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,7 +3684,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3656,7 +3705,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3831,7 +3880,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4702,11 +4751,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4722,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5872,7 +5921,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "badgelib"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e51ca8bc944c97ffd76b405052031133daafe47f21348b6200538c43b8ea3d"
+checksum = "49eacfc65dde3241384baab02a4df9ffc2540ac54d971dd049b625c65113beb7"
 dependencies = [
  "base64 0.23.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ async-compression = { version = "0.4.43", default-features = false, features = [
 async-stream = "0.3.6"
 axum = "0.8.9"
 axum-extra = { version = "0.12.6", features = [ "typed-header", "cookie" ] }
+badgelib = "0.5.0"
 base64 = "0.23.0"
 blake3 = "1.8.5"
 bstr = "1.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-compression = { version = "0.4.43", default-features = false, features = [
 async-stream = "0.3.6"
 axum = "0.8.9"
 axum-extra = { version = "0.12.6", features = [ "typed-header", "cookie" ] }
-badgelib = "0.5.0"
+badgelib = "0.5.1"
 base64 = "0.23.0"
 blake3 = "1.8.5"
 bstr = "1.13.0"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -12,6 +12,7 @@ async-compression.workspace   = true
 async-stream.workspace        = true
 axum.workspace                = true
 axum-extra                    = { workspace = true, features = [ "cookie" ] }
+badgelib.workspace            = true
 base64.workspace              = true
 chrono.workspace              = true
 circus-proto.workspace        = true

--- a/crates/server/src/routes/badges.rs
+++ b/crates/server/src/routes/badges.rs
@@ -1,13 +1,24 @@
 use axum::{
   Router,
-  extract::{Path, State},
+  extract::{Path, Query, State},
   http::StatusCode,
   response::{IntoResponse, Response},
   routing::get,
 };
-use badgelib::{Badge, Color};
+use badgelib::{Badge, Color, Style};
 
 use crate::{error::ApiError, state::AppState};
+
+#[derive(serde::Deserialize)]
+struct BadgeParams {
+  style: Option<Style>,
+}
+
+impl BadgeParams {
+  fn style(self) -> Style {
+    self.style.unwrap_or(Style::Flat)
+  }
+}
 
 /// Wrap a generated SVG in a 200 response with the correct content-type
 /// and cache headers. Used for every successful badge return so callers
@@ -27,7 +38,10 @@ fn svg_response(svg: String) -> Response {
 async fn build_badge(
   State(state): State<AppState>,
   Path((project_name, jobset_name, job_name)): Path<(String, String, String)>,
+  Query(params): Query<BadgeParams>,
 ) -> Result<Response, ApiError> {
+  let style = params.style();
+
   // Find the project
   let project =
     circus_common::repo::projects::get_by_name(&state.pool, &project_name)
@@ -44,7 +58,12 @@ async fn build_badge(
 
   let jobset = jobsets.iter().find(|j| j.name == jobset_name);
   let Some(jobset) = jobset else {
-    return Ok(svg_response(shield_svg("build", "not found", "#9f9f9f")));
+    return Ok(svg_response(shield_svg(
+      "build",
+      "not found",
+      "#9f9f9f",
+      style,
+    )));
   };
 
   // Get latest evaluation
@@ -57,6 +76,7 @@ async fn build_badge(
       "build",
       "no evaluations",
       "#9f9f9f",
+      style,
     )));
   };
 
@@ -93,7 +113,7 @@ async fn build_badge(
     }
   });
 
-  Ok(svg_response(shield_svg("build", label, color)))
+  Ok(svg_response(shield_svg("build", label, color, style)))
 }
 
 /// Latest successful build redirect
@@ -137,12 +157,18 @@ async fn latest_build(
   )
 }
 
-fn shield_svg(subject: &str, status: &str, color: &str) -> String {
+fn shield_svg(
+  subject: &str,
+  status: &str,
+  color: &str,
+  style: Style,
+) -> String {
   Badge::new()
     .label(subject)
     .label_color(Color::Hex("555".into()))
     .value(status)
     .value_color(Color::Hex(color.trim_start_matches('#').into()))
+    .style(style)
     .to_svg()
 }
 
@@ -161,7 +187,7 @@ mod tests {
   #[test]
   fn test_shield_svg_is_valid_svg() {
     let color = "#4c1";
-    let svg = shield_svg("build", "passing", color);
+    let svg = shield_svg("build", "passing", color, Style::Flat);
     let color = Color::Hex(color.trim_start_matches('#').into()).to_css();
     assert!(svg.starts_with("<svg xmlns="));
     assert!(svg.ends_with("</svg>"));
@@ -172,7 +198,7 @@ mod tests {
 
   #[test]
   fn test_shield_svg_escapes_text() {
-    let svg = shield_svg("<build>", "passing & cached", "#4c1");
+    let svg = shield_svg("<build>", "passing & cached", "#4c1", Style::Flat);
     assert!(svg.contains("&lt;build&gt;"));
     assert!(svg.contains("passing &amp; cached"));
   }
@@ -185,7 +211,7 @@ mod tests {
       ("building", "#dfb317"),
       ("not found", "#9f9f9f"),
     ] {
-      let svg = shield_svg("build", status, color);
+      let svg = shield_svg("build", status, color, Style::Flat);
       let css_color = Color::Hex(color.trim_start_matches('#').into()).to_css();
       assert!(svg.contains(status), "SVG should contain status '{status}'");
       assert!(
@@ -193,5 +219,22 @@ mod tests {
         "SVG should contain color '{color}'"
       );
     }
+  }
+
+  #[test]
+  fn test_shield_svg_styles() {
+    let flat = shield_svg("build", "passing", "#4c1", Style::Flat);
+    let flat_square = shield_svg("build", "passing", "#4c1", Style::FlatSquare);
+    let for_the_badge =
+      shield_svg("build", "passing", "#4c1", Style::ForTheBadge);
+
+    assert!(flat.contains(r#"id="s""#));
+    assert!(!flat_square.contains(r#"id="s""#));
+    assert!(for_the_badge.contains(r#"height="28""#));
+  }
+
+  #[test]
+  fn test_badge_style_defaults_to_flat() {
+    assert!(matches!(BadgeParams { style: None }.style(), Style::Flat));
   }
 }

--- a/crates/server/src/routes/badges.rs
+++ b/crates/server/src/routes/badges.rs
@@ -5,6 +5,7 @@ use axum::{
   response::{IntoResponse, Response},
   routing::get,
 };
+use badgelib::{Badge, Color};
 
 use crate::{error::ApiError, state::AppState};
 
@@ -137,67 +138,12 @@ async fn latest_build(
 }
 
 fn shield_svg(subject: &str, status: &str, color: &str) -> String {
-  use std::fmt::Write;
-
-  let subject_width = subject.len() * 7 + 10;
-  let status_width = status.len() * 7 + 10;
-  let total_width = subject_width + status_width;
-  let subject_x = subject_width / 2;
-  let status_x = subject_width + status_width / 2;
-
-  let mut svg = String::with_capacity(768);
-  let _ = writeln!(
-    svg,
-    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total_width}\" \
-     height=\"20\">"
-  );
-  svg.push_str("  <linearGradient id=\"b\" x2=\"0\" y2=\"100%\">\n");
-  svg.push_str(
-    "    <stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/>\n",
-  );
-  svg.push_str("    <stop offset=\"1\" stop-opacity=\".1\"/>\n");
-  svg.push_str("  </linearGradient>\n");
-  svg.push_str("  <mask id=\"a\">\n");
-  let _ = writeln!(
-    svg,
-    "    <rect width=\"{total_width}\" height=\"20\" rx=\"3\" fill=\"#fff\"/>"
-  );
-  svg.push_str("  </mask>\n");
-  svg.push_str("  <g mask=\"url(#a)\">\n");
-  let _ = writeln!(
-    svg,
-    "    <rect width=\"{subject_width}\" height=\"20\" fill=\"#555\"/>"
-  );
-  let _ = writeln!(
-    svg,
-    "    <rect x=\"{subject_width}\" width=\"{status_width}\" height=\"20\" \
-     fill=\"{color}\"/>"
-  );
-  let _ = writeln!(
-    svg,
-    "    <rect width=\"{total_width}\" height=\"20\" fill=\"url(#b)\"/>"
-  );
-  svg.push_str("  </g>\n");
-  svg.push_str(
-    "  <g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu \
-     Sans,Verdana,Geneva,sans-serif\" font-size=\"11\">\n",
-  );
-  let _ = writeln!(
-    svg,
-    "    <text x=\"{subject_x}\" y=\"15\" fill=\"#010101\" \
-     fill-opacity=\".3\">{subject}</text>"
-  );
-  let _ =
-    writeln!(svg, "    <text x=\"{subject_x}\" y=\"14\">{subject}</text>");
-  let _ = writeln!(
-    svg,
-    "    <text x=\"{status_x}\" y=\"15\" fill=\"#010101\" \
-     fill-opacity=\".3\">{status}</text>"
-  );
-  let _ = writeln!(svg, "    <text x=\"{status_x}\" y=\"14\">{status}</text>");
-  svg.push_str("  </g>\n");
-  svg.push_str("</svg>");
-  svg
+  Badge::new()
+    .label(subject)
+    .label_color(Color::Hex("555".into()))
+    .value(status)
+    .value_color(Color::Hex(color.trim_start_matches('#').into()))
+    .to_svg()
 }
 
 pub fn router() -> Router<AppState> {
@@ -214,30 +160,21 @@ mod tests {
 
   #[test]
   fn test_shield_svg_is_valid_svg() {
-    let svg = shield_svg("build", "passing", "#4c1");
+    let color = "#4c1";
+    let svg = shield_svg("build", "passing", color);
+    let color = Color::Hex(color.trim_start_matches('#').into()).to_css();
     assert!(svg.starts_with("<svg xmlns="));
     assert!(svg.ends_with("</svg>"));
     assert!(svg.contains("build"));
     assert!(svg.contains("passing"));
-    assert!(svg.contains("#4c1"));
+    assert!(svg.contains(&color));
   }
 
   #[test]
-  fn test_shield_svg_dimensions() {
-    let svg = shield_svg("build", "failing", "#e05d44");
-    // "build" = 5 chars * 7 + 10 = 45
-    // "failing" = 7 chars * 7 + 10 = 59
-    // total = 104
-    assert!(svg.contains("width=\"104\""));
-  }
-
-  #[test]
-  fn test_shield_svg_text_positions() {
-    let svg = shield_svg("ci", "ok", "#4c1");
-    // "ci" = 2*7+10 = 24, subject_x = 12
-    // "ok" = 2*7+10 = 24, status_x = 24 + 12 = 36
-    assert!(svg.contains("x=\"12\""));
-    assert!(svg.contains("x=\"36\""));
+  fn test_shield_svg_escapes_text() {
+    let svg = shield_svg("<build>", "passing & cached", "#4c1");
+    assert!(svg.contains("&lt;build&gt;"));
+    assert!(svg.contains("passing &amp; cached"));
   }
 
   #[test]
@@ -249,8 +186,12 @@ mod tests {
       ("not found", "#9f9f9f"),
     ] {
       let svg = shield_svg("build", status, color);
+      let css_color = Color::Hex(color.trim_start_matches('#').into()).to_css();
       assert!(svg.contains(status), "SVG should contain status '{status}'");
-      assert!(svg.contains(color), "SVG should contain color '{color}'");
+      assert!(
+        svg.contains(&css_color),
+        "SVG should contain color '{color}'"
+      );
     }
   }
 }

--- a/crates/server/src/routes/openapi.rs
+++ b/crates/server/src/routes/openapi.rs
@@ -317,10 +317,12 @@ fn document_value() -> Value {
       },
       "/job/{project}/{jobset}/{job}/shield": {
         "get": { "summary": "Build status shield SVG",
+          "parameters": [{ "name": "style", "in": "query", "required": false, "schema": { "type": "string", "enum": ["flat", "flat-square", "for-the-badge"], "default": "flat" } }],
           "responses": { "200": { "description": "SVG badge" } } }
       },
       "/job/{project}/{jobset}/{job}/badge": {
         "get": { "summary": "Build status badge SVG",
+          "parameters": [{ "name": "style", "in": "query", "required": false, "schema": { "type": "string", "enum": ["flat", "flat-square", "for-the-badge"], "default": "flat" } }],
           "responses": { "200": { "description": "SVG badge" } } }
       },
       "/job/{project}/{jobset}/{job}/latest": {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -165,8 +165,7 @@ GET /job/{project}/{jobset}/{job}/shield
 GET /job/{project}/{jobset}/{job}/latest
 ```
 
-Use badges in README files or status dashboards. Use `latest` when you need a
-stable URL to the latest successful output for a job.
+Use badges in README files or status dashboards. Both badge endpoints accept an optional `style` query parameter: `flat` (default), `flat-square`, or `for-the-badge`. Use `latest` when you need a stable URL to the latest successful output for a job.
 
 ### Channels
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -165,7 +165,10 @@ GET /job/{project}/{jobset}/{job}/shield
 GET /job/{project}/{jobset}/{job}/latest
 ```
 
-Use badges in README files or status dashboards. Both badge endpoints accept an optional `style` query parameter: `flat` (default), `flat-square`, or `for-the-badge`. Use `latest` when you need a stable URL to the latest successful output for a job.
+Use badges in README files or status dashboards. Both badge endpoints accept an
+optional `style` query parameter: `flat` (default), `flat-square`, or
+`for-the-badge`. Use `latest` when you need a stable URL to the latest
+successful output for a job.
 
 ### Channels
 


### PR DESCRIPTION
Hi! I came across Circus and found it interesting and useful. I noticed that it includes built-in build-status badges, which I think is a useful feature. The current renderer works, but badge generation is specialized code outside Circus's core logic that still needs maintenance.

I work on [badges.ws](https://badges.ws) and maintain [badgelib](https://github.com/vladkens/badgelib), a Rust library for generating badges. I'd like to replace Circus's custom renderer with it. `badgelib` is tested and supports multiple styles, icons, gradients, and animations. As an additional benefit, this integration exposes an optional `style` query parameter, letting users choose between `flat`, `flat-square`, and `for-the-badge`.

This is a small change that preserves the current behavior. The generated badges are slightly more compact. What do you think?
