### PR TITLE
contrib: add grafana dashboard

### DIFF
--- a/contrib/grafana/README.md
+++ b/contrib/grafana/README.md
@@ -1,0 +1,45 @@
+# Grafana dashboard
+
+`circus.json` is a Grafana dashboard for a Circus deployment. Import it from
+**Dashboards → New → Import**, upload the file, and pick a Prometheus data
+source when prompted.
+
+## Prometheus
+
+Everything comes from `circus-server`'s `/prometheus` endpoint, which is
+unauthenticated and served from the same listener as the web UI.
+
+```yaml
+scrape_configs:
+  - job_name: circus
+    metrics_path: /prometheus
+    static_configs:
+      - targets: ["circus.example.com:3000"]
+```
+
+Every metric is a gauge recomputed from the database on each scrape, so the
+scrape interval only controls dashboard resolution. One minute is plenty.
+
+The `$job` and `$instance` variables scope the whole dashboard, and the panels
+sum across whatever is selected. That is what you want when one Prometheus
+scrapes several separate Circus deployments. If instead you run several
+`circus-server` replicas against a single database, every replica reports the
+same database-wide totals and the sums double, so pin `$instance` to one
+replica.
+
+## Loki
+
+Panel 20 needs a Loki data source with journald logs, and asks for one under the
+**Logs source** variable. The rest of the dashboard works without Loki. Delete
+that panel and the `logs` variable if you do not ship logs.
+
+The query matches the level token in the log line rather than parsing fields,
+because the default `compact` tracing format prints `WARN` and `ERROR` as bare
+tokens with no `level=` key for `logfmt` to find. If you set `format = "json"`
+under `[tracing]` in the server config, the stricter
+
+```logql
+{unit=~"circus-.+"} | json | level=~"WARN|ERROR"
+```
+
+works and will not match the words inside a message body.

--- a/contrib/grafana/circus.json
+++ b/contrib/grafana/circus.json
@@ -239,6 +239,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "none",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -477,7 +478,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "clamp_min(sum(circus_builds_total{status=\"all\", job=~\"$job\", instance=~\"$instance\"}) - sum(min_over_time(circus_builds_total{status=\"all\", job=~\"$job\", instance=~\"$instance\"}[24h])), 0)",
+          "expr": "clamp_min(sum(circus_builds_total{status=~\"succeeded|failed\", job=~\"$job\", instance=~\"$instance\"}) - sum(min_over_time(circus_builds_total{status=~\"succeeded|failed\", job=~\"$job\", instance=~\"$instance\"}[24h])), 0)",
           "refId": "A"
         }
       ]
@@ -499,6 +500,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "none",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1196,7 +1198,7 @@
       "title": "Evaluations (all time)",
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 3,
         "x": 12,
         "y": 8
       },
@@ -1236,8 +1238,8 @@
       "title": "Projects",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 16,
+        "w": 3,
+        "x": 15,
         "y": 8
       },
       "datasource": {
@@ -1271,13 +1273,53 @@
       ]
     },
     {
+      "id": 21,
+      "type": "stat",
+      "title": "Channels",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_channels_total{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "id": 19,
       "type": "stat",
       "title": "Remote builders (enabled)",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 20,
+        "w": 3,
+        "x": 21,
         "y": 8
       },
       "datasource": {
@@ -1325,7 +1367,7 @@
         "type": "loki",
         "uid": "${logs}"
       },
-      "description": "Optional. Needs a Loki data source with circus journald logs. Adjust the label selector to your shipper - `unit` is what Grafana Alloy / Loki's journal source use.",
+      "description": "Optional. Needs a Loki data source with circus journald logs. Adjust the label selector to your shipper - `unit` is what Grafana Alloy / Loki's journal source use. The line filter matches the level token printed by both the `compact` and `json` tracing formats.",
       "options": {
         "showTime": true,
         "wrapLogMessage": true,
@@ -1340,7 +1382,7 @@
             "type": "loki",
             "uid": "${logs}"
           },
-          "expr": "{unit=~\"circus-.+\"} | logfmt | level=~\"warn|error\"",
+          "expr": "{unit=~\"circus-.+\"} |~ `\\b(WARN|ERROR)\\b`",
           "refId": "A"
         }
       ]

--- a/contrib/grafana/circus.json
+++ b/contrib/grafana/circus.json
@@ -1,0 +1,1349 @@
+{
+  "title": "Circus CI",
+  "uid": "circus-ci",
+  "description": "Build/evaluation/queue metrics from circus-server's /prometheus endpoint. Scoped by $job / $instance so one dashboard covers several Circus deployments.",
+  "tags": [
+    "circus",
+    "ci",
+    "nix"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": {
+    "from": "now-48h",
+    "to": "now"
+  },
+  "annotations": {
+    "list": []
+  },
+  "links": [],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "regex": "",
+        "current": {},
+        "options": []
+      },
+      {
+        "name": "logs",
+        "label": "Logs source",
+        "type": "datasource",
+        "query": "loki",
+        "refresh": 1,
+        "hide": 0,
+        "regex": "",
+        "current": {},
+        "options": []
+      },
+      {
+        "name": "job",
+        "label": "Job",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values({__name__=~\"circus_.+\"}, job)",
+        "regex": "",
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": []
+      },
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(circus_builds_total{job=~\"$job\"}, instance)",
+        "regex": "",
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Circus server",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "up{job=~\"$job\", instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}",
+          "instant": true
+        }
+      ],
+      "description": "up{job=\"circus\"} - is circus-server being scraped. The evaluator and queue-runner have no metrics endpoint; check /health for those."
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Build failures (24h)",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}) - sum(min_over_time(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}[24h])), 0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Eval failures (24h)",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_evaluations_by_status{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}) - sum(min_over_time(circus_evaluations_by_status{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}[24h])), 0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "bargauge",
+      "title": "Success rate (all time)",
+      "gridPos": {
+        "h": 4,
+        "w": 10,
+        "x": 14,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "succeeded / (succeeded + failed) over all retained builds.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum(circus_builds_total{status=\"succeeded\", job=~\"$job\", instance=~\"$instance\"}) / clamp_min(sum(circus_builds_total{status=\"succeeded\", job=~\"$job\", instance=~\"$instance\"}) + sum(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}), 1)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Queue depth",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_queue_depth{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Running builds",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_builds_total{status=\"running\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Builds completed (24h)",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_builds_total{status=\"all\", job=~\"$job\", instance=~\"$instance\"}) - sum(min_over_time(circus_builds_total{status=\"all\", job=~\"$job\", instance=~\"$instance\"}[24h])), 0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Evaluations in flight",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_evaluations_by_status{status=~\"pending|running\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Build throughput",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 90,
+            "spanNulls": 600000,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_builds_total{status=\"succeeded\", job=~\"$job\", instance=~\"$instance\"}) - sum(circus_builds_total{status=\"succeeded\", job=~\"$job\", instance=~\"$instance\"} offset $__interval), 0) or vector(0)",
+          "refId": "A",
+          "legendFormat": "succeeded"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}) - sum(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"} offset $__interval), 0) or vector(0)",
+          "refId": "B",
+          "legendFormat": "failed"
+        }
+      ],
+      "interval": "5m",
+      "description": "Builds finishing per bucket, from the delta of the cumulative counts."
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Queue & running",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": 600000,
+            "lineInterpolation": "stepAfter"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "queued"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "running"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_queue_depth{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "queued"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_builds_total{status=\"running\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "B",
+          "legendFormat": "running"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "bargauge",
+      "title": "Build duration (lifetime)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "App-computed percentiles over all retained builds - a slow-moving baseline, not a trend.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1800
+              },
+              {
+                "color": "red",
+                "value": 3600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "avg(circus_builds_duration_seconds{quantile=\"0.5\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "median"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "avg(circus_builds_duration_seconds{quantile=\"0.95\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "avg(circus_builds_duration_seconds{quantile=\"0.99\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "C",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "avg(circus_builds_avg_duration_seconds{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "D",
+          "legendFormat": "avg"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Evaluation throughput",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 90,
+            "spanNulls": 600000,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "completed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_evaluations_by_status{status=\"completed\", job=~\"$job\", instance=~\"$instance\"}) - sum(circus_evaluations_by_status{status=\"completed\", job=~\"$job\", instance=~\"$instance\"} offset $__interval), 0) or vector(0)",
+          "refId": "A",
+          "legendFormat": "completed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_min(sum(circus_evaluations_by_status{status=\"failed\", job=~\"$job\", instance=~\"$instance\"}) - sum(circus_evaluations_by_status{status=\"failed\", job=~\"$job\", instance=~\"$instance\"} offset $__interval), 0) or vector(0)",
+          "refId": "B",
+          "legendFormat": "failed"
+        }
+      ],
+      "interval": "5m"
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Builds per project (all time)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (project) (circus_project_builds_completed{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (project) (circus_project_builds_failed{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "B",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "100 * sum by (project) (circus_project_builds_failed{job=~\"$job\", instance=~\"$instance\"}) / clamp_min(sum by (project) (circus_project_builds_completed{job=~\"$job\", instance=~\"$instance\"}) + sum by (project) (circus_project_builds_failed{job=~\"$job\", instance=~\"$instance\"}), 1)",
+          "refId": "C",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "project",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "includeByName": {
+              "project": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true
+            },
+            "indexByName": {
+              "project": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3
+            },
+            "excludeByName": {},
+            "renameByName": {
+              "project": "Project",
+              "Value #A": "Succeeded",
+              "Value #B": "Failed",
+              "Value #C": "Failure %"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [
+          {
+            "displayName": "Failed",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": [
+            "sum"
+          ],
+          "fields": [
+            "Succeeded",
+            "Failed"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failure %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 2
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Project"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 280
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Builds (all time)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_builds_total{status=\"all\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Succeeded (all time)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_builds_total{status=\"succeeded\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "Failed (all time)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_builds_total{status=\"failed\", job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Evaluations (all time)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_evaluations_total{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "Projects",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_projects_total{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "stat",
+      "title": "Remote builders (enabled)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(circus_remote_builders_active{job=~\"$job\", instance=~\"$instance\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "Count of enabled remote builder config rows - not a live-connection count."
+    },
+    {
+      "id": 20,
+      "type": "logs",
+      "title": "Recent circus warnings & errors",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${logs}"
+      },
+      "description": "Optional. Needs a Loki data source with circus journald logs. Adjust the label selector to your shipper - `unit` is what Grafana Alloy / Loki's journal source use.",
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "noValue": "No warnings or errors"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${logs}"
+          },
+          "expr": "{unit=~\"circus-.+\"} | logfmt | level=~\"warn|error\"",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -85,6 +85,15 @@ pub enum EvaluationStatus {
 }
 
 impl EvaluationStatus {
+  pub const ALL: [Self; 6] = [
+    Self::Pending,
+    Self::Running,
+    Self::Completed,
+    Self::Failed,
+    Self::Cancelled,
+    Self::TimedOut,
+  ];
+
   #[must_use]
   pub const fn as_db_str(&self) -> &'static str {
     match self {

--- a/crates/server/src/routes/metrics.rs
+++ b/crates/server/src/routes/metrics.rs
@@ -63,6 +63,24 @@ fn escape_prometheus_label(s: &str) -> String {
     .replace('\n', "\\n")
 }
 
+/// `evaluations_by_status` groups existing rows, so a status with no rows
+/// would otherwise be a missing series rather than a zero.
+fn evaluation_status_counts(
+  rows: &[circus_common::repo::build_metrics::EvaluationStatusCount],
+) -> Vec<(&'static str, i64)> {
+  circus_common::models::EvaluationStatus::ALL
+    .iter()
+    .map(|status| {
+      let db_str = status.as_db_str();
+      let count = rows
+        .iter()
+        .find(|row| row.status == db_str)
+        .map_or(0, |row| row.count);
+      (db_str, count)
+    })
+    .collect()
+}
+
 async fn prometheus_metrics(State(state): State<AppState>) -> Response {
   use std::fmt::Write;
 
@@ -173,12 +191,10 @@ async fn prometheus_metrics(State(state): State<AppState>) -> Response {
   output
     .push_str("\n# HELP circus_evaluations_by_status Evaluations by status\n");
   output.push_str("# TYPE circus_evaluations_by_status gauge\n");
-  for item in &eval_by_status {
+  for (status, count) in evaluation_status_counts(&eval_by_status) {
     let _ = writeln!(
       output,
-      "circus_evaluations_by_status{{status=\"{}\"}} {}",
-      escape_prometheus_label(&item.status),
-      item.count
+      "circus_evaluations_by_status{{status=\"{status}\"}} {count}",
     );
   }
 
@@ -388,5 +404,23 @@ mod tests {
   #[test]
   fn test_escape_prometheus_label_combined() {
     assert_eq!(escape_prometheus_label("a\\b\n\"c\""), r#"a\\b\n\"c\""#);
+  }
+
+  #[test]
+  fn test_evaluation_status_counts_fills_absent_statuses() {
+    let rows =
+      vec![circus_common::repo::build_metrics::EvaluationStatusCount {
+        status: "completed".to_string(),
+        count:  7,
+      }];
+
+    assert_eq!(evaluation_status_counts(&rows), vec![
+      ("pending", 0),
+      ("running", 0),
+      ("completed", 7),
+      ("failed", 0),
+      ("cancelled", 0),
+      ("timed_out", 0),
+    ]);
   }
 }


### PR DESCRIPTION
This PR adds a Grafana dashboard for seeing Circus health and stats. 

<img width="1809" height="1268" alt="pasted file0" src="https://github.com/user-attachments/assets/b4e7acec-ea3e-48df-afd4-27668c26352e" />
<img width="1809" height="1268" alt="pasted file1" src="https://github.com/user-attachments/assets/f512ac5d-a426-4a8b-8b2d-8426a6a1dfde" />
